### PR TITLE
docs: no-progress only works in non-interactive mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Flags:
   -i, --ignore-dirs strings   Absolute paths to ignore (separated by comma) (default [/proc,/dev,/sys,/run])
   -l, --log-file string       Path to a logfile (default "/dev/null")
   -c, --no-color              Do not use colorized output
-  -p, --no-progress           Do not show progress
+  -p, --no-progress           Do not show progress in non-interactive mode
   -n, --non-interactive       Do not run in interactive mode
   -d, --show-disks            Show all mounted disks
   -v, --version               Print version
@@ -77,7 +77,7 @@ Flags:
     gdu -c /                              # use only white/gray/black colors
 
     gdu -n /                              # only print stats, do not start interactive mode
-    gdu -np /                             # do not show progress either
+    gdu -np /                             # do not show progress, useful when using its output in a script
     gdu / > file                          # write stats to file, do not start interactive mode
 
 Gdu has two modes: interactive (default) and non-interactive.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -35,7 +35,7 @@ However HDDs work as well, but the performance gain is not so huge.
 	flags.BoolVarP(&sf.showVersion, "version", "v", false, "Print version")
 	flags.BoolVarP(&sf.noColor, "no-color", "c", false, "Do not use colorized output")
 	flags.BoolVarP(&sf.nonInteractive, "non-interactive", "n", false, "Do not run in interactive mode")
-	flags.BoolVarP(&sf.noProgress, "no-progress", "p", false, "Do not show progress")
+	flags.BoolVarP(&sf.noProgress, "no-progress", "p", false, "Do not show progress in non-interactive mode")
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)

--- a/gdu.1
+++ b/gdu.1
@@ -39,7 +39,7 @@ However HDDs work as well, but the performance gain is not so huge.
 
 .PP
 \fB\-p\fP, \fB\-\-no\-progress\fP[=false]
-	Do not show progress
+	Do not show progress in non-interactive mode
 
 .PP
 \fB\-n\fP, \fB\-\-non\-interactive\fP[=false]


### PR DESCRIPTION
It confused me that no-progress didn't work in the interactive mode. After reading the source code, I realized that it only works in non-interactive mode. This makes sense because it seems that no-progress is useful only when its output is used in a script. So I believe this is not a bug but the help text needs to mention this.