### PR TITLE
Keep cursor on selection when swapping between apparent/actual size.

### DIFF
--- a/tui/keys.go
+++ b/tui/keys.go
@@ -48,7 +48,9 @@ func (ui *UI) keyPressed(key *tcell.EventKey) *tcell.EventKey {
 	case 'a':
 		ui.showApparentSize = !ui.showApparentSize
 		if ui.currentDir != nil {
+			row, column := ui.table.GetSelection()
 			ui.showDir()
+			ui.table.Select(row, column)
 		}
 	case 'r':
 		if ui.currentDir != nil {


### PR DESCRIPTION
Quick hack to keep the cursor on place when toggling actual/apparent size. Not sure this is the ideal place to do this as I'm completely unfamiliar with tview, but just thought I'd share. Thanks for this great little app.