### PR TITLE
Use check-handle draft syntax in gdu

### DIFF
--- a/analyze/file.go
+++ b/analyze/file.go
@@ -220,10 +220,7 @@ func (f ByName) Less(i, j int) bool { return f[i].GetName() > f[j].GetName() }
 
 // RemoveItemFromDir removes item from dir
 func RemoveItemFromDir(dir *Dir, item Item) error {
-	err := os.RemoveAll(item.GetPath())
-	if err != nil {
-		return err
-	}
+	check os.RemoveAll(item.GetPath())
 
 	dir.Files = dir.Files.Remove(item)
 

--- a/cmd/app/app.go
+++ b/cmd/app/app.go
@@ -64,10 +64,10 @@ func (a *App) Run() error {
 
 	var path string
 
-	f, err := os.OpenFile(a.Flags.LogFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
-	if err != nil {
+	handle err {
 		return fmt.Errorf("opening log file: %w", err)
 	}
+	f := check os.OpenFile(a.Flags.LogFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
 	defer f.Close()
 	log.SetOutput(f)
 
@@ -77,18 +77,18 @@ func (a *App) Run() error {
 		path = "."
 	}
 
-	ui := a.createUI()
-
-	if err := a.setNoCross(path); err != nil {
+	handle err {
 		return err
 	}
+
+	ui := a.createUI()
+
+	check a.setNoCross(path)
 
 	ui.SetIgnoreDirPaths(a.Flags.IgnoreDirs)
 
 	if len(a.Flags.IgnoreDirPatterns) > 0 {
-		if err := ui.SetIgnoreDirPatterns(a.Flags.IgnoreDirPatterns); err != nil {
-			return err
-		}
+		check ui.SetIgnoreDirPatterns(a.Flags.IgnoreDirPatterns)
 	}
 
 	if a.Flags.NoHidden {
@@ -97,9 +97,7 @@ func (a *App) Run() error {
 
 	a.setMaxProcs()
 
-	if err := a.runAction(ui, path); err != nil {
-		return err
-	}
+	check a.runAction(ui, path)
 
 	return ui.StartUILoop()
 }
@@ -138,10 +136,10 @@ func (a *App) createUI() UI {
 
 func (a *App) setNoCross(path string) error {
 	if a.Flags.NoCross {
-		mounts, err := a.Getter.GetMounts()
-		if err != nil {
+		handle err {
 			return fmt.Errorf("loading mount points: %w", err)
 		}
+		mounts := check a.Getter.GetMounts()
 		paths := device.GetNestedMountpointsPaths(path, mounts)
 		a.Flags.IgnoreDirs = append(a.Flags.IgnoreDirs, paths...)
 	}
@@ -150,13 +148,15 @@ func (a *App) setNoCross(path string) error {
 
 func (a *App) runAction(ui UI, path string) error {
 	if a.Flags.ShowDisks {
-		if err := ui.ListDevices(a.Getter); err != nil {
+		handle err {
 			return fmt.Errorf("loading mount points: %w", err)
 		}
+		check ui.ListDevices(a.Getter)
 	} else {
-		if err := ui.AnalyzePath(path, nil); err != nil {
+		handle err {
 			return fmt.Errorf("scanning dir: %w", err)
 		}
+		check ui.AnalyzePath(path, nil)
 	}
 	return nil
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -62,10 +62,10 @@ func runE(command *cobra.Command, args []string) error {
 	var termApp *tview.Application = nil
 
 	if !af.ShowVersion && !af.NonInteractive && istty {
-		screen, err := tcell.NewScreen()
-		if err != nil {
+		handle err {
 			return fmt.Errorf("Error creating screen: %w", err)
 		}
+		screen := check tcell.NewScreen()
 		screen.Init()
 		defer screen.Clear()
 		defer screen.Fini()
@@ -88,7 +88,8 @@ func runE(command *cobra.Command, args []string) error {
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
-	if err := rootCmd.Execute(); err != nil {
+	handle err {
 		os.Exit(1)
 	}
+	check rootCmd.Execute()
 }

--- a/common/ignore.go
+++ b/common/ignore.go
@@ -10,12 +10,8 @@ import (
 
 // CreateIgnorePattern creates one pattern from all path patterns
 func CreateIgnorePattern(paths []string) (*regexp.Regexp, error) {
-	var err error
-
 	for i, path := range paths {
-		if _, err = regexp.Compile(path); err != nil {
-			return nil, err
-		}
+		check regexp.Compile(path)
 		paths[i] = "(" + path + ")"
 	}
 
@@ -34,10 +30,9 @@ func (ui *UI) SetIgnoreDirPaths(paths []string) {
 
 // SetIgnoreDirPatterns sets regular patters of dirs to ignore
 func (ui *UI) SetIgnoreDirPatterns(paths []string) error {
-	var err error
 	log.Printf("Ignoring dir patterns %s", strings.Join(paths, ", "))
-	ui.IgnoreDirPathPatterns, err = CreateIgnorePattern(paths)
-	return err
+	ui.IgnoreDirPathPatterns = check CreateIgnorePattern(paths)
+	return nil
 }
 
 // SetIgnoreHidden sets flags if hidden dirs should be ignored

--- a/device/dev_freebsd.go
+++ b/device/dev_freebsd.go
@@ -20,10 +20,7 @@ var Getter DevicesInfoGetter = FreeBSDDevicesInfoGetter{MountCmd: "/sbin/mount"}
 
 // GetMounts returns all mounted filesystems from /proc/mounts
 func (t FreeBSDDevicesInfoGetter) GetMounts() (Devices, error) {
-	out, err := exec.Command(t.MountCmd).Output()
-	if err != nil {
-		return nil, err
-	}
+	out := check exec.Command(t.MountCmd).Output()
 
 	rdr := bytes.NewReader(out)
 
@@ -32,10 +29,7 @@ func (t FreeBSDDevicesInfoGetter) GetMounts() (Devices, error) {
 
 // GetDevicesInfo returns result of GetMounts with usage info about mounted devices (by calling Statfs syscall)
 func (t FreeBSDDevicesInfoGetter) GetDevicesInfo() (Devices, error) {
-	mounts, err := t.GetMounts()
-	if err != nil {
-		return nil, err
-	}
+	mounts := check t.GetMounts()
 
 	return processMounts(mounts)
 }
@@ -67,9 +61,7 @@ func readMountOutput(rdr io.Reader) (Devices, error) {
 		mounts = append(mounts, device)
 	}
 
-	if err := scanner.Err(); err != nil {
-		return nil, err
-	}
+	check scanner.Err()
 
 	return mounts, nil
 }

--- a/device/dev_linux.go
+++ b/device/dev_linux.go
@@ -18,10 +18,7 @@ var Getter DevicesInfoGetter = LinuxDevicesInfoGetter{MountsPath: "/proc/mounts"
 
 // GetMounts returns all mounted filesystems from /proc/mounts
 func (t LinuxDevicesInfoGetter) GetMounts() (Devices, error) {
-	file, err := os.Open(t.MountsPath)
-	if err != nil {
-		return nil, err
-	}
+	file:= check os.Open(t.MountsPath)
 	defer file.Close()
 
 	return readMountsFile(file)
@@ -29,11 +26,7 @@ func (t LinuxDevicesInfoGetter) GetMounts() (Devices, error) {
 
 // GetDevicesInfo returns result of GetMounts with usage info about mounted devices (by calling Statfs syscall)
 func (t LinuxDevicesInfoGetter) GetDevicesInfo() (Devices, error) {
-	mounts, err := t.GetMounts()
-	if err != nil {
-		return nil, err
-	}
-
+	mounts := check t.GetMounts()
 	return processMounts(mounts)
 }
 
@@ -53,9 +46,7 @@ func readMountsFile(file io.Reader) (Devices, error) {
 		mounts = append(mounts, device)
 	}
 
-	if err := scanner.Err(); err != nil {
-		return nil, err
-	}
+	check scanner.Err()
 
 	return mounts, nil
 }

--- a/internal/testdir/test_dir.go
+++ b/internal/testdir/test_dir.go
@@ -11,10 +11,10 @@ func CreateTestDir() func() {
 	os.WriteFile("test_dir/nested/subnested/file", []byte("hello"), 0644)
 	os.WriteFile("test_dir/nested/file2", []byte("go"), 0644)
 	return func() {
-		err := os.RemoveAll("test_dir")
-		if err != nil {
+		handle err {
 			panic(err)
 		}
+		check os.RemoveAll("test_dir")
 	}
 }
 

--- a/stdout/stdout.go
+++ b/stdout/stdout.go
@@ -56,10 +56,7 @@ func (ui *UI) StartUILoop() error {
 
 // ListDevices lists mounted devices and shows their disk usage
 func (ui *UI) ListDevices(getter device.DevicesInfoGetter) error {
-	devices, err := getter.GetDevicesInfo()
-	if err != nil {
-		return err
-	}
+	devices := check getter.GetDevicesInfo()
 
 	maxDeviceNameLenght := maxInt(maxLength(
 		devices,
@@ -120,10 +117,7 @@ func (ui *UI) AnalyzePath(path string, _ *analyze.Dir) error {
 	)
 	abspath, _ := filepath.Abs(path)
 
-	_, err := ui.PathChecker(abspath)
-	if err != nil {
-		return err
-	}
+	check ui.PathChecker(abspath)
 
 	if ui.ShowProgress {
 		wait.Add(1)

--- a/tui/actions.go
+++ b/tui/actions.go
@@ -17,11 +17,7 @@ const linesTreshold = 20
 
 // ListDevices lists mounted devices and shows their disk usage
 func (ui *UI) ListDevices(getter device.DevicesInfoGetter) error {
-	var err error
-	ui.devices, err = getter.GetDevicesInfo()
-	if err != nil {
-		return err
-	}
+	ui.devices = check getter.GetDevicesInfo()
 
 	ui.table.SetCell(0, 0, tview.NewTableCell("Device name").SetSelectable(false))
 	ui.table.SetCell(0, 1, tview.NewTableCell("Size").SetSelectable(false))
@@ -59,10 +55,7 @@ func (ui *UI) ListDevices(getter device.DevicesInfoGetter) error {
 func (ui *UI) AnalyzePath(path string, parentDir *analyze.Dir) error {
 	abspath, _ := filepath.Abs(path)
 
-	_, err := ui.PathChecker(abspath)
-	if err != nil {
-		return err
-	}
+	check ui.PathChecker(abspath)
 
 	ui.progress = tview.NewTextView().SetText("Scanning...")
 	ui.progress.SetBorder(true).SetBorderPadding(2, 2, 2, 2)
@@ -121,7 +114,7 @@ func (ui *UI) deleteSelected() {
 	currentDir := ui.currentDir
 
 	go func() {
-		if err := ui.remover(currentDir, selectedFile); err != nil {
+		handle err {
 			msg := "Can't delete " + selectedFile.GetName()
 			ui.app.QueueUpdateDraw(func() {
 				ui.pages.RemovePage("deleting")
@@ -132,6 +125,7 @@ func (ui *UI) deleteSelected() {
 			}
 			return
 		}
+		check ui.remover(currentDir, selectedFile)
 
 		ui.app.QueueUpdateDraw(func() {
 			ui.pages.RemovePage("deleting")
@@ -152,11 +146,11 @@ func (ui *UI) showFile() *tview.TextView {
 		return nil
 	}
 
-	f, err := os.Open(selectedFile.GetPath())
-	if err != nil {
+	handle err {
 		ui.showErr("Error opening file", err)
 		return nil
 	}
+	f := check os.Open(selectedFile.GetPath())
 
 	totalLines := 0
 	scanner := bufio.NewScanner(f)

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -142,9 +142,7 @@ func CreateUI(app common.TermApplication, useColors bool, showApparentSize bool)
 
 // StartUILoop starts tview application
 func (ui *UI) StartUILoop() error {
-	if err := ui.app.Run(); err != nil {
-		return err
-	}
+	check ui.app.Run()
 	return nil
 }
 


### PR DESCRIPTION
Some notes from the rewriting to check-handle syntax:

* it removes a lot of boiler-plate code - the handling of errors is now almost a half
* it's little bit harder to read and understand (mostly when explicit handler is used)
* one has to think on every occasion if `check` can be used (because control cannot resume if `check` fails)

Both 2 and 3 are probably just matter of time. It's a new concept, brain has to adapt to it :) 

The removal of unnecessary error handling code and thus more meaningful code in general are probably worth all the cons :+1: 
