### PR TITLE
Shell fixes

### DIFF
--- a/tui/exec_other.go
+++ b/tui/exec_other.go
@@ -1,0 +1,12 @@
+// +build !windows
+
+package tui
+
+import (
+	"syscall"
+)
+
+func Execute(argv0 string, argv []string, envv []string) error {
+	// append argv0 to argv, as execve will make first argument the "binary name".
+	return syscall.Exec(argv0, append([]string{argv0}, argv...), envv)
+}

--- a/tui/exec_windows.go
+++ b/tui/exec_windows.go
@@ -1,0 +1,20 @@
+package tui
+
+import (
+	"os"
+	"os/exec"
+)
+
+func Execute(argv0 string, argv []string, envv []string) error {
+	// Windows does not support exec syscall.
+	cmd := exec.Command(argv0, argv...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+	cmd.Env = envv
+	err := cmd.Run()
+	if err == nil {
+		os.Exit(0)
+	}
+	return err
+}

--- a/tui/keys.go
+++ b/tui/keys.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"fmt"
 	"os"
+	"runtime"
 
 	"github.com/dundee/gdu/v5/pkg/analyze"
 	"github.com/gdamore/tcell/v2"
@@ -44,9 +45,19 @@ func (ui *UI) keyPressed(key *tcell.EventKey) *tcell.EventKey {
 		if err := os.Chdir(ui.currentDirPath); err != nil {
 			panic(err)
 		}
-		shell, ok := os.LookupEnv("SHELL")
-		if !ok {
-			shell = "/bin/bash"
+		var shell string
+		if runtime.GOOS == "windows" {
+			shellbin, ok := os.LookupEnv("COMSPEC")
+			if !ok {
+				shellbin = "C:\\WINDOWS\\System32\\cmd.exe"
+			}
+			shell = shellbin
+		} else {
+			shellbin, ok := os.LookupEnv("SHELL")
+			if !ok {
+				shellbin = "/bin/bash"
+			}
+			shell = shellbin
 		}
 		if err := ui.exec(shell, nil, os.Environ()); err != nil {
 			panic(err)

--- a/tui/keys.go
+++ b/tui/keys.go
@@ -3,7 +3,6 @@ package tui
 import (
 	"fmt"
 	"os"
-	"runtime"
 
 	"github.com/dundee/gdu/v5/pkg/analyze"
 	"github.com/gdamore/tcell/v2"
@@ -45,21 +44,7 @@ func (ui *UI) keyPressed(key *tcell.EventKey) *tcell.EventKey {
 		if err := os.Chdir(ui.currentDirPath); err != nil {
 			panic(err)
 		}
-		var shell string
-		if runtime.GOOS == "windows" {
-			shellbin, ok := os.LookupEnv("COMSPEC")
-			if !ok {
-				shellbin = "C:\\WINDOWS\\System32\\cmd.exe"
-			}
-			shell = shellbin
-		} else {
-			shellbin, ok := os.LookupEnv("SHELL")
-			if !ok {
-				shellbin = "/bin/bash"
-			}
-			shell = shellbin
-		}
-		if err := ui.exec(shell, nil, os.Environ()); err != nil {
+		if err := ui.exec(getShellBin(), nil, os.Environ()); err != nil {
 			panic(err)
 		}
 		return nil

--- a/tui/shell_other.go
+++ b/tui/shell_other.go
@@ -1,0 +1,15 @@
+// +build !windows
+
+package tui
+
+import (
+	"os"
+)
+
+func getShellBin() string {
+	shellbin, ok := os.LookupEnv("SHELL")
+	if !ok {
+		shellbin = "/bin/bash"
+	}
+	return shellbin
+}

--- a/tui/shell_windows.go
+++ b/tui/shell_windows.go
@@ -1,0 +1,13 @@
+package tui
+
+import (
+	"os"
+)
+
+func getShellBin() string {
+	shellbin, ok := os.LookupEnv("COMSPEC")
+	if !ok {
+		shellbin = "C:\\WINDOWS\\System32\\cmd.exe"
+	}
+	return shellbin
+}

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -3,12 +3,8 @@ package tui
 import (
 	"fmt"
 	"io"
-	"os"
-	"os/exec"
-	"runtime"
 	"sort"
 	"strings"
-	"syscall"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -78,25 +74,6 @@ type UI struct {
 	remover         func(*analyze.Dir, analyze.Item) error
 	emptier         func(*analyze.Dir, analyze.Item) error
 	exec            func(argv0 string, argv []string, envv []string) error
-}
-
-func Execute(argv0 string, argv []string, envv []string) error {
-	// Windows does not support exec syscall.
-	if runtime.GOOS == "windows" {
-		cmd := exec.Command(argv0, argv...)
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		cmd.Stdin = os.Stdin
-		cmd.Env = envv
-		err := cmd.Run()
-		if err == nil {
-			os.Exit(0)
-		}
-		return err
-	}
-
-	// append argv0 to argv, as execve will make first argument the "binary name".
-	return syscall.Exec(argv0, append([]string{argv0}, argv...), envv)
 }
 
 // CreateUI creates the whole UI app


### PR DESCRIPTION
This PR abstracts the `ui.exec` method away into a separate function, which fixes three things:
#### Linux
When `SHELL` is set to `/usr/bin/pwsh`, gdu threw this error on pressing <kbd>b</kbd>:
```
terminate called after throwing an instance of 'std::bad_alloc'
  what():  std::bad_alloc
```
This has been fixed, and PowerShell now spawns correctly in the current directory.

#### macOS
Pressing <kbd>b</kbd> didn't work if `SHELL` was Zsh or PowerShell; it only worked on Bash.
_zsh_
```
zsh: too few arguments
```
_pwsh_
```
libc++abi.dylib: terminating with uncaught exception of type std::length_error: vector
```
This has been fixed; any shell works now.

#### On Windows 
The system call `Exec` does not exist on Windows. A workaround is to spawn a new process and give the input/output/error descriptors of gdu to that process. Reference has been taken from here - https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go#L157
As a result, pressing <kbd>b</kbd> to launch shell in current directory now works on Windows.

All existing tests pass on Linux and macOS (on Windows they were failing even before my commits so I didn't pay any attention to them). Let me know if I should add more. (I'll need some help with them, I'm completely new to Golang).