### PR TITLE
Info modal closes with "i"

### DIFF
--- a/tui/keys.go
+++ b/tui/keys.go
@@ -29,6 +29,15 @@ func (ui *UI) keyPressed(key *tcell.EventKey) *tcell.EventKey {
 			return nil
 		}
 	}
+	
+	if key.Rune() == 'i' {
+		if ui.pages.HasPage("info") {
+			ui.pages.RemovePage("info")
+			_, page := ui.pages.GetFrontPage()
+			ui.app.SetFocus(page)
+			return nil
+		}
+	}
 
 	switch key.Rune() {
 	case 'Q':


### PR DESCRIPTION
Pressing "i" when info modal is open will now close the info modal. Note that this block of code would only work when placed before what is now the block at lines 57-72, it would not work after that.