### PR TITLE
Implement noCross for darwin

### DIFF
--- a/pkg/device/dev_darwin.go
+++ b/pkg/device/dev_darwin.go
@@ -1,0 +1,94 @@
+package device
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"io"
+	"os/exec"
+	"regexp"
+	"strings"
+	"syscall"
+)
+
+// DarwinDevicesInfoGetter returns info for Darwin devices
+type DarwinDevicesInfoGetter struct {
+	MountCmd string
+}
+
+// Getter is current instance of DevicesInfoGetter
+var Getter DevicesInfoGetter = DarwinDevicesInfoGetter{MountCmd: "/sbin/mount"}
+
+// GetMounts returns all mounted filesystems from output of /sbin/mount
+func (t DarwinDevicesInfoGetter) GetMounts() (Devices, error) {
+	out, err := exec.Command(t.MountCmd).Output()
+	if err != nil {
+		return nil, err
+	}
+
+	rdr := bytes.NewReader(out)
+
+	return readMountOutput(rdr)
+}
+
+// GetDevicesInfo returns result of GetMounts with usage info about mounted devices (by calling Statfs syscall)
+func (t DarwinDevicesInfoGetter) GetDevicesInfo() (Devices, error) {
+	mounts, err := t.GetMounts()
+	if err != nil {
+		return nil, err
+	}
+
+	return processMounts(mounts, false)
+}
+
+func readMountOutput(rdr io.Reader) (Devices, error) {
+	mounts := Devices{}
+
+	scanner := bufio.NewScanner(rdr)
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		re := regexp.MustCompile("^(.*) on (/.*) \\(([^)]+)\\)$")
+		parts := re.FindAllStringSubmatch(line, -1)
+
+		if len(parts) < 1 {
+			return nil, errors.New("Cannot parse mount output")
+		}
+
+		fstype := strings.TrimSpace(strings.Split(parts[0][3], ",")[0])
+
+		device := &Device{
+			Name:       parts[0][1],
+			MountPoint: parts[0][2],
+			Fstype:     fstype,
+		}
+		mounts = append(mounts, device)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return mounts, nil
+}
+
+func processMounts(mounts Devices, ignoreErrors bool) (Devices, error) {
+	devices := Devices{}
+
+	for _, mount := range mounts {
+		if strings.HasPrefix(mount.Name, "/dev") || mount.Fstype == "zfs" {
+			info := &syscall.Statfs_t{}
+			err := syscall.Statfs(mount.MountPoint, info)
+			if err != nil && !ignoreErrors {
+				return nil, err
+			}
+
+			mount.Size = int64(info.Bsize) * int64(info.Blocks)
+			mount.Free = int64(info.Bsize) * int64(info.Bavail)
+
+			devices = append(devices, mount)
+		}
+	}
+
+	return devices, nil
+}

--- a/pkg/device/dev_darwin_test.go
+++ b/pkg/device/dev_darwin_test.go
@@ -1,0 +1,31 @@
+//go:build darwin
+// +build darwin
+
+package device
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetDevicesInfo(t *testing.T) {
+	getter := DarwinDevicesInfoGetter{MountCmd: "/sbin/mount"}
+	devices, _ := getter.GetDevicesInfo()
+	assert.IsType(t, Devices{}, devices)
+}
+
+func TestGetDevicesInfoFail(t *testing.T) {
+	getter := DarwinDevicesInfoGetter{MountCmd: "/nonexistent"}
+	_, err := getter.GetDevicesInfo()
+	assert.Equal(t, "fork/exec /nonexistent: no such file or directory", err.Error())
+}
+
+func TestMountsWithSpace(t *testing.T) {
+	mounts, err := readMountOutput(strings.NewReader(`//inglor@vault.lan/volatile on /Users/inglor/Mountpoints/volatile (vault.lan) (smbfs, nodev, nosuid, mounted by inglor)`))
+	assert.Equal(t, "//inglor@vault.lan/volatile", mounts[0].Name)
+	assert.Equal(t, "/Users/inglor/Mountpoints/volatile (vault.lan)", mounts[0].MountPoint)
+	assert.Equal(t, "smbfs", mounts[0].Fstype)
+	assert.Nil(t, err)
+}

--- a/pkg/device/dev_other.go
+++ b/pkg/device/dev_other.go
@@ -1,4 +1,5 @@
-// +build windows darwin openbsd netbsd plan9
+//go:build windows || openbsd || netbsd || plan9
+// +build windows openbsd netbsd plan9
 
 package device
 


### PR DESCRIPTION
The output of `/sbin/mount` is pretty similar to FreeBSD one. Since its
very common to have spaces in paths we handle mount points with spaces
as well.

Fixes:  #107