### PR TITLE
Properly count only the first hard link size on a rescan

### DIFF
--- a/tui/tui.go
+++ b/tui/tui.go
@@ -179,6 +179,7 @@ func (ui *UI) resetSorting() {
 
 func (ui *UI) rescanDir() {
 	ui.Analyzer.ResetProgress()
+	ui.linkedItems = make(fs.HardLinkedItems)
 	err := ui.AnalyzePath(ui.currentDirPath, ui.currentDir.GetParent())
 	if err != nil {
 		ui.showErr("Error rescanning path", err)


### PR DESCRIPTION
Fixes #124

As a side effect also fixes the hard link information in the "info"
screen after a rescan.