### PR TITLE
fix: honor --summarize when reading analysis

### DIFF
--- a/stdout/stdout.go
+++ b/stdout/stdout.go
@@ -265,7 +265,11 @@ func (ui *UI) ReadAnalysis(input io.Reader) error {
 		return err
 	}
 
-	ui.showDir(dir)
+	if ui.summarize {
+		ui.printTotalItem(dir)
+	} else {
+		ui.showDir(dir)
+	}
 
 	return nil
 }

--- a/stdout/stdout_test.go
+++ b/stdout/stdout_test.go
@@ -186,6 +186,19 @@ func TestReadAnalysisWithWrongFile(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
+func TestReadAnalysisWithSummarize(t *testing.T) {
+	input, err := os.OpenFile("../internal/testdata/test.json", os.O_RDONLY, 0644)
+	assert.Nil(t, err)
+
+	output := bytes.NewBuffer(make([]byte, 10))
+
+	ui := CreateStdoutUI(output, false, false, false, false, true, false, false)
+	err = ui.ReadAnalysis(input)
+
+	assert.Nil(t, err)
+	assert.Contains(t, output.String(), " gdu\n")
+}
+
 func TestMaxInt(t *testing.T) {
 	assert.Equal(t, 5, maxInt(2, 5))
 	assert.Equal(t, 4, maxInt(4, 2))


### PR DESCRIPTION
Before this change, gdu produces different output for `gdu -nps` and
`gdu -p -o- | gdu -nps -f-`.

Check ui.summarize in ReadAnalysis, similar to AnalyzePath.