### PR TITLE
Use GNU tar on Darwin to fix build error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,10 @@ LDFLAGS := -s -w -extldflags '-static' \
 	-X '$(PACKAGE)/build.Version=$(VERSION)' \
 	-X '$(PACKAGE)/build.User=$(shell id -u -n)' \
 	-X '$(PACKAGE)/build.Time=$(shell LC_ALL=en_US.UTF-8 date)'
+TAR := tar
+ifeq ($(shell uname -s),Darwin)
+	TAR := gtar # brew install gnu-tar
+endif
 
 all: clean tarball build-all man clean-uncompressed-dist shasums
 
@@ -22,7 +26,7 @@ vendor: go.mod go.sum
 
 tarball: vendor
 	-mkdir dist
-	tar czf dist/$(NAMEVER).tgz --transform "s,^,$(NAMEVER)/," --exclude dist --exclude test_dir --exclude coverage.txt *
+	$(TAR) czf dist/$(NAMEVER).tgz --transform "s,^,$(NAMEVER)/," --exclude dist --exclude test_dir --exclude coverage.txt *
 
 build:
 	@echo "Version: " $(VERSION)


### PR DESCRIPTION
On macOS `tar` doesn't support the `--transform` flag, but one can install the GNU version of it via `brew install gnu-tar` and call it via `gtar`. So all I did was to replace `tar` with `gtar` on macOS. 

I'm not sure if this is a good solution as it involves installation of external dependency and having Homebrew installed as well. Perhaps a better fix would be to create a `$(NAMEVER)` directory, copy binaries there and tar that directory instead for maximum cross-compatibility.