### PR TITLE
Fix link to Arch Linux package

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Using curl:
     chmod +x gdu_linux_amd64
     mv gdu_linux_amd64 /usr/bin/gdu
 
-[Arch Linux](https://aur.archlinux.org/packages/gdu/):
+[Arch Linux](https://archlinux.org/packages/community/x86_64/gdu/):
 
     pacman -S gdu
 


### PR DESCRIPTION
The previous link was referencing the AUR package which no longer exists