### PR TITLE
feat: use unicode block elements in size bar

### DIFF
--- a/cmd/gdu/app/app.go
+++ b/cmd/gdu/app/app.go
@@ -74,6 +74,7 @@ type Flags struct {
 type Style struct {
 	SelectedRow   ColorStyle        `yaml:"selected-row"`
 	ProgressModal ProgressModalOpts `yaml:"progress-modal"`
+	UseOldSizeBar bool              `yaml:"use-old-size-bar"`
 }
 
 // ProgressModalOpts defines options for progress modal
@@ -234,6 +235,11 @@ func (a *App) createUI() (UI, error) {
 		if a.Flags.Style.ProgressModal.CurrentItemNameMaxLen > 0 {
 			opts = append(opts, func(ui *tui.UI) {
 				ui.SetCurrentItemNameMaxLen(a.Flags.Style.ProgressModal.CurrentItemNameMaxLen)
+			})
+		}
+		if a.Flags.Style.UseOldSizeBar {
+			opts = append(opts, func(ui *tui.UI) {
+				ui.UseOldSizeBar()
 			})
 		}
 		if a.Flags.Sorting.Order != "" || a.Flags.Sorting.By != "" {

--- a/tui/format.go
+++ b/tui/format.go
@@ -13,9 +13,9 @@ func (ui *UI) formatFileRow(item fs.Item, maxUsage int64, maxSize int64, marked 
 	var part int
 
 	if ui.ShowApparentSize {
-		part = int(float64(item.GetSize()) / float64(maxSize) * 10.0)
+		part = int(float64(item.GetSize()) / float64(maxSize) * 100.0)
 	} else {
-		part = int(float64(item.GetUsage()) / float64(maxUsage) * 10.0)
+		part = int(float64(item.GetUsage()) / float64(maxUsage) * 100.0)
 	}
 
 	row := string(item.GetFlag())
@@ -32,7 +32,11 @@ func (ui *UI) formatFileRow(item fs.Item, maxUsage int64, maxSize int64, marked 
 		row += fmt.Sprintf("%15s", ui.formatSize(item.GetUsage(), false, true))
 	}
 
-	row += getUsageGraph(part)
+	if ui.useOldSizeBar {
+		row += " " + getUsageGraphOld(part) + " "
+	} else {
+		row += getUsageGraph(part)
+	}
 
 	if ui.showItemCount {
 		if ui.UseColors && !marked {

--- a/tui/format_test.go
+++ b/tui/format_test.go
@@ -85,6 +85,7 @@ func TestMarked(t *testing.T) {
 	app := testapp.CreateMockedApp(true)
 	ui := CreateUI(app, simScreen, &bytes.Buffer{}, false, false, false, false, false)
 	ui.markedRows[0] = struct{}{}
+	ui.useOldSizeBar = true
 
 	dir := &analyze.Dir{
 		File: &analyze.File{
@@ -100,4 +101,26 @@ func TestMarked(t *testing.T) {
 
 	assert.Contains(t, ui.formatFileRow(file, file.GetUsage(), file.GetSize(), true), "✓ Aaa")
 	assert.Contains(t, ui.formatFileRow(file, file.GetUsage(), file.GetSize(), false), "[##########]   Aaa")
+}
+
+func TestSizeBar(t *testing.T) {
+	simScreen := testapp.CreateSimScreen()
+	defer simScreen.Fini()
+
+	app := testapp.CreateMockedApp(true)
+	ui := CreateUI(app, simScreen, &bytes.Buffer{}, false, false, false, false, false)
+
+	dir := &analyze.Dir{
+		File: &analyze.File{
+			Usage: 10,
+		},
+	}
+
+	file := &analyze.File{
+		Name:   "Aaa",
+		Parent: dir,
+		Usage:  10,
+	}
+
+	assert.Contains(t, ui.formatFileRow(file, file.GetUsage(), file.GetSize(), false), "██████████▏Aaa")
 }

--- a/tui/show.go
+++ b/tui/show.go
@@ -186,7 +186,7 @@ func (ui *UI) showDevices() {
 		ui.table.SetCell(i+1, 0, tview.NewTableCell(textColor+device.Name).SetReference(ui.devices[i]))
 		ui.table.SetCell(i+1, 1, tview.NewTableCell(ui.formatSize(device.Size, false, true)))
 		ui.table.SetCell(i+1, 2, tview.NewTableCell(sizeColor+ui.formatSize(device.Size-device.Free, false, true)))
-		ui.table.SetCell(i+1, 3, tview.NewTableCell(getDeviceUsagePart(device)))
+		ui.table.SetCell(i+1, 3, tview.NewTableCell(getDeviceUsagePart(device, ui.useOldSizeBar)))
 		ui.table.SetCell(i+1, 4, tview.NewTableCell(ui.formatSize(device.Free, false, true)))
 		ui.table.SetCell(i+1, 5, tview.NewTableCell(textColor+device.MountPoint))
 	}

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -50,6 +50,7 @@ type UI struct {
 	selectedTextColor       tcell.Color
 	selectedBackgroundColor tcell.Color
 	currentItemNameMaxLen   int
+	useOldSizeBar           bool
 	defaultSortBy           string
 	defaultSortOrder        string
 	markedRows              map[int]struct{}
@@ -178,6 +179,11 @@ func (ui *UI) SetSelectedBackgroundColor(color tcell.Color) {
 // to be shown in the progress modal
 func (ui *UI) SetCurrentItemNameMaxLen(len int) {
 	ui.currentItemNameMaxLen = len
+}
+
+// UseOldSizeBar uses the old size bar (# chars) instead of the new one (unicode block elements)
+func (ui *UI) UseOldSizeBar() {
+	ui.useOldSizeBar = true
 }
 
 // SetChangeCwdFn sets function that can be used to change current working dir

--- a/tui/utils.go
+++ b/tui/utils.go
@@ -4,22 +4,50 @@ import (
 	"github.com/dundee/gdu/v5/pkg/device"
 )
 
-func getDeviceUsagePart(item *device.Device) string {
-	part := int(float64(item.Size-item.Free) / float64(item.Size) * 10.0)
-	row := "["
-	for i := 0; i < 10; i++ {
-		if part > i {
-			row += "#"
-		} else {
-			row += " "
-		}
+var (
+	barFullRune  = "\u2588"
+	barPartRunes = map[int]string{
+		0: " ",
+		1: "\u258F",
+		2: "\u258E",
+		3: "\u258D",
+		4: "\u258C",
+		5: "\u258B",
+		6: "\u258A",
+		7: "\u2589",
 	}
-	row += "]"
-	return row
+)
+
+func getDeviceUsagePart(item *device.Device, useOld bool) string {
+	part := int(float64(item.Size-item.Free) / float64(item.Size) * 100.0)
+	if useOld {
+		return getUsageGraphOld(part)
+	}
+	return getUsageGraph(part)
 }
 
 func getUsageGraph(part int) string {
-	graph := " ["
+	graph := " "
+	whole := part / 10
+	for i := 0; i < whole; i++ {
+		graph += barFullRune
+	}
+	partWidth := (part % 10) * 8 / 10
+	if part < 100 {
+		graph += barPartRunes[partWidth]
+	}
+
+	for i := 0; i < 10-whole-1; i++ {
+		graph += " "
+	}
+
+	graph += "\u258F"
+	return graph
+}
+
+func getUsageGraphOld(part int) string {
+	part = part / 10
+	graph := "["
 	for i := 0; i < 10; i++ {
 		if part > i {
 			graph += "#"
@@ -27,7 +55,7 @@ func getUsageGraph(part int) string {
 			graph += " "
 		}
 	}
-	graph += "] "
+	graph += "]"
 	return graph
 }
 

--- a/tui/utils_test.go
+++ b/tui/utils_test.go
@@ -1,0 +1,31 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetUsageGraph(t *testing.T) {
+	assert.Equal(t, "           \u258F", getUsageGraph(0))
+	assert.Equal(t, " █         \u258F", getUsageGraph(10))
+	assert.Equal(t, " ██        \u258F", getUsageGraph(20))
+	assert.Equal(t, " ███       \u258F", getUsageGraph(30))
+	assert.Equal(t, " ████      \u258F", getUsageGraph(40))
+	assert.Equal(t, " █████     \u258F", getUsageGraph(50))
+	assert.Equal(t, " ██████    \u258F", getUsageGraph(60))
+	assert.Equal(t, " ███████   \u258F", getUsageGraph(70))
+	assert.Equal(t, " ████████  \u258F", getUsageGraph(80))
+	assert.Equal(t, " █████████ \u258F", getUsageGraph(90))
+	assert.Equal(t, " ██████████\u258F", getUsageGraph(100))
+
+	assert.Equal(t, " █         \u258F", getUsageGraph(11))
+	assert.Equal(t, " █▏        \u258F", getUsageGraph(12))
+	assert.Equal(t, " █▎        \u258F", getUsageGraph(13))
+	assert.Equal(t, " █▍        \u258F", getUsageGraph(14))
+	assert.Equal(t, " █▌        \u258F", getUsageGraph(15))
+	assert.Equal(t, " █▌        \u258F", getUsageGraph(16))
+	assert.Equal(t, " █▋        \u258F", getUsageGraph(17))
+	assert.Equal(t, " █▊        \u258F", getUsageGraph(18))
+	assert.Equal(t, " █▉        \u258F", getUsageGraph(19))
+}


### PR DESCRIPTION
config option `style.use-old-size-bar` added to revert back to legacy size bar

closes #254 