### PR TITLE
Update NCDU description: it has been rewritten to Zig

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ Filesystem cache was cleared using `sync; echo 3 | sudo tee /proc/sys/vm/drop_ca
 
 ## Alternatives
 
-* [ncdu](https://dev.yorhel.nl/ncdu) - NCurses based tool written in pure C
+* [ncdu](https://dev.yorhel.nl/ncdu) - NCurses based tool written in Zig
 * [godu](https://github.com/viktomas/godu) - Analyzer with carousel like user interface
 * [dua](https://github.com/Byron/dua-cli) - Tool written in Rust with interface similar to gdu (and ncdu)
 * [diskus](https://github.com/sharkdp/diskus) - Very simple but very fast tool written in Rust


### PR DESCRIPTION
Hello,

I noticed ncdu is still described as developed in C whereas it has been rewritten in Zig. On the ncdu website the stable version is the Zig one, and the C version is described as the LTS one (still maintained but not the main version anymore).

Annoucement here: https://dev.yorhel.nl/doc/ncdu2

