### PR TITLE
feat: handle vim-style navigation in confirmation

### DIFF
--- a/tui/keys.go
+++ b/tui/keys.go
@@ -33,8 +33,11 @@ func (ui *UI) keyPressed(key *tcell.EventKey) *tcell.EventKey {
 		return nil
 	}
 
-	if ui.pages.HasPage("confirm") ||
-		ui.pages.HasPage("progress") ||
+	if ui.pages.HasPage("confirm") {
+		return ui.handleConfirmation(key)
+	}
+
+	if ui.pages.HasPage("progress") ||
 		ui.pages.HasPage("deleting") ||
 		ui.pages.HasPage("emptying") {
 		return key
@@ -79,6 +82,16 @@ func (ui *UI) handleClosingModals(key *tcell.EventKey) *tcell.EventKey {
 			ui.app.SetFocus(ui.table)
 			return nil
 		}
+	}
+	return key
+}
+
+func (ui *UI) handleConfirmation(key *tcell.EventKey) *tcell.EventKey {
+	if key.Rune() == 'h' {
+		return tcell.NewEventKey(tcell.KeyLeft, 0, 0)
+	}
+	if key.Rune() == 'l' {
+		return tcell.NewEventKey(tcell.KeyRight, 0, 0)
 	}
 	return key
 }

--- a/tui/keys_test.go
+++ b/tui/keys_test.go
@@ -82,9 +82,13 @@ func TestLeftRightKeyWhileConfirm(t *testing.T) {
 	modal := tview.NewModal().SetText("Really?")
 	ui.pages.AddPage("confirm", modal, true, true)
 
-	key := ui.keyPressed(tcell.NewEventKey(tcell.KeyLeft, 'h', 0))
+	key := ui.keyPressed(tcell.NewEventKey(tcell.KeyLeft, 0, 0))
 	assert.Equal(t, tcell.KeyLeft, key.Key())
-	key = ui.keyPressed(tcell.NewEventKey(tcell.KeyRight, 'l', 0))
+	key = ui.keyPressed(tcell.NewEventKey(tcell.KeyRight, 0, 0))
+	assert.Equal(t, tcell.KeyRight, key.Key())
+	key = ui.keyPressed(tcell.NewEventKey(tcell.KeyRune, 'h', 0))
+	assert.Equal(t, tcell.KeyLeft, key.Key())
+	key = ui.keyPressed(tcell.NewEventKey(tcell.KeyRune, 'l', 0))
 	assert.Equal(t, tcell.KeyRight, key.Key())
 }
 


### PR DESCRIPTION
Handle `h` and `l` keys for navigation within confirmation modal in empty/delete operation

Closes #232 