### PR TITLE
Fix instructions for homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ Using curl:
 [Homebrew](https://formulae.brew.sh/formula/gdu):
 
     brew install -f gdu
-    brew link --overwrite gdu  # if you have coreutils installed as well
+    # gdu will be installed as `gdu-go` to avoid conflicts with coreutils
+    gdu-go
 
 [Snap](https://snapcraft.io/gdu-disk-usage-analyzer):
 


### PR DESCRIPTION
Follow-up of https://github.com/dundee/gdu/issues/48#issuecomment-1604226714

After installing I can confirm that `gdu` doesn't run the program, but `gdu-go` does.