### PR TITLE
docs: add tag to docker command example

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ See the [installation page](./INSTALL.md) for other ways how to install Gdu to y
 
 Or you can use Gdu directly via Docker:
 
-    docker run --rm --init --interactive --tty --privileged --volume /:/mnt/root ghcr.io/dundee/gdu /mnt/root
+    docker run --rm --init --interactive --tty --privileged --volume /:/mnt/root ghcr.io/dundee/gdu:master /mnt/root
 
 ## Usage
 


### PR DESCRIPTION
the auto docker image build workflow doesn't tag the latest images with `latest` so the example doesn't actually work:
```bash
docker run --rm --init --interactive --tty --privileged --volume /:/mnt/root ghcr.io/dundee/gdu /mnt/roo
Unable to find image 'ghcr.io/dundee/gdu:latest' locally
```