### PR TITLE
Update INSTALL.md: reminder to restart windows terminal

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -47,6 +47,8 @@ You can either run it as `gdu_windows_amd64.exe` or
 * add an alias with `Doskey`.
 * add `alias gdu="gdu_windows_amd64.exe"` to your `~/.bashrc` file if using Git Bash to run it as `gdu`.
 
+You might need to restart your terminal.
+
 [Scoop](https://github.com/ScoopInstaller/Main/blob/master/bucket/gdu.json):
 
     scoop install gdu


### PR DESCRIPTION
I tried to install gdu on windows, and got stuck after installation, because I needed to restart my terminal for Windows to handle gdu PATH.

I propose to add a single line that might help future Windows users.