### PR TITLE
docs: fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ flag with following meaning:
 
 Gdu can read (and write) YAML configuration file.
 
-`$HOME/.config/gdu/gdu.yaml` and `$HOME/.gdu.yaml` are checked for the presense of the config file by default.
+`$HOME/.config/gdu/gdu.yaml` and `$HOME/.gdu.yaml` are checked for the presence of the config file by default.
 
 See the [full list of all configuration options](configuration).
 
@@ -177,8 +177,8 @@ gdu --write-config
 
 ## Styling
 
-There are wast ways how terminals can be colored.
-Some gdu primitives (like basic text) addapt to different color schemas, but the selected/highlighted row does not.
+There are waste ways how terminals can be colored.
+Some gdu primitives (like basic text) adapt to different color schemas, but the selected/highlighted row does not.
 
 If the default look is not sufficient, it can be changed in configuration file, e.g.:
 

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ gdu --write-config
 
 ## Styling
 
-There are waste ways how terminals can be colored.
+There are wide options for how terminals can be colored.
 Some gdu primitives (like basic text) adapt to different color schemas, but the selected/highlighted row does not.
 
 If the default look is not sufficient, it can be changed in configuration file, e.g.:

--- a/gdu.spec
+++ b/gdu.spec
@@ -88,7 +88,7 @@ install -Dpm 0755 %{name}.1 $RPM_BUILD_ROOT%{_mandir}/man1/gdu.1
 - feat: add ctrl+z for job control by @yurenchen000 in #250
 - feat: upgrade dependencies by @dundee in #252
 * Thu May 11 2023 Danie de Jager - 5.23.0-2
-- Compiled wiht golang 1.19.9
+- Compiled with golang 1.19.9
 * Tue Apr 11 2023 Danie de Jager - 5.23.0-1
 - feat: added configuration option to change CWD when browsing directories by @leapfog in #230
 - fix: do not show help modal when confirm modal is already opened by @dundee in #237

--- a/internal/common/ignore.go
+++ b/internal/common/ignore.go
@@ -33,7 +33,7 @@ func (ui *UI) SetIgnoreDirPaths(paths []string) {
 	}
 }
 
-// SetIgnoreDirPatterns sets regular patters of dirs to ignore
+// SetIgnoreDirPatterns sets regular patterns of dirs to ignore
 func (ui *UI) SetIgnoreDirPatterns(paths []string) error {
 	var err error
 	log.Printf("Ignoring dir patterns %s", strings.Join(paths, ", "))
@@ -41,7 +41,7 @@ func (ui *UI) SetIgnoreDirPatterns(paths []string) error {
 	return err
 }
 
-// SetIgnoreFromFile sets regular patters of dirs to ignore
+// SetIgnoreFromFile sets regular patterns of dirs to ignore
 func (ui *UI) SetIgnoreFromFile(ignoreFile string) error {
 	var err error
 	var paths []string

--- a/pkg/analyze/file.go
+++ b/pkg/analyze/file.go
@@ -145,7 +145,7 @@ type Dir struct {
 	m         sync.RWMutex
 }
 
-// AddFile add item fo files
+// AddFile add item to files
 func (f *Dir) AddFile(item fs.Item) {
 	f.Files = append(f.Files, item)
 }

--- a/pkg/path/path.go
+++ b/pkg/path/path.go
@@ -10,7 +10,7 @@ func ShortenPath(path string, maxLen int) string {
 
 	res := ""
 	parts := strings.SplitAfter(path, "/")
-	curLen := len(parts[len(parts)-1]) // count lenght of last part for start
+	curLen := len(parts[len(parts)-1]) // count length of last part for start
 
 	for _, part := range parts[:len(parts)-1] {
 		curLen += len(part)

--- a/stdout/stdout.go
+++ b/stdout/stdout.go
@@ -92,7 +92,7 @@ func (ui *UI) ListDevices(getter device.DevicesInfoGetter) error {
 		return err
 	}
 
-	maxDeviceNameLenght := maxInt(maxLength(
+	maxDeviceNameLength := maxInt(maxLength(
 		devices,
 		func(device *device.Device) string { return device.Name },
 	), len("Devices"))
@@ -108,7 +108,7 @@ func (ui *UI) ListDevices(getter device.DevicesInfoGetter) error {
 
 	lineFormat := fmt.Sprintf(
 		"%%%ds %%%ds %%%ds %%%ds %%%ds %%s\n",
-		maxDeviceNameLenght,
+		maxDeviceNameLength,
 		sizeLength,
 		sizeLength,
 		sizeLength,
@@ -117,7 +117,7 @@ func (ui *UI) ListDevices(getter device.DevicesInfoGetter) error {
 
 	fmt.Fprintf(
 		ui.output,
-		fmt.Sprintf("%%%ds %%9s %%9s %%9s %%5s %%s\n", maxDeviceNameLenght),
+		fmt.Sprintf("%%%ds %%9s %%9s %%9s %%5s %%s\n", maxDeviceNameLength),
 		"Device",
 		"Size",
 		"Used",

--- a/tui/actions.go
+++ b/tui/actions.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	defaultLinesCount = 500
-	linesTreshold     = 20
+	linesThreshold    = 20
 
 	actionEmpty  = "empty"
 	actionDelete = "delete"
@@ -396,11 +396,11 @@ func (ui *UI) exportAnalysis() {
 		}
 
 		if _, err = buff.Write([]byte("]\n")); err != nil {
-			ui.showErrFromGo("Error writting to buffer", err)
+			ui.showErrFromGo("Error writing to buffer", err)
 			return
 		}
 		if _, err = buff.WriteTo(file); err != nil {
-			ui.showErrFromGo("Error writting to file", err)
+			ui.showErrFromGo("Error writing to file", err)
 			return
 		}
 	}()

--- a/tui/show_file.go
+++ b/tui/show_file.go
@@ -88,7 +88,7 @@ func (ui *UI) showFile() *tview.TextView {
 			event.Key() == tcell.KeyDown || event.Key() == tcell.KeyPgDn {
 			_, _, _, height := file.GetInnerRect()
 			row, _ := file.GetScrollOffset()
-			if height+row > totalLines-linesTreshold {
+			if height+row > totalLines-linesThreshold {
 				totalLines += readNextPart(defaultLinesCount)
 			}
 		}

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -94,7 +94,7 @@ type ResultRow struct {
 	DirectoryColor string
 }
 
-// Option is optional function customizing the bahaviour of UI
+// Option is optional function customizing the behaviour of UI
 type Option func(ui *UI)
 
 // CreateUI creates the whole UI app
@@ -211,12 +211,12 @@ func (ui *UI) createGrid() {
 	}
 }
 
-// SetSelectedTextColor sets the color for the highighted selected text
+// SetSelectedTextColor sets the color for the highlighted selected text
 func (ui *UI) SetSelectedTextColor(color tcell.Color) {
 	ui.selectedTextColor = color
 }
 
-// SetSelectedBackgroundColor sets the color for the highighted selected text
+// SetSelectedBackgroundColor sets the color for the highlighted selected text
 func (ui *UI) SetSelectedBackgroundColor(color tcell.Color) {
 	ui.selectedBackgroundColor = color
 }


### PR DESCRIPTION
found via `codespell -H` and `typos --hidden --format brief`