### PR TITLE
feat: relative path ignore support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ Flags:
       --enable-profiling              Enable collection of profiling data and provide it on http://localhost:6060/debug/pprof/
   -L, --follow-symlinks               Follow symlinks for files, i.e. show the size of the file to which symlink points to (symlinks to directories are not followed)
   -h, --help                          help for gdu
-  -i, --ignore-dirs strings           Absolute paths to ignore (separated by comma) (default [/proc,/dev,/sys,/run])
-  -I, --ignore-dirs-pattern strings   Absolute path patterns to ignore (separated by comma)
-  -X, --ignore-from string            Read absolute path patterns to ignore from file
+  -i, --ignore-dirs strings           Paths to ignore (separated by comma). Can be absolute or relative to current directory (default [/proc,/dev,/sys,/run])
+  -I, --ignore-dirs-pattern strings   Path patterns to ignore (separated by comma)
+  -X, --ignore-from string            Read path patterns to ignore from file
   -f, --input-file string             Import analysis from JSON file
   -l, --log-file string               Path to a logfile (default "/dev/null")
   -m, --max-cores int                 Set max cores that Gdu will use. 12 cores available (default 12)

--- a/cmd/gdu/main.go
+++ b/cmd/gdu/main.go
@@ -48,9 +48,12 @@ func init() {
 	flags.BoolVar(&af.SequentialScanning, "sequential", false, "Use sequential scanning (intended for rotating HDDs)")
 	flags.BoolVarP(&af.ShowVersion, "version", "v", false, "Print version")
 
-	flags.StringSliceVarP(&af.IgnoreDirs, "ignore-dirs", "i", []string{"/proc", "/dev", "/sys", "/run"}, "Absolute paths to ignore (separated by comma)")
-	flags.StringSliceVarP(&af.IgnoreDirPatterns, "ignore-dirs-pattern", "I", []string{}, "Absolute path patterns to ignore (separated by comma)")
-	flags.StringVarP(&af.IgnoreFromFile, "ignore-from", "X", "", "Read absolute path patterns to ignore from file")
+	flags.StringSliceVarP(&af.IgnoreDirs, "ignore-dirs", "i", []string{"/proc", "/dev", "/sys", "/run"},
+		"Paths to ignore (separated by comma). Can be absolute or relative to current directory")
+	flags.StringSliceVarP(&af.IgnoreDirPatterns, "ignore-dirs-pattern", "I", []string{},
+		"Path patterns to ignore (separated by comma)")
+	flags.StringVarP(&af.IgnoreFromFile, "ignore-from", "X", "",
+		"Read path patterns to ignore from file")
 	flags.BoolVarP(&af.NoHidden, "no-hidden", "H", false, "Ignore hidden directories (beginning with dot)")
 	flags.BoolVarP(
 		&af.FollowSymlinks, "follow-symlinks", "L", false,

--- a/configuration.md
+++ b/configuration.md
@@ -26,11 +26,11 @@ Export all info into file as JSON
 
 #### `ignore-dirs`
 
-Absolute paths to ignore (separated by comma) (default [/proc,/dev,/sys,/run])
+Paths to ignore (separated by comma). Can be absolute (like `/proc`) or relative to the current working directory (like `node_modules`). Default values are [/proc,/dev,/sys,/run].
 
 #### `ignore-dir-patterns`
 
-Absolute path regex patterns to ignore (separated by comma)
+Path patterns to ignore (separated by comma). Patterns can be absolute or relative to the current working directory.
 
 #### `ignore-from-file`
 
@@ -91,7 +91,6 @@ Follow symlinks for files, i.e. show the size of the file to which symlink point
 #### `profiling`
 
 Enable collection of profiling data and provide it on http://localhost:6060/debug/pprof/
-
 #### `const-gc`
 
 Enable memory garbage collection during analysis with constant level set by GOGC

--- a/configuration.md
+++ b/configuration.md
@@ -34,7 +34,7 @@ Path patterns to ignore (separated by comma). Patterns can be absolute or relati
 
 #### `ignore-from-file`
 
-Read absolute path regex patterns to ignore from file
+Read path patterns to ignore from file. Patterns can be absolute or relative to the current working directory.
 
 #### `max-cores`
 

--- a/gdu.1.md
+++ b/gdu.1.md
@@ -24,11 +24,17 @@ is not so huge.
 
 **-h**, **\--help**\[=false\] help for gdu
 
-**-i**, **\--ignore-dirs**=\[/proc,/dev,/sys,/run\] Paths to ignore (separated by comma). Supports both absolute and relative paths.
+**-i**, **\--ignore-dirs**=\[/proc,/dev,/sys,/run\]
+    Paths to ignore (separated by comma).
+    Supports both absolute and relative paths.
 
-**-I**, **\--ignore-dirs-pattern** Path patterns to ignore (separated by comma). Supports both absolute and relative path patterns.
+**-I**, **\--ignore-dirs-pattern**
+    Path patterns to ignore (separated by comma).
+    Supports both absolute and relative path patterns.
 
-**-X**, **\--ignore-from** Read absolute path patterns to ignore from file
+**-X**, **\--ignore-from**
+    Read path patterns to ignore from file.
+    Supports both absolute and relative path patterns.
 
 **-l**, **\--log-file**=\"/dev/null\" Path to a logfile
 

--- a/gdu.1.md
+++ b/gdu.1.md
@@ -24,11 +24,9 @@ is not so huge.
 
 **-h**, **\--help**\[=false\] help for gdu
 
-**-i**, **\--ignore-dirs**=\[/proc,/dev,/sys,/run\] Absolute paths to
-ignore (separated by comma)
+**-i**, **\--ignore-dirs**=\[/proc,/dev,/sys,/run\] Paths to ignore (separated by comma). Supports both absolute and relative paths.
 
-**-I**, **\--ignore-dirs-pattern** Absolute path patterns to
-ignore (separated by comma)
+**-I**, **\--ignore-dirs-pattern** Path patterns to ignore (separated by comma). Supports both absolute and relative path patterns.
 
 **-X**, **\--ignore-from** Read absolute path patterns to ignore from file
 

--- a/internal/common/ignore.go
+++ b/internal/common/ignore.go
@@ -18,6 +18,17 @@ func CreateIgnorePattern(paths []string) (*regexp.Regexp, error) {
 		if _, err = regexp.Compile(path); err != nil {
 			return nil, err
 		}
+		if !filepath.IsAbs(path) {
+			absPath, err := filepath.Abs(path)
+			if err == nil {
+				paths = append(paths, absPath)
+			}
+		} else {
+			relPath, err := filepath.Rel("/", path)
+			if err == nil {
+				paths = append(paths, relPath)
+			}
+		}
 		paths[i] = "(" + path + ")"
 	}
 

--- a/internal/common/ignore_test.go
+++ b/internal/common/ignore_test.go
@@ -2,6 +2,7 @@ package common_test
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	log "github.com/sirupsen/logrus"
@@ -151,4 +152,28 @@ func TestIgnoreByAll(t *testing.T) {
 	assert.True(t, shouldBeIgnored(".git", "/aaa/.git"))
 	assert.True(t, shouldBeIgnored(".bbb", "/aaa/.bbb"))
 	assert.False(t, shouldBeIgnored("xxx", "/xxx"))
+}
+
+func TestIgnoreByRelativePath(t *testing.T) {
+	ui := &common.UI{}
+	ui.SetIgnoreDirPaths([]string{"test_dir/abc"})
+	shouldBeIgnored := ui.CreateIgnoreFunc()
+
+	assert.True(t, shouldBeIgnored("abc", "test_dir/abc"))
+	absPath, err := filepath.Abs("test_dir/abc")
+	assert.Nil(t, err)
+	assert.True(t, shouldBeIgnored("abc", absPath))
+	assert.False(t, shouldBeIgnored("xxx", "test_dir/xxx"))
+}
+
+func TestIgnoreByAbsPathWithRelativeMatch(t *testing.T) {
+	ui := &common.UI{}
+	absPath, err := filepath.Abs("test_dir/abc")
+	assert.Nil(t, err)
+	ui.SetIgnoreDirPaths([]string{absPath})
+	shouldBeIgnored := ui.CreateIgnoreFunc()
+
+	assert.True(t, shouldBeIgnored("abc", absPath))
+	assert.True(t, shouldBeIgnored("abc", "test_dir/abc"))
+	assert.False(t, shouldBeIgnored("xxx", "test_dir/xxx"))
 }


### PR DESCRIPTION
### Description
Improves path handling in ignore functionality to support both absolute and relative paths. This includes the `--ignore-dirs` flag, `--ignore-dirs-pattern` flag, and `--ignore-from` file patterns.

### Changes
- Updated all ignore mechanisms to support relative paths
- Updated documentation in README.md, configuration.md, and gdu.1.md

### Documentation
Updated all relevant documentation to reflect the new path handling capabilities.