### PR TITLE
feat: Add support showing size of absent git-annex'ed files

### DIFF
--- a/cmd/gdu/app/app.go
+++ b/cmd/gdu/app/app.go
@@ -36,6 +36,7 @@ type UI interface {
 	SetIgnoreFromFile(ignoreFile string) error
 	SetIgnoreHidden(value bool)
 	SetFollowSymlinks(value bool)
+	SetShowAnnexedSize(value bool)
 	SetAnalyzer(analyzer common.Analyzer)
 	StartUILoop() error
 }
@@ -54,6 +55,7 @@ type Flags struct {
 	ShowDisks          bool     `yaml:"-"`
 	ShowApparentSize   bool     `yaml:"show-apparent-size"`
 	ShowRelativeSize   bool     `yaml:"show-relative-size"`
+	ShowAnnexedSize    bool     `yaml:"show-annexed-size"`
 	ShowVersion        bool     `yaml:"-"`
 	ShowItemCount      bool     `yaml:"show-item-count"`
 	ShowMTime          bool     `yaml:"show-mtime"`
@@ -182,6 +184,9 @@ func (a *App) Run() error {
 	}
 	if a.Flags.FollowSymlinks {
 		ui.SetFollowSymlinks(true)
+	}
+	if a.Flags.ShowAnnexedSize {
+		ui.SetShowAnnexedSize(true)
 	}
 	if err := a.setNoCross(path); err != nil {
 		return err

--- a/cmd/gdu/app/app_test.go
+++ b/cmd/gdu/app/app_test.go
@@ -77,6 +77,21 @@ func TestFollowSymlinks(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+func TestShowAnnexedSize(t *testing.T) {
+	fin := testdir.CreateTestDir()
+	defer fin()
+
+	out, err := runApp(
+		&Flags{LogFile: "/dev/null", ShowAnnexedSize: true},
+		[]string{"test_dir"},
+		false,
+		testdev.DevicesInfoGetterMock{},
+	)
+
+	assert.Contains(t, out, "nested")
+	assert.Nil(t, err)
+}
+
 func TestAnalyzePathProfiling(t *testing.T) {
 	fin := testdir.CreateTestDir()
 	defer fin()

--- a/cmd/gdu/main.go
+++ b/cmd/gdu/main.go
@@ -59,6 +59,10 @@ func init() {
 		&af.FollowSymlinks, "follow-symlinks", "L", false,
 		"Follow symlinks for files, i.e. show the size of the file to which symlink points to (symlinks to directories are not followed)",
 	)
+	flags.BoolVarP(
+		&af.ShowAnnexedSize, "show-annexed-size", "A", false,
+		"Use apparent size of git-annex'ed files in case files are not present locally (real usage is zero)",
+	)
 	flags.BoolVarP(&af.NoCross, "no-cross", "x", false, "Do not cross filesystem boundaries")
 	flags.BoolVarP(&af.ConstGC, "const-gc", "g", false, "Enable memory garbage collection during analysis with constant level set by GOGC")
 	flags.BoolVar(&af.Profiling, "enable-profiling", false, "Enable collection of profiling data and provide it on http://localhost:6060/debug/pprof/")

--- a/internal/common/analyze.go
+++ b/internal/common/analyze.go
@@ -16,6 +16,7 @@ type ShouldDirBeIgnored func(name, path string) bool
 type Analyzer interface {
 	AnalyzeDir(path string, ignore ShouldDirBeIgnored, constGC bool) fs.Item
 	SetFollowSymlinks(bool)
+	SetShowAnnexedSize(bool)
 	GetProgressChan() chan CurrentProgress
 	GetDone() SignalGroup
 	ResetProgress()

--- a/internal/common/ui.go
+++ b/internal/common/ui.go
@@ -29,6 +29,11 @@ func (ui *UI) SetFollowSymlinks(v bool) {
 	ui.Analyzer.SetFollowSymlinks(v)
 }
 
+// SetShowAnnexedSize sets whether to use annexed size of git-annex files
+func (ui *UI) SetShowAnnexedSize(v bool) {
+	ui.Analyzer.SetShowAnnexedSize(v)
+}
+
 // binary multiplies prefixes (IEC)
 const (
 	_ float64 = 1 << (10 * iota)

--- a/internal/common/ui_test.go
+++ b/internal/common/ui_test.go
@@ -21,8 +21,18 @@ func TestSetFollowSymlinks(t *testing.T) {
 	assert.Equal(t, true, ui.Analyzer.(*MockedAnalyzer).FollowSymlinks)
 }
 
+func TestSetShowAnnexedSize(t *testing.T) {
+	ui := UI{
+		Analyzer: &MockedAnalyzer{},
+	}
+	ui.SetShowAnnexedSize(true)
+
+	assert.Equal(t, true, ui.Analyzer.(*MockedAnalyzer).ShowAnnexedSize)
+}
+
 type MockedAnalyzer struct {
-	FollowSymlinks bool
+	FollowSymlinks  bool
+	ShowAnnexedSize bool
 }
 
 // AnalyzeDir returns dir with files with different size exponents
@@ -50,4 +60,9 @@ func (a *MockedAnalyzer) ResetProgress() {}
 // SetFollowSymlinks does nothing
 func (a *MockedAnalyzer) SetFollowSymlinks(v bool) {
 	a.FollowSymlinks = v
+}
+
+// SetShowAnnexedSize does nothing
+func (a *MockedAnalyzer) SetShowAnnexedSize(v bool) {
+	a.ShowAnnexedSize = v
 }

--- a/internal/testanalyze/analyze.go
+++ b/internal/testanalyze/analyze.go
@@ -84,6 +84,9 @@ func (a *MockedAnalyzer) ResetProgress() {}
 // SetFollowSymlinks does nothing
 func (a *MockedAnalyzer) SetFollowSymlinks(v bool) {}
 
+// SetShowAnnexedSize does nothing
+func (a *MockedAnalyzer) SetShowAnnexedSize(v bool) {}
+
 // ItemFromDirWithErr returns error
 func ItemFromDirWithErr(dir, file fs.Item) error {
 	return errors.New("Failed")

--- a/pkg/analyze/sequential.go
+++ b/pkg/analyze/sequential.go
@@ -20,6 +20,7 @@ type SequentialAnalyzer struct {
 	wait             *WaitGroup
 	ignoreDir        common.ShouldDirBeIgnored
 	followSymlinks   bool
+	gitAnnexedSize   bool
 }
 
 // CreateSeqAnalyzer returns Analyzer
@@ -40,6 +41,11 @@ func CreateSeqAnalyzer() *SequentialAnalyzer {
 // SetFollowSymlinks sets whether symlink to files should be followed
 func (a *SequentialAnalyzer) SetFollowSymlinks(v bool) {
 	a.followSymlinks = v
+}
+
+// SetShowAnnexedSize sets whether to use annexed size of git-annex files
+func (a *SequentialAnalyzer) SetShowAnnexedSize(v bool) {
+	a.gitAnnexedSize = v
 }
 
 // GetProgressChan returns channel for getting progress
@@ -127,7 +133,7 @@ func (a *SequentialAnalyzer) processDir(path string) *Dir {
 				continue
 			}
 			if a.followSymlinks && info.Mode()&os.ModeSymlink != 0 {
-				infoF, err := followSymlink(entryPath)
+				infoF, err := followSymlink(entryPath, a.gitAnnexedSize)
 				if err != nil {
 					log.Print(err.Error())
 					dir.Flag = '!'

--- a/pkg/analyze/stored.go
+++ b/pkg/analyze/stored.go
@@ -25,6 +25,7 @@ type StoredAnalyzer struct {
 	wait             *WaitGroup
 	ignoreDir        common.ShouldDirBeIgnored
 	followSymlinks   bool
+	gitAnnexedSize   bool
 }
 
 // CreateStoredAnalyzer returns Analyzer
@@ -55,6 +56,10 @@ func (a *StoredAnalyzer) GetDone() common.SignalGroup {
 
 func (a *StoredAnalyzer) SetFollowSymlinks(v bool) {
 	a.followSymlinks = v
+}
+
+func (a *StoredAnalyzer) SetShowAnnexedSize(v bool) {
+	a.gitAnnexedSize = v
 }
 
 // ResetProgress returns progress

--- a/pkg/analyze/symlink.go
+++ b/pkg/analyze/symlink.go
@@ -1,0 +1,39 @@
+package analyze
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/dundee/gdu/v5/pkg/annex"
+)
+
+func followSymlink(path string, gitAnnexedSize bool) (tInfo os.FileInfo, err error) {
+	target, err := os.Readlink(path)
+	if err != nil {
+		fmt.Println(path, err)
+		return nil, err
+	}
+
+	tInfo, err = os.Lstat(target)
+	if err != nil {
+		if os.IsNotExist(err) && gitAnnexedSize && strings.Contains(target, ".git/annex/objects") {
+			tInfo, err = os.Lstat(path)
+			if err != nil {
+				return nil, err
+			}
+
+			name := filepath.Base(target)
+			tInfo = annex.AnnexedFileInfo(tInfo, name)
+		} else {
+			return nil, err
+		}
+	}
+
+	if tInfo.IsDir() {
+		return nil, nil
+	}
+
+	return tInfo, nil
+}

--- a/pkg/analyze/symlink.go
+++ b/pkg/analyze/symlink.go
@@ -1,7 +1,6 @@
 package analyze
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -10,9 +9,8 @@ import (
 )
 
 func followSymlink(path string, gitAnnexedSize bool) (tInfo os.FileInfo, err error) {
-	target, err := os.Readlink(path)
+	target, err := filepath.EvalSymlinks(path)
 	if err != nil {
-		fmt.Println(path, err)
 		return nil, err
 	}
 

--- a/pkg/analyze/symlink.go
+++ b/pkg/analyze/symlink.go
@@ -11,7 +11,7 @@ import (
 func followSymlink(path string, gitAnnexedSize bool) (tInfo os.FileInfo, err error) {
 	target, err := filepath.EvalSymlinks(path)
 	if err != nil {
-		target, err := os.Readlink(path)
+		target, err = os.Readlink(path)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/analyze/symlink_test.go
+++ b/pkg/analyze/symlink_test.go
@@ -36,7 +36,7 @@ func TestFollowSymlinkErr(t *testing.T) {
 	_, err = followSymlink("test_dir/nested/file3", true)
 	assert.NoError(t, err)
 
-	res, err := followSymlink("some_dir", true)
+	res, err := followSymlink("test_dir/some_dir", true)
 	assert.Equal(t, nil, res)
 	assert.NoError(t, err)
 }

--- a/pkg/analyze/symlink_test.go
+++ b/pkg/analyze/symlink_test.go
@@ -1,0 +1,42 @@
+package analyze
+
+import (
+	"os"
+	"testing"
+
+	"github.com/dundee/gdu/v5/internal/testdir"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFollowSymlinkErr(t *testing.T) {
+	fin := testdir.CreateTestDir()
+	defer fin()
+
+	err := os.Mkdir("test_dir/empty", 0o644)
+	assert.Nil(t, err)
+
+	err = os.Symlink(
+		".git/annex/objects/qx/qX/SHA256E-s967858083--"+
+			"3e54803fded8dc3a9ea68b106f7b51e04e33c79b4a7b32a860f0b22d89af5c65.mp4/SHA256E-s967858083--"+
+			"3e54803fded8dc3a9ea68b106f7b51e04e33c79b4a7b32a860f0b22d89af5c65.mp4",
+		"test_dir/nested/file3")
+	assert.Nil(t, err)
+
+	err = os.Symlink(
+		"test_dir/nested",
+		"test_dir/some_dir")
+	assert.Nil(t, err)
+
+	_, err = followSymlink("xxx", false)
+	assert.ErrorContains(t, err, "no such file or directory")
+
+	_, err = followSymlink("test_dir/nested/file3", false)
+	assert.ErrorContains(t, err, "no such file or directory")
+
+	_, err = followSymlink("test_dir/nested/file3", true)
+	assert.NoError(t, err)
+
+	res, err := followSymlink("some_dir", true)
+	assert.Equal(t, nil, res)
+	assert.NoError(t, err)
+}

--- a/pkg/annex/annex.go
+++ b/pkg/annex/annex.go
@@ -19,7 +19,7 @@ func SizeFromKey(name string) (int64, error) {
 	}
 
 	for _, p := range backendKVParts[1:] {
-		if len(p) == 0 || p[0] != 's' {
+		if p == "" || p[0] != 's' {
 			continue
 		}
 

--- a/pkg/annex/annex.go
+++ b/pkg/annex/annex.go
@@ -1,0 +1,65 @@
+package annex
+
+import (
+	"fmt"
+	"io/fs"
+	"log"
+	"strconv"
+	"strings"
+)
+
+// SizeFromKey returns size from git-annex key.
+func SizeFromKey(name string) (int64, error) {
+	nameParts := strings.SplitN(name, "--", 2)
+	backendKVs := nameParts[0]
+	backendKVParts := strings.Split(backendKVs, "-")
+
+	if len(backendKVParts) < 2 {
+		return 0, fmt.Errorf("key is is missing backend")
+	}
+
+	for _, p := range backendKVParts[1:] {
+		if len(p) == 0 || p[0] != 's' {
+			continue
+		}
+
+		size, err := strconv.ParseInt(p[1:], 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("failed to parse size: %w", err)
+		}
+
+		return size, nil
+	}
+
+	return 0, fmt.Errorf("size not found in key")
+}
+
+// AnnexedFileInfo returns a new FileInfo with size from git-annex key.
+func AnnexedFileInfo(fi fs.FileInfo, name string) *FileInfo {
+	size, err := SizeFromKey(name)
+	if err != nil {
+		log.Print(err.Error())
+		return &FileInfo{FileInfo: fi}
+	}
+
+	afi := &FileInfo{
+		FileInfo: fi,
+		size:     size,
+	}
+
+	return afi
+}
+
+var _ fs.FileInfo = (*FileInfo)(nil)
+
+// FileInfo is a wrapper around fs.FileInfo to overwrite the size.
+type FileInfo struct {
+	fs.FileInfo
+
+	size int64
+}
+
+// Length in bytes for regular files; system-dependent for others
+func (fi *FileInfo) Size() int64 {
+	return int64(fi.size)
+}

--- a/pkg/annex/annex_test.go
+++ b/pkg/annex/annex_test.go
@@ -1,0 +1,39 @@
+package annex
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAnnexedFileInfo(t *testing.T) {
+	fi := &FileInfo{}
+	fi = AnnexedFileInfo(fi, "SHA256E-s967858083--3e54803fded8dc3a9ea68b106f7b51e04e33c79b4a7b32a860f0b22d89af5c65.mp4")
+
+	assert.Equal(t, int64(967858083), fi.Size())
+}
+
+func TestAnnexedFileInfoErr(t *testing.T) {
+	fi := &FileInfo{}
+	fi = AnnexedFileInfo(fi, "xxx")
+
+	assert.Equal(t, int64(0), fi.Size())
+}
+
+func TestSizeFromKeyErr(t *testing.T) {
+	_, err := SizeFromKey("xxx")
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "key is is missing backend")
+
+	_, err = SizeFromKey("SHA256E-sXXX--3e54803fded8dc3a9ea68b106f7b51e04e33c79b4a7b32a860f0b22d89af5c65.mp4")
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "failed to parse size")
+
+	_, err = SizeFromKey("SHA256E-s--3e54803fded8dc3a9ea68b106f7b51e04e33c79b4a7b32a860f0b22d89af5c65.mp4")
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "failed to parse size")
+
+	_, err = SizeFromKey("SHA256E-a-b-c--3e54803fded8dc3a9ea68b106f7b51e04e33c79b4a7b32a860f0b22d89af5c65.mp4")
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "size not found in key")
+}


### PR DESCRIPTION
git-annex encodes the apparent size of files their symlinks.

gdu now is capable of extracting those sizes from the broken symlinks to calculate the total size of git-annex repositories.

Reference: https://git-annex.branchable.com/internals/key_format/

**Note:** real usage remains zero. gdu needs to be invoked via:

```shell
gdu --follow-symlinks --show-apparent-size --show-annexed-size
```