### PR TITLE
fix: item count for --show-item-count

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.23.3
+golang 1.23.4

--- a/tui/format.go
+++ b/tui/format.go
@@ -62,7 +62,7 @@ func (ui *UI) formatFileRow(item fs.Item, maxUsage, maxSize int64, marked, ignor
 		} else {
 			row += defaultColorBold
 		}
-		
+
 		countToDisplay := item.GetItemCount()
 		if item.IsDir() {
 			countToDisplay--

--- a/tui/format.go
+++ b/tui/format.go
@@ -62,7 +62,12 @@ func (ui *UI) formatFileRow(item fs.Item, maxUsage, maxSize int64, marked, ignor
 		} else {
 			row += defaultColorBold
 		}
-		row += fmt.Sprintf("%11s ", ui.formatCount(item.GetItemCount()))
+		
+		countToDisplay := item.GetItemCount()
+		if item.IsDir() {
+			countToDisplay--
+		}
+		row += fmt.Sprintf("%11s ", ui.formatCount(countToDisplay))
 	}
 
 	if ui.showMtime {


### PR DESCRIPTION
This is a fix for issue #412 where `gdu --show-item-count` incorrectly includes the directory itself in its item count.