### PR TITLE
make no-mouse default true

### DIFF
--- a/cmd/gdu/main.go
+++ b/cmd/gdu/main.go
@@ -84,7 +84,7 @@ func init() {
 	flags.IntVarP(&af.Top, "top", "t", 0, "Show only top X largest files in non-interactive mode")
 	flags.BoolVar(&af.UseSIPrefix, "si", false, "Show sizes with decimal SI prefixes (kB, MB, GB) instead of binary prefixes (KiB, MiB, GiB)")
 	flags.BoolVar(&af.NoPrefix, "no-prefix", false, "Show sizes as raw numbers without any prefixes (SI or binary) in non-interactive mode")
-	flags.BoolVar(&af.NoMouse, "no-mouse", false, "Do not use mouse")
+	flags.BoolVar(&af.NoMouse, "no-mouse", true, "Do not use mouse")
 	flags.BoolVar(&af.NoDelete, "no-delete", false, "Do not allow deletions")
 	flags.BoolVar(&af.WriteConfig, "write-config", false, "Write current configuration to file (default is $HOME/.gdu.yaml)")
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dundee/gdu/v5
 
-go 1.22
+go 1.24.4
 
 require (
 	github.com/dgraph-io/badger/v3 v3.2103.2

--- a/report/export.go
+++ b/report/export.go
@@ -67,12 +67,12 @@ func (ui *UI) StartUILoop() error {
 
 // ListDevices lists mounted devices and shows their disk usage
 func (ui *UI) ListDevices(getter device.DevicesInfoGetter) error {
-	return errors.New("Exporting devices list is not supported")
+	return errors.New("exporting devices list is not supported")
 }
 
 // ReadAnalysis reads analysis report from JSON file
 func (ui *UI) ReadAnalysis(input io.Reader) error {
-	return errors.New("Reading analysis is not possible while exporting")
+	return errors.New("reading analysis is not possible while exporting")
 }
 
 // ReadFromStorage reads analysis data from persistent key-value storage

--- a/report/import.go
+++ b/report/import.go
@@ -28,12 +28,12 @@ func ReadAnalysis(input io.Reader) (*analyze.Dir, error) {
 		return nil, errors.New("JSON file does not contain top level array")
 	}
 	if len(dataArray) < 4 {
-		return nil, errors.New("Top level array must have at least 4 items")
+		return nil, errors.New("top level array must have at least 4 items")
 	}
 
 	items, ok := dataArray[3].([]interface{})
 	if !ok {
-		return nil, errors.New("Array of maps not found in the top level array on 4th position")
+		return nil, errors.New("array of maps not found in the top level array on 4th position")
 	}
 
 	return processDir(items)
@@ -47,11 +47,11 @@ func processDir(items []interface{}) (*analyze.Dir, error) {
 	}
 	dirMap, ok := items[0].(map[string]interface{})
 	if !ok {
-		return nil, errors.New("Directory item is not a map")
+		return nil, errors.New("directory item is not a map")
 	}
 	name, ok := dirMap["name"].(string)
 	if !ok {
-		return nil, errors.New("Directory name is not a string")
+		return nil, errors.New("directory name is not a string")
 	}
 	if mtime, ok := dirMap["mtime"].(float64); ok {
 		dir.Mtime = time.Unix(int64(mtime), 0)

--- a/tui/actions.go
+++ b/tui/actions.go
@@ -192,7 +192,7 @@ func (ui *UI) deleteSelected(shouldEmpty bool) {
 	}
 	modal := tview.NewModal().SetText(
 		// nolint: staticcheck // Why: fixed string
-		strings.Title(acting) +
+		strings.Title(acting) + //lint:ignore SA1019 we love using "Title"
 			" " +
 			tview.Escape(selectedItem.GetName()) +
 			"...",

--- a/tui/marked.go
+++ b/tui/marked.go
@@ -55,7 +55,7 @@ func (ui *UI) deleteMarked(shouldEmpty bool) {
 			ui.app.QueueUpdateDraw(func() {
 				modal.SetText(
 					// nolint: staticcheck // Why: fixed string
-					strings.Title(acting) +
+					strings.Title(acting) + //lint:ignore SA1019 we love using "Title"
 						" " +
 						tview.Escape(one.GetName()) +
 						"...",


### PR DESCRIPTION
make the option `--no-mouse` `true` by default.

Rationale: users of `gdu` would be used to `ncdu` where text selection is ON by default. If I am using gdu on a remote server, my use of text-selection is even more obvious.

Ideally the option `--no-mouse` could be turned as `--mouse` with "false" as default.

Putting this PR out there to see if it is OK.