### PR TITLE
switch mouse flag name. mimic default ncdu behavior

### DIFF
--- a/cmd/gdu/app/app.go
+++ b/cmd/gdu/app/app.go
@@ -60,7 +60,7 @@ type Flags struct {
 	ShowItemCount      bool     `yaml:"show-item-count"`
 	ShowMTime          bool     `yaml:"show-mtime"`
 	NoColor            bool     `yaml:"no-color"`
-	NoMouse            bool     `yaml:"no-mouse"`
+	Mouse              bool     `yaml:"mouse"`
 	NonInteractive     bool     `yaml:"non-interactive"`
 	NoProgress         bool     `yaml:"no-progress"`
 	NoUnicode          bool     `yaml:"no-unicode"`

--- a/cmd/gdu/main.go
+++ b/cmd/gdu/main.go
@@ -84,7 +84,7 @@ func init() {
 	flags.IntVarP(&af.Top, "top", "t", 0, "Show only top X largest files in non-interactive mode")
 	flags.BoolVar(&af.UseSIPrefix, "si", false, "Show sizes with decimal SI prefixes (kB, MB, GB) instead of binary prefixes (KiB, MiB, GiB)")
 	flags.BoolVar(&af.NoPrefix, "no-prefix", false, "Show sizes as raw numbers without any prefixes (SI or binary) in non-interactive mode")
-	flags.BoolVar(&af.NoMouse, "no-mouse", false, "Do not use mouse")
+	flags.BoolVar(&af.Mouse, "mouse", false, "Use mouse")
 	flags.BoolVar(&af.NoDelete, "no-delete", false, "Do not allow deletions")
 	flags.BoolVar(&af.WriteConfig, "write-config", false, "Write current configuration to file (default is $HOME/.gdu.yaml)")
 
@@ -221,7 +221,7 @@ func runE(command *cobra.Command, args []string) error {
 		termApp = tview.NewApplication()
 		termApp.SetScreen(screen)
 
-		if !af.NoMouse {
+		if af.Mouse {
 			termApp.EnableMouse(true)
 		}
 	}


### PR DESCRIPTION
Mimicking the default behavior of `ncdu`.

Keep `mouse` off by default.