### PR TITLE
feat: time filters

### DIFF
--- a/cmd/gdu/app/app.go
+++ b/cmd/gdu/app/app.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
@@ -20,6 +21,7 @@ import (
 	"github.com/dundee/gdu/v5/pkg/analyze"
 	"github.com/dundee/gdu/v5/pkg/device"
 	gfs "github.com/dundee/gdu/v5/pkg/fs"
+	"github.com/dundee/gdu/v5/pkg/timefilter"
 	"github.com/dundee/gdu/v5/report"
 	"github.com/dundee/gdu/v5/stdout"
 	"github.com/dundee/gdu/v5/tui"
@@ -38,6 +40,7 @@ type UI interface {
 	SetFollowSymlinks(value bool)
 	SetShowAnnexedSize(value bool)
 	SetAnalyzer(analyzer common.Analyzer)
+	SetTimeFilter(timeFilter common.TimeFilter)
 	StartUILoop() error
 }
 
@@ -83,6 +86,7 @@ type Flags struct {
 	DeleteInParallel   bool     `yaml:"delete-in-parallel"`
 	Style              Style    `yaml:"style"`
 	Sorting            Sorting  `yaml:"sorting"`
+	Since              string   `yaml:"since"`
 }
 
 // ShouldRunInNonInteractiveMode checks if the application should run in non-interactive mode
@@ -200,6 +204,22 @@ func (a *App) Run() error {
 	}
 	if a.Flags.ShowAnnexedSize {
 		ui.SetShowAnnexedSize(true)
+	}
+
+	// Set up time filter if --since is provided
+	if a.Flags.Since != "" {
+		loc := time.Local
+		sinceBound, err := timefilter.ParseSince(a.Flags.Since, loc)
+		if err != nil {
+			return fmt.Errorf("invalid --since value: %w", err)
+		}
+
+		if !sinceBound.IsEmpty() {
+			timeFilterFunc := func(mtime time.Time) bool {
+				return timefilter.IncludeBySince(mtime, sinceBound, loc)
+			}
+			ui.SetTimeFilter(timeFilterFunc)
+		}
 	}
 	if err := a.setNoCross(path); err != nil {
 		return err

--- a/cmd/gdu/app/app.go
+++ b/cmd/gdu/app/app.go
@@ -87,6 +87,9 @@ type Flags struct {
 	Style              Style    `yaml:"style"`
 	Sorting            Sorting  `yaml:"sorting"`
 	Since              string   `yaml:"since"`
+	Until              string   `yaml:"until"`
+	MaxAge             string   `yaml:"max-age"`
+	MinAge             string   `yaml:"min-age"`
 }
 
 // ShouldRunInNonInteractiveMode checks if the application should run in non-interactive mode
@@ -206,17 +209,26 @@ func (a *App) Run() error {
 		ui.SetShowAnnexedSize(true)
 	}
 
-	// Set up time filter if --since is provided
-	if a.Flags.Since != "" {
+	// Set up time filter if any time flags are provided
+	if a.Flags.Since != "" || a.Flags.Until != "" || a.Flags.MaxAge != "" || a.Flags.MinAge != "" {
 		loc := time.Local
-		sinceBound, err := timefilter.ParseSince(a.Flags.Since, loc)
+		now := time.Now()
+		
+		timeFilter, err := timefilter.NewTimeFilter(
+			a.Flags.Since,
+			a.Flags.Until,
+			a.Flags.MaxAge,
+			a.Flags.MinAge,
+			now,
+			loc,
+		)
 		if err != nil {
-			return fmt.Errorf("invalid --since value: %w", err)
+			return fmt.Errorf("invalid time filter: %w", err)
 		}
 
-		if !sinceBound.IsEmpty() {
+		if !timeFilter.IsEmpty() {
 			timeFilterFunc := func(mtime time.Time) bool {
-				return timefilter.IncludeBySince(mtime, sinceBound, loc)
+				return timeFilter.IncludeByTimeFilter(mtime, now, loc)
 			}
 			ui.SetTimeFilter(timeFilterFunc)
 		}

--- a/cmd/gdu/app/app.go
+++ b/cmd/gdu/app/app.go
@@ -231,6 +231,11 @@ func (a *App) Run() error {
 				return timeFilter.IncludeByTimeFilter(mtime, now, loc)
 			}
 			ui.SetTimeFilter(timeFilterFunc)
+			
+			// If this is a TUI, also set the filter info for display
+			if tuiUI, ok := ui.(*tui.UI); ok {
+				tuiUI.SetTimeFilterWithInfo(timeFilter, loc)
+			}
 		}
 	}
 	if err := a.setNoCross(path); err != nil {

--- a/cmd/gdu/main.go
+++ b/cmd/gdu/main.go
@@ -88,6 +88,9 @@ func init() {
 	flags.BoolVar(&af.NoDelete, "no-delete", false, "Do not allow deletions")
 	flags.BoolVar(&af.WriteConfig, "write-config", false, "Write current configuration to file (default is $HOME/.gdu.yaml)")
 	flags.StringVar(&af.Since, "since", "", "Include files with mtime >= WHEN. WHEN accepts RFC3339 timestamp (e.g., 2025-08-11T01:00:00-07:00) or date only YYYY-MM-DD (calendar-day compare; includes the whole day)")
+	flags.StringVar(&af.Until, "until", "", "Include files with mtime <= WHEN. WHEN accepts RFC3339 timestamp or date only YYYY-MM-DD")
+	flags.StringVar(&af.MaxAge, "max-age", "", "Include files with mtime no older than DURATION (e.g., 7d, 2h30m, 1y2mo)")
+	flags.StringVar(&af.MinAge, "min-age", "", "Include files with mtime at least DURATION old (e.g., 30d, 1w)")
 
 	initConfig()
 	setDefaults()

--- a/cmd/gdu/main.go
+++ b/cmd/gdu/main.go
@@ -87,6 +87,7 @@ func init() {
 	flags.BoolVar(&af.Mouse, "mouse", false, "Use mouse")
 	flags.BoolVar(&af.NoDelete, "no-delete", false, "Do not allow deletions")
 	flags.BoolVar(&af.WriteConfig, "write-config", false, "Write current configuration to file (default is $HOME/.gdu.yaml)")
+	flags.StringVar(&af.Since, "since", "", "Include files with mtime >= WHEN. WHEN accepts RFC3339 timestamp (e.g., 2025-08-11T01:00:00-07:00) or date only YYYY-MM-DD (calendar-day compare; includes the whole day)")
 
 	initConfig()
 	setDefaults()

--- a/internal/common/analyze.go
+++ b/internal/common/analyze.go
@@ -1,6 +1,10 @@
 package common
 
-import "github.com/dundee/gdu/v5/pkg/fs"
+import (
+	"time"
+
+	"github.com/dundee/gdu/v5/pkg/fs"
+)
 
 // CurrentProgress struct
 type CurrentProgress struct {
@@ -17,7 +21,11 @@ type Analyzer interface {
 	AnalyzeDir(path string, ignore ShouldDirBeIgnored, constGC bool) fs.Item
 	SetFollowSymlinks(bool)
 	SetShowAnnexedSize(bool)
+	SetTimeFilter(timeFilter TimeFilter)
 	GetProgressChan() chan CurrentProgress
 	GetDone() SignalGroup
 	ResetProgress()
 }
+
+// TimeFilter represents a function that determines if a file should be included based on its mtime
+type TimeFilter func(mtime time.Time) bool

--- a/internal/common/ui.go
+++ b/internal/common/ui.go
@@ -34,6 +34,11 @@ func (ui *UI) SetShowAnnexedSize(v bool) {
 	ui.Analyzer.SetShowAnnexedSize(v)
 }
 
+// SetTimeFilter sets the time filter function for file inclusion
+func (ui *UI) SetTimeFilter(timeFilter TimeFilter) {
+	ui.Analyzer.SetTimeFilter(timeFilter)
+}
+
 // binary multiplies prefixes (IEC)
 const (
 	_ float64 = 1 << (10 * iota)

--- a/internal/common/ui_test.go
+++ b/internal/common/ui_test.go
@@ -66,3 +66,6 @@ func (a *MockedAnalyzer) SetFollowSymlinks(v bool) {
 func (a *MockedAnalyzer) SetShowAnnexedSize(v bool) {
 	a.ShowAnnexedSize = v
 }
+
+// SetTimeFilter does nothing
+func (a *MockedAnalyzer) SetTimeFilter(timeFilter TimeFilter) {}

--- a/internal/testanalyze/analyze.go
+++ b/internal/testanalyze/analyze.go
@@ -87,6 +87,9 @@ func (a *MockedAnalyzer) SetFollowSymlinks(v bool) {}
 // SetShowAnnexedSize does nothing
 func (a *MockedAnalyzer) SetShowAnnexedSize(v bool) {}
 
+// SetTimeFilter does nothing
+func (a *MockedAnalyzer) SetTimeFilter(timeFilter common.TimeFilter) {}
+
 // ItemFromDirWithErr returns error
 func ItemFromDirWithErr(dir, file fs.Item) error {
 	return errors.New("Failed")

--- a/pkg/analyze/parallel.go
+++ b/pkg/analyze/parallel.go
@@ -24,6 +24,7 @@ type ParallelAnalyzer struct {
 	ignoreDir        common.ShouldDirBeIgnored
 	followSymlinks   bool
 	gitAnnexedSize   bool
+	timeFilter       common.TimeFilter
 }
 
 // CreateAnalyzer returns Analyzer
@@ -49,6 +50,11 @@ func (a *ParallelAnalyzer) SetFollowSymlinks(v bool) {
 // SetShowAnnexedSize sets whether to use annexed size of git-annex files
 func (a *ParallelAnalyzer) SetShowAnnexedSize(v bool) {
 	a.gitAnnexedSize = v
+}
+
+// SetTimeFilter sets the time filter function for file inclusion
+func (a *ParallelAnalyzer) SetTimeFilter(timeFilter common.TimeFilter) {
+	a.timeFilter = timeFilter
 }
 
 // GetProgressChan returns channel for getting progress
@@ -164,6 +170,11 @@ func (a *ParallelAnalyzer) processDir(path string) *Dir {
 				Parent: dir,
 			}
 			setPlatformSpecificAttrs(file, info)
+
+			// Apply time filter if set
+			if a.timeFilter != nil && !a.timeFilter(info.ModTime()) {
+				continue // Skip this file
+			}
 
 			totalSize += info.Size()
 

--- a/pkg/analyze/sequential.go
+++ b/pkg/analyze/sequential.go
@@ -21,6 +21,7 @@ type SequentialAnalyzer struct {
 	ignoreDir        common.ShouldDirBeIgnored
 	followSymlinks   bool
 	gitAnnexedSize   bool
+	timeFilter       common.TimeFilter
 }
 
 // CreateSeqAnalyzer returns Analyzer
@@ -46,6 +47,11 @@ func (a *SequentialAnalyzer) SetFollowSymlinks(v bool) {
 // SetShowAnnexedSize sets whether to use annexed size of git-annex files
 func (a *SequentialAnalyzer) SetShowAnnexedSize(v bool) {
 	a.gitAnnexedSize = v
+}
+
+// SetTimeFilter sets the time filter function for file inclusion
+func (a *SequentialAnalyzer) SetTimeFilter(timeFilter common.TimeFilter) {
+	a.timeFilter = timeFilter
 }
 
 // GetProgressChan returns channel for getting progress
@@ -151,6 +157,11 @@ func (a *SequentialAnalyzer) processDir(path string) *Dir {
 				Parent: dir,
 			}
 			setPlatformSpecificAttrs(file, info)
+
+			// Apply time filter if set
+			if a.timeFilter != nil && !a.timeFilter(info.ModTime()) {
+				continue // Skip this file
+			}
 
 			totalSize += info.Size()
 

--- a/pkg/analyze/stored.go
+++ b/pkg/analyze/stored.go
@@ -26,6 +26,7 @@ type StoredAnalyzer struct {
 	ignoreDir        common.ShouldDirBeIgnored
 	followSymlinks   bool
 	gitAnnexedSize   bool
+	timeFilter       common.TimeFilter
 }
 
 // CreateStoredAnalyzer returns Analyzer
@@ -60,6 +61,11 @@ func (a *StoredAnalyzer) SetFollowSymlinks(v bool) {
 
 func (a *StoredAnalyzer) SetShowAnnexedSize(v bool) {
 	a.gitAnnexedSize = v
+}
+
+// SetTimeFilter sets the time filter function for file inclusion
+func (a *StoredAnalyzer) SetTimeFilter(timeFilter common.TimeFilter) {
+	a.timeFilter = timeFilter
 }
 
 // ResetProgress returns progress
@@ -174,6 +180,11 @@ func (a *StoredAnalyzer) processDir(path string) *StoredDir {
 				Parent: parent,
 			}
 			setPlatformSpecificAttrs(file, info)
+
+			// Apply time filter if set
+			if a.timeFilter != nil && !a.timeFilter(info.ModTime()) {
+				continue // Skip this file
+			}
 
 			totalSize += info.Size()
 

--- a/pkg/timefilter/timefilter.go
+++ b/pkg/timefilter/timefilter.go
@@ -2,65 +2,255 @@ package timefilter
 
 import (
 	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
 	"time"
 )
 
-// SinceBound represents a parsed --since value that can be either an instant or a date-only value
-type SinceBound struct {
+// TimeBound represents a parsed time filter value that can be either an instant or a date-only value
+type TimeBound struct {
 	instant  *time.Time // absolute instant (UTC)
 	dateOnly *time.Time // at local midnight; only YYYY-MM-DD will set this
 }
 
-// ParseSince parses --since into either a timestamp Instant or a DateOnly value.
-func ParseSince(arg string, loc *time.Location) (SinceBound, error) {
+// TimeFilter represents multiple time filtering criteria
+type TimeFilter struct {
+	since   *TimeBound
+	until   *TimeBound
+	maxAge  *time.Duration
+	minAge  *time.Duration
+}
+
+// SinceBound represents a parsed --since value that can be either an instant or a date-only value
+// Deprecated: Use TimeBound instead
+type SinceBound = TimeBound
+
+// ParseDuration parses a duration string with support for extended units
+// Supports: s, m, h, d (=24h), w (=7d), mo (=30d), y (=365d)
+// Examples: "90m", "2h30m", "7d", "6w", "1y2mo"
+func ParseDuration(input string) (time.Duration, error) {
+	if input == "" {
+		return 0, fmt.Errorf("empty duration")
+	}
+
+	// Remove whitespace and convert to lowercase
+	input = strings.ToLower(strings.ReplaceAll(input, " ", ""))
+
+	// Regex to match number+unit pairs (mo must come before m to avoid greedy matching)
+	re := regexp.MustCompile(`(\d+)(mo|s|m|h|d|w|y)`)
+	matches := re.FindAllStringSubmatch(input, -1)
+
+	if len(matches) == 0 {
+		return 0, fmt.Errorf("invalid duration format %q. Use combinations like 7d, 2h30m, 1y2mo", input)
+	}
+
+	// Check if the entire input was consumed by matches
+	consumed := ""
+	for _, match := range matches {
+		consumed += match[0]
+	}
+	if consumed != input {
+		return 0, fmt.Errorf("invalid duration format %q. Use combinations like 7d, 2h30m, 1y2mo", input)
+	}
+
+	var total time.Duration
+	for _, match := range matches {
+		value, err := strconv.Atoi(match[1])
+		if err != nil {
+			return 0, fmt.Errorf("invalid number in duration: %s", match[1])
+		}
+
+		unit := match[2]
+		var duration time.Duration
+
+		switch unit {
+		case "s":
+			duration = time.Duration(value) * time.Second
+		case "m":
+			duration = time.Duration(value) * time.Minute
+		case "h":
+			duration = time.Duration(value) * time.Hour
+		case "d":
+			duration = time.Duration(value) * 24 * time.Hour
+		case "w":
+			duration = time.Duration(value) * 7 * 24 * time.Hour
+		case "mo":
+			duration = time.Duration(value) * 30 * 24 * time.Hour
+		case "y":
+			duration = time.Duration(value) * 365 * 24 * time.Hour
+		default:
+			return 0, fmt.Errorf("unsupported duration unit: %s", unit)
+		}
+
+		total += duration
+	}
+
+	return total, nil
+}
+
+// ParseTimeValue parses a time value into either a timestamp instant or a date-only value
+func ParseTimeValue(arg string, loc *time.Location) (TimeBound, error) {
 	if arg == "" {
-		return SinceBound{}, nil
+		return TimeBound{}, nil
 	}
 
 	// 1) Try RFC3339 instant
 	if t, err := time.Parse(time.RFC3339Nano, arg); err == nil {
 		u := t.UTC()
-		return SinceBound{instant: &u}, nil
+		return TimeBound{instant: &u}, nil
 	}
 
 	// 2) Try strict YYYY-MM-DD
 	if len(arg) == 10 {
 		if d, err := time.ParseInLocation("2006-01-02", arg, loc); err == nil {
 			// dateOnly uses local date; we will compare date parts only
-			return SinceBound{dateOnly: &d}, nil
+			return TimeBound{dateOnly: &d}, nil
 		}
 	}
 
-	return SinceBound{}, fmt.Errorf("invalid --since %q. Use RFC3339 timestamp or YYYY-MM-DD", arg)
+	return TimeBound{}, fmt.Errorf("invalid time value %q. Use RFC3339 timestamp or YYYY-MM-DD", arg)
 }
 
-// IncludeBySince determines if a file should be included based on its mtime and the since bound
-func IncludeBySince(mtime time.Time, sb SinceBound, loc *time.Location) bool {
-	if sb.instant == nil && sb.dateOnly == nil {
+// ParseSince parses --since into either a timestamp Instant or a DateOnly value.
+func ParseSince(arg string, loc *time.Location) (SinceBound, error) {
+	return ParseTimeValue(arg, loc)
+}
+
+// NewTimeFilter creates a new TimeFilter with the given parameters
+func NewTimeFilter(since, until string, maxAge, minAge string, now time.Time, loc *time.Location) (*TimeFilter, error) {
+	tf := &TimeFilter{}
+
+	// Parse since
+	if since != "" {
+		sinceBound, err := ParseTimeValue(since, loc)
+		if err != nil {
+			return nil, fmt.Errorf("invalid --since value: %w", err)
+		}
+		if !sinceBound.IsEmpty() {
+			tf.since = &sinceBound
+		}
+	}
+
+	// Parse until
+	if until != "" {
+		untilBound, err := ParseTimeValue(until, loc)
+		if err != nil {
+			return nil, fmt.Errorf("invalid --until value: %w", err)
+		}
+		if !untilBound.IsEmpty() {
+			tf.until = &untilBound
+		}
+	}
+
+	// Parse max-age (convert to since)
+	if maxAge != "" {
+		duration, err := ParseDuration(maxAge)
+		if err != nil {
+			return nil, fmt.Errorf("invalid --max-age value: %w", err)
+		}
+		tf.maxAge = &duration
+	}
+
+	// Parse min-age (convert to until)
+	if minAge != "" {
+		duration, err := ParseDuration(minAge)
+		if err != nil {
+			return nil, fmt.Errorf("invalid --min-age value: %w", err)
+		}
+		tf.minAge = &duration
+	}
+
+	return tf, nil
+}
+
+// IncludeByTimeBound determines if a file should be included based on its mtime and the time bound
+func IncludeByTimeBound(mtime time.Time, tb TimeBound, loc *time.Location, isUntil bool) bool {
+	if tb.instant == nil && tb.dateOnly == nil {
 		return true // no filter applied
 	}
 
-	if sb.instant != nil {
-		return !mtime.Before(*sb.instant) // inclusive
+	if tb.instant != nil {
+		if isUntil {
+			return !mtime.After(*tb.instant) // inclusive (<=)
+		}
+		return !mtime.Before(*tb.instant) // inclusive (>=)
 	}
 
-	if sb.dateOnly != nil {
+	if tb.dateOnly != nil {
 		// Compare local date parts only
 		y1, m1, d1 := mtime.In(loc).Date()
-		y2, m2, d2 := sb.dateOnly.In(loc).Date()
+		y2, m2, d2 := tb.dateOnly.In(loc).Date()
+		
 		if y1 != y2 {
-			return y1 > y2
+			if isUntil {
+				return y1 < y2 || (y1 == y2) // <=
+			}
+			return y1 > y2 // >=
 		}
 		if m1 != m2 {
-			return m1 > m2
+			if isUntil {
+				return m1 < m2 || (m1 == m2) // <=
+			}
+			return m1 > m2 // >=
 		}
-		return d1 >= d2
+		if isUntil {
+			return d1 <= d2 // <=
+		}
+		return d1 >= d2 // >=
 	}
 
 	return true
 }
 
-// IsEmpty returns true if the SinceBound has no filter criteria
-func (sb SinceBound) IsEmpty() bool {
-	return sb.instant == nil && sb.dateOnly == nil
+// IncludeBySince determines if a file should be included based on its mtime and the since bound
+func IncludeBySince(mtime time.Time, sb SinceBound, loc *time.Location) bool {
+	return IncludeByTimeBound(mtime, sb, loc, false)
+}
+
+// IncludeByTimeFilter determines if a file should be included based on the complete time filter
+func (tf *TimeFilter) IncludeByTimeFilter(mtime time.Time, now time.Time, loc *time.Location) bool {
+	// Check since bound
+	if tf.since != nil {
+		if !IncludeByTimeBound(mtime, *tf.since, loc, false) {
+			return false
+		}
+	}
+
+	// Check until bound
+	if tf.until != nil {
+		if !IncludeByTimeBound(mtime, *tf.until, loc, true) {
+			return false
+		}
+	}
+
+	// Check max-age (convert to since)
+	if tf.maxAge != nil {
+		sinceTime := now.Add(-*tf.maxAge).UTC()
+		sinceBound := TimeBound{instant: &sinceTime}
+		if !IncludeByTimeBound(mtime, sinceBound, loc, false) {
+			return false
+		}
+	}
+
+	// Check min-age (convert to until)
+	if tf.minAge != nil {
+		untilTime := now.Add(-*tf.minAge).UTC()
+		untilBound := TimeBound{instant: &untilTime}
+		if !IncludeByTimeBound(mtime, untilBound, loc, true) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// IsEmpty returns true if the TimeFilter has no filter criteria
+func (tf *TimeFilter) IsEmpty() bool {
+	return tf.since == nil && tf.until == nil && tf.maxAge == nil && tf.minAge == nil
+}
+
+// IsEmpty returns true if the TimeBound has no filter criteria
+func (tb TimeBound) IsEmpty() bool {
+	return tb.instant == nil && tb.dateOnly == nil
 }

--- a/pkg/timefilter/timefilter.go
+++ b/pkg/timefilter/timefilter.go
@@ -16,10 +16,10 @@ type TimeBound struct {
 
 // TimeFilter represents multiple time filtering criteria
 type TimeFilter struct {
-	since   *TimeBound
-	until   *TimeBound
-	maxAge  *time.Duration
-	minAge  *time.Duration
+	since  *TimeBound
+	until  *TimeBound
+	maxAge *time.Duration
+	minAge *time.Duration
 }
 
 // SinceBound represents a parsed --since value that can be either an instant or a date-only value
@@ -180,14 +180,14 @@ func IncludeByTimeBound(mtime time.Time, tb TimeBound, loc *time.Location, isUnt
 	if tb.dateOnly != nil {
 		// For date-only comparisons, adjust the bound to cover the whole day.
 		boundDate := tb.dateOnly.In(loc)
-		
+
 		if isUntil {
 			// For `until`, we want to include the entire day.
 			// So the upper bound is the beginning of the *next* day.
 			upperBound := time.Date(boundDate.Year(), boundDate.Month(), boundDate.Day(), 0, 0, 0, 0, loc).AddDate(0, 0, 1)
 			return mtime.Before(upperBound)
 		}
-		
+
 		// For `since`, we want to include the entire day.
 		// So the lower bound is the beginning of that day.
 		lowerBound := time.Date(boundDate.Year(), boundDate.Month(), boundDate.Day(), 0, 0, 0, 0, loc)
@@ -257,7 +257,7 @@ func (tf *TimeFilter) FormatForDisplay(loc *time.Location) string {
 	}
 
 	var parts []string
-	
+
 	if tf.since != nil {
 		if tf.since.instant != nil {
 			parts = append(parts, "since="+tf.since.instant.In(loc).Format(time.RFC3339))
@@ -265,7 +265,7 @@ func (tf *TimeFilter) FormatForDisplay(loc *time.Location) string {
 			parts = append(parts, "since="+tf.since.dateOnly.Format("2006-01-02")+" (date-only)")
 		}
 	}
-	
+
 	if tf.until != nil {
 		if tf.until.instant != nil {
 			parts = append(parts, "until="+tf.until.instant.In(loc).Format(time.RFC3339))
@@ -273,11 +273,11 @@ func (tf *TimeFilter) FormatForDisplay(loc *time.Location) string {
 			parts = append(parts, "until="+tf.until.dateOnly.Format("2006-01-02")+" (date-only)")
 		}
 	}
-	
+
 	if tf.maxAge != nil {
 		parts = append(parts, "max-age="+tf.maxAge.String())
 	}
-	
+
 	if tf.minAge != nil {
 		parts = append(parts, "min-age="+tf.minAge.String())
 	}
@@ -286,5 +286,5 @@ func (tf *TimeFilter) FormatForDisplay(loc *time.Location) string {
 		return ""
 	}
 
-	return " • Filtered by: time=mtime; " + strings.Join(parts, "; ")
+	return " Filtered by: time=mtime; " + strings.Join(parts, "; ")
 }

--- a/pkg/timefilter/timefilter.go
+++ b/pkg/timefilter/timefilter.go
@@ -1,0 +1,66 @@
+package timefilter
+
+import (
+	"fmt"
+	"time"
+)
+
+// SinceBound represents a parsed --since value that can be either an instant or a date-only value
+type SinceBound struct {
+	instant  *time.Time // absolute instant (UTC)
+	dateOnly *time.Time // at local midnight; only YYYY-MM-DD will set this
+}
+
+// ParseSince parses --since into either a timestamp Instant or a DateOnly value.
+func ParseSince(arg string, loc *time.Location) (SinceBound, error) {
+	if arg == "" {
+		return SinceBound{}, nil
+	}
+
+	// 1) Try RFC3339 instant
+	if t, err := time.Parse(time.RFC3339Nano, arg); err == nil {
+		u := t.UTC()
+		return SinceBound{instant: &u}, nil
+	}
+
+	// 2) Try strict YYYY-MM-DD
+	if len(arg) == 10 {
+		if d, err := time.ParseInLocation("2006-01-02", arg, loc); err == nil {
+			// dateOnly uses local date; we will compare date parts only
+			return SinceBound{dateOnly: &d}, nil
+		}
+	}
+
+	return SinceBound{}, fmt.Errorf("invalid --since %q. Use RFC3339 timestamp or YYYY-MM-DD", arg)
+}
+
+// IncludeBySince determines if a file should be included based on its mtime and the since bound
+func IncludeBySince(mtime time.Time, sb SinceBound, loc *time.Location) bool {
+	if sb.instant == nil && sb.dateOnly == nil {
+		return true // no filter applied
+	}
+
+	if sb.instant != nil {
+		return !mtime.Before(*sb.instant) // inclusive
+	}
+
+	if sb.dateOnly != nil {
+		// Compare local date parts only
+		y1, m1, d1 := mtime.In(loc).Date()
+		y2, m2, d2 := sb.dateOnly.In(loc).Date()
+		if y1 != y2 {
+			return y1 > y2
+		}
+		if m1 != m2 {
+			return m1 > m2
+		}
+		return d1 >= d2
+	}
+
+	return true
+}
+
+// IsEmpty returns true if the SinceBound has no filter criteria
+func (sb SinceBound) IsEmpty() bool {
+	return sb.instant == nil && sb.dateOnly == nil
+}

--- a/pkg/timefilter/timefilter.go
+++ b/pkg/timefilter/timefilter.go
@@ -178,26 +178,20 @@ func IncludeByTimeBound(mtime time.Time, tb TimeBound, loc *time.Location, isUnt
 	}
 
 	if tb.dateOnly != nil {
-		// Compare local date parts only
-		y1, m1, d1 := mtime.In(loc).Date()
-		y2, m2, d2 := tb.dateOnly.In(loc).Date()
+		// For date-only comparisons, adjust the bound to cover the whole day.
+		boundDate := tb.dateOnly.In(loc)
 		
-		if y1 != y2 {
-			if isUntil {
-				return y1 < y2 || (y1 == y2)
-			}
-			return y1 > y2
-		}
-		if m1 != m2 {
-			if isUntil {
-				return m1 < m2 || (m1 == m2)
-			}
-			return m1 > m2
-		}
 		if isUntil {
-			return d1 <= d2
+			// For `until`, we want to include the entire day.
+			// So the upper bound is the beginning of the *next* day.
+			upperBound := time.Date(boundDate.Year(), boundDate.Month(), boundDate.Day(), 0, 0, 0, 0, loc).AddDate(0, 0, 1)
+			return mtime.Before(upperBound)
 		}
-		return d1 >= d2
+		
+		// For `since`, we want to include the entire day.
+		// So the lower bound is the beginning of that day.
+		lowerBound := time.Date(boundDate.Year(), boundDate.Month(), boundDate.Day(), 0, 0, 0, 0, loc)
+		return !mtime.Before(lowerBound) // inclusive (>=)
 	}
 
 	return true

--- a/pkg/timefilter/timefilter.go
+++ b/pkg/timefilter/timefilter.go
@@ -184,20 +184,20 @@ func IncludeByTimeBound(mtime time.Time, tb TimeBound, loc *time.Location, isUnt
 		
 		if y1 != y2 {
 			if isUntil {
-				return y1 < y2 || (y1 == y2) // <=
+				return y1 < y2 || (y1 == y2)
 			}
-			return y1 > y2 // >=
+			return y1 > y2
 		}
 		if m1 != m2 {
 			if isUntil {
-				return m1 < m2 || (m1 == m2) // <=
+				return m1 < m2 || (m1 == m2)
 			}
-			return m1 > m2 // >=
+			return m1 > m2
 		}
 		if isUntil {
-			return d1 <= d2 // <=
+			return d1 <= d2
 		}
-		return d1 >= d2 // >=
+		return d1 >= d2
 	}
 
 	return true
@@ -253,4 +253,44 @@ func (tf *TimeFilter) IsEmpty() bool {
 // IsEmpty returns true if the TimeBound has no filter criteria
 func (tb TimeBound) IsEmpty() bool {
 	return tb.instant == nil && tb.dateOnly == nil
+}
+
+// FormatForDisplay returns a formatted string showing the active time filters
+// This shows what the program actually parsed and is acting on
+func (tf *TimeFilter) FormatForDisplay(loc *time.Location) string {
+	if tf.IsEmpty() {
+		return ""
+	}
+
+	var parts []string
+	
+	if tf.since != nil {
+		if tf.since.instant != nil {
+			parts = append(parts, "since="+tf.since.instant.In(loc).Format(time.RFC3339))
+		} else if tf.since.dateOnly != nil {
+			parts = append(parts, "since="+tf.since.dateOnly.Format("2006-01-02")+" (date-only)")
+		}
+	}
+	
+	if tf.until != nil {
+		if tf.until.instant != nil {
+			parts = append(parts, "until="+tf.until.instant.In(loc).Format(time.RFC3339))
+		} else if tf.until.dateOnly != nil {
+			parts = append(parts, "until="+tf.until.dateOnly.Format("2006-01-02")+" (date-only)")
+		}
+	}
+	
+	if tf.maxAge != nil {
+		parts = append(parts, "max-age="+tf.maxAge.String())
+	}
+	
+	if tf.minAge != nil {
+		parts = append(parts, "min-age="+tf.minAge.String())
+	}
+
+	if len(parts) == 0 {
+		return ""
+	}
+
+	return " • Filtered by: time=mtime; " + strings.Join(parts, "; ")
 }

--- a/pkg/timefilter/timefilter_test.go
+++ b/pkg/timefilter/timefilter_test.go
@@ -577,6 +577,34 @@ func TestTimeFilterIncludeByTimeFilter(t *testing.T) {
 			fileMtime:     "2025-08-10T12:00:00-07:00", // 1 day ago
 			expectInclude: false,
 		},
+		{
+			name:          "date-only since and max-age - fail",
+			since:         "2025-08-10",
+			maxAge:        "3d",
+			fileMtime:     "2025-08-09T12:00:00-07:00", // 2 days old, but before since date
+			expectInclude: false,
+		},
+		{
+			name:          "date-only since and max-age - pass",
+			since:         "2025-08-10",
+			maxAge:        "3d",
+			fileMtime:     "2025-08-10T12:00:00-07:00", // 1 day old, and on since date
+			expectInclude: true,
+		},
+		{
+			name:          "date-only until and min-age - fail",
+			until:         "2025-08-10",
+			minAge:        "1d",
+			fileMtime:     "2025-08-10T12:00:00-07:00", // 1 day old, but not old enough to be excluded by until
+			expectInclude: true,
+		},
+		{
+			name:          "date-only until and min-age - pass",
+			until:         "2025-08-10",
+			minAge:        "2d",
+			fileMtime:     "2025-08-08T12:00:00-07:00", // 3 days old, and before until date
+			expectInclude: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -658,30 +686,58 @@ func TestIncludeByTimeBound(t *testing.T) {
 			expectInclude: true,
 		},
 		{
-			name:          "since date - file on same day",
+			name:          "since date - file just before day",
 			boundArg:      "2025-08-11",
-			fileMtime:     "2025-08-11T15:30:00-07:00",
-			isUntil:       false,
-			expectInclude: true,
-		},
-		{
-			name:          "since date - file on previous day",
-			boundArg:      "2025-08-11",
-			fileMtime:     "2025-08-10T23:59:00-07:00",
+			fileMtime:     "2025-08-10T23:59:59-07:00",
 			isUntil:       false,
 			expectInclude: false,
 		},
 		{
-			name:          "until date - file on same day",
+			name:          "since date - file at start of day",
 			boundArg:      "2025-08-11",
-			fileMtime:     "2025-08-11T15:30:00-07:00",
+			fileMtime:     "2025-08-11T00:00:00-07:00",
+			isUntil:       false,
+			expectInclude: true,
+		},
+		{
+			name:          "since date - file at end of day",
+			boundArg:      "2025-08-11",
+			fileMtime:     "2025-08-11T23:59:59-07:00",
+			isUntil:       false,
+			expectInclude: true,
+		},
+		{
+			name:          "since date - file on next day",
+			boundArg:      "2025-08-11",
+			fileMtime:     "2025-08-12T00:00:00-07:00",
+			isUntil:       false,
+			expectInclude: true,
+		},
+		{
+			name:          "until date - file on previous day",
+			boundArg:      "2025-08-11",
+			fileMtime:     "2025-08-10T23:59:59-07:00",
 			isUntil:       true,
 			expectInclude: true,
 		},
 		{
-			name:          "until date - file on next day",
+			name:          "until date - file at start of day",
 			boundArg:      "2025-08-11",
-			fileMtime:     "2025-08-12T00:01:00-07:00",
+			fileMtime:     "2025-08-11T00:00:00-07:00",
+			isUntil:       true,
+			expectInclude: true,
+		},
+		{
+			name:          "until date - file at end of day",
+			boundArg:      "2025-08-11",
+			fileMtime:     "2025-08-11T23:59:59-07:00",
+			isUntil:       true,
+			expectInclude: true,
+		},
+		{
+			name:          "until date - file just after day",
+			boundArg:      "2025-08-11",
+			fileMtime:     "2025-08-12T00:00:00-07:00",
 			isUntil:       true,
 			expectInclude: false,
 		},

--- a/pkg/timefilter/timefilter_test.go
+++ b/pkg/timefilter/timefilter_test.go
@@ -1,0 +1,251 @@
+package timefilter
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseSince(t *testing.T) {
+	// Use America/Vancouver timezone for testing (UTC-7 or UTC-8 depending on DST)
+	loc, err := time.LoadLocation("America/Vancouver")
+	if err != nil {
+		t.Fatalf("Failed to load timezone: %v", err)
+	}
+
+	tests := []struct {
+		name        string
+		input       string
+		expectError bool
+		expectType  string // "instant", "dateOnly", or "empty"
+	}{
+		{
+			name:        "empty string",
+			input:       "",
+			expectError: false,
+			expectType:  "empty",
+		},
+		{
+			name:        "RFC3339 with timezone",
+			input:       "2025-08-11T01:00:00-07:00",
+			expectError: false,
+			expectType:  "instant",
+		},
+		{
+			name:        "RFC3339 UTC",
+			input:       "2025-08-11T08:00:00Z",
+			expectError: false,
+			expectType:  "instant",
+		},
+		{
+			name:        "RFC3339 with nanoseconds",
+			input:       "2025-08-11T01:00:00.123456789-07:00",
+			expectError: false,
+			expectType:  "instant",
+		},
+		{
+			name:        "date only YYYY-MM-DD",
+			input:       "2025-08-11",
+			expectError: false,
+			expectType:  "dateOnly",
+		},
+		{
+			name:        "invalid format",
+			input:       "2025/08/11",
+			expectError: true,
+			expectType:  "",
+		},
+		{
+			name:        "invalid date",
+			input:       "2025-13-01",
+			expectError: true,
+			expectType:  "",
+		},
+		{
+			name:        "too short date",
+			input:       "2025-8-1",
+			expectError: true,
+			expectType:  "",
+		},
+		{
+			name:        "too long date",
+			input:       "2025-08-011",
+			expectError: true,
+			expectType:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ParseSince(tt.input, loc)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("Expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+				return
+			}
+
+			switch tt.expectType {
+			case "empty":
+				if !result.IsEmpty() {
+					t.Errorf("Expected empty result")
+				}
+			case "instant":
+				if result.instant == nil {
+					t.Errorf("Expected instant to be set")
+				}
+				if result.dateOnly != nil {
+					t.Errorf("Expected dateOnly to be nil")
+				}
+			case "dateOnly":
+				if result.dateOnly == nil {
+					t.Errorf("Expected dateOnly to be set")
+				}
+				if result.instant != nil {
+					t.Errorf("Expected instant to be nil")
+				}
+			}
+		})
+	}
+}
+
+func TestIncludeBySince(t *testing.T) {
+	// Use America/Vancouver timezone for testing (UTC-7 or UTC-8 depending on DST)
+	loc, err := time.LoadLocation("America/Vancouver")
+	if err != nil {
+		t.Fatalf("Failed to load timezone: %v", err)
+	}
+
+	// Test cases from the MVP document
+	tests := []struct {
+		name         string
+		fileMtime    string // local time
+		sinceArg     string
+		expectInclude bool
+	}{
+		{
+			name:         "file before date boundary",
+			fileMtime:    "2025-08-10T23:59:00-07:00",
+			sinceArg:     "2025-08-11",
+			expectInclude: false,
+		},
+		{
+			name:         "file at start of date",
+			fileMtime:    "2025-08-11T00:00:00-07:00",
+			sinceArg:     "2025-08-11",
+			expectInclude: true,
+		},
+		{
+			name:         "file during date",
+			fileMtime:    "2025-08-11T01:00:00-07:00",
+			sinceArg:     "2025-08-11",
+			expectInclude: true,
+		},
+		{
+			name:         "file at end of date",
+			fileMtime:    "2025-08-11T23:59:00-07:00",
+			sinceArg:     "2025-08-11",
+			expectInclude: true,
+		},
+		{
+			name:         "file after date",
+			fileMtime:    "2025-08-12T00:00:00-07:00",
+			sinceArg:     "2025-08-11",
+			expectInclude: true,
+		},
+		{
+			name:         "instant mode - file before",
+			fileMtime:    "2025-08-11T01:00:00-07:00",
+			sinceArg:     "2025-08-11T02:00:00-07:00",
+			expectInclude: false,
+		},
+		{
+			name:         "instant mode - file after",
+			fileMtime:    "2025-08-11T03:00:00-07:00",
+			sinceArg:     "2025-08-11T02:00:00-07:00",
+			expectInclude: true,
+		},
+		{
+			name:         "instant mode - file exactly at boundary",
+			fileMtime:    "2025-08-11T02:00:00-07:00",
+			sinceArg:     "2025-08-11T02:00:00-07:00",
+			expectInclude: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Parse file mtime
+			fileMtime, err := time.Parse(time.RFC3339, tt.fileMtime)
+			if err != nil {
+				t.Fatalf("Failed to parse file mtime: %v", err)
+			}
+
+			// Parse since bound
+			sinceBound, err := ParseSince(tt.sinceArg, loc)
+			if err != nil {
+				t.Fatalf("Failed to parse since arg: %v", err)
+			}
+
+			// Test inclusion
+			result := IncludeBySince(fileMtime, sinceBound, loc)
+			if result != tt.expectInclude {
+				t.Errorf("Expected include=%v, got include=%v", tt.expectInclude, result)
+			}
+		})
+	}
+}
+
+func TestIncludeBySinceEmpty(t *testing.T) {
+	loc, err := time.LoadLocation("America/Vancouver")
+	if err != nil {
+		t.Fatalf("Failed to load timezone: %v", err)
+	}
+
+	// Test with empty since bound (no filter)
+	emptySince := SinceBound{}
+	testTime := time.Now()
+
+	result := IncludeBySince(testTime, emptySince, loc)
+	if !result {
+		t.Errorf("Expected true for empty since bound, got false")
+	}
+}
+
+func TestSinceBoundIsEmpty(t *testing.T) {
+	tests := []struct {
+		name     string
+		bound    SinceBound
+		expected bool
+	}{
+		{
+			name:     "empty bound",
+			bound:    SinceBound{},
+			expected: true,
+		},
+		{
+			name:     "instant bound",
+			bound:    SinceBound{instant: &time.Time{}},
+			expected: false,
+		},
+		{
+			name:     "dateOnly bound",
+			bound:    SinceBound{dateOnly: &time.Time{}},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.bound.IsEmpty()
+			if result != tt.expected {
+				t.Errorf("Expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}

--- a/pkg/timefilter/timefilter_test.go
+++ b/pkg/timefilter/timefilter_test.go
@@ -249,3 +249,463 @@ func TestSinceBoundIsEmpty(t *testing.T) {
 		})
 	}
 }
+
+func TestParseDuration(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		expected    time.Duration
+		expectError bool
+	}{
+		{
+			name:        "empty string",
+			input:       "",
+			expectError: true,
+		},
+		{
+			name:     "seconds",
+			input:    "30s",
+			expected: 30 * time.Second,
+		},
+		{
+			name:     "minutes",
+			input:    "45m",
+			expected: 45 * time.Minute,
+		},
+		{
+			name:     "hours",
+			input:    "2h",
+			expected: 2 * time.Hour,
+		},
+		{
+			name:     "days",
+			input:    "7d",
+			expected: 7 * 24 * time.Hour,
+		},
+		{
+			name:     "weeks",
+			input:    "2w",
+			expected: 2 * 7 * 24 * time.Hour,
+		},
+		{
+			name:     "months",
+			input:    "3mo",
+			expected: 3 * 30 * 24 * time.Hour,
+		},
+		{
+			name:     "years",
+			input:    "1y",
+			expected: 365 * 24 * time.Hour,
+		},
+		{
+			name:     "combined hours and minutes",
+			input:    "2h30m",
+			expected: 2*time.Hour + 30*time.Minute,
+		},
+		{
+			name:     "combined with spaces",
+			input:    "2 h 30 m",
+			expected: 2*time.Hour + 30*time.Minute,
+		},
+		{
+			name:     "complex combination",
+			input:    "1y2mo3w4d5h6m7s",
+			expected: 365*24*time.Hour + 2*30*24*time.Hour + 3*7*24*time.Hour + 4*24*time.Hour + 5*time.Hour + 6*time.Minute + 7*time.Second,
+		},
+		{
+			name:     "uppercase",
+			input:    "2H30M",
+			expected: 2*time.Hour + 30*time.Minute,
+		},
+		{
+			name:        "invalid format",
+			input:       "2x",
+			expectError: true,
+		},
+		{
+			name:        "no number",
+			input:       "h",
+			expectError: true,
+		},
+		{
+			name:        "partial match",
+			input:       "2h30",
+			expectError: true,
+		},
+		{
+			name:        "invalid number",
+			input:       "abch",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ParseDuration(tt.input)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("Expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+				return
+			}
+
+			if result != tt.expected {
+				t.Errorf("Expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestNewTimeFilter(t *testing.T) {
+	loc, err := time.LoadLocation("America/Vancouver")
+	if err != nil {
+		t.Fatalf("Failed to load timezone: %v", err)
+	}
+
+	now := time.Date(2025, 8, 11, 12, 0, 0, 0, loc)
+
+	tests := []struct {
+		name        string
+		since       string
+		until       string
+		maxAge      string
+		minAge      string
+		expectError bool
+		expectEmpty bool
+	}{
+		{
+			name:        "empty filter",
+			expectEmpty: true,
+		},
+		{
+			name:  "since only",
+			since: "2025-08-10",
+		},
+		{
+			name:  "until only",
+			until: "2025-08-12",
+		},
+		{
+			name:   "max-age only",
+			maxAge: "7d",
+		},
+		{
+			name:   "min-age only",
+			minAge: "30d",
+		},
+		{
+			name:  "since and until",
+			since: "2025-08-01",
+			until: "2025-08-15",
+		},
+		{
+			name:   "max-age and min-age",
+			maxAge: "7d",
+			minAge: "1d",
+		},
+		{
+			name:   "all filters",
+			since:  "2025-08-01",
+			until:  "2025-08-15",
+			maxAge: "30d",
+			minAge: "1d",
+		},
+		{
+			name:        "invalid since",
+			since:       "invalid",
+			expectError: true,
+		},
+		{
+			name:        "invalid until",
+			until:       "invalid",
+			expectError: true,
+		},
+		{
+			name:        "invalid max-age",
+			maxAge:      "invalid",
+			expectError: true,
+		},
+		{
+			name:        "invalid min-age",
+			minAge:      "invalid",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filter, err := NewTimeFilter(tt.since, tt.until, tt.maxAge, tt.minAge, now, loc)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("Expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+				return
+			}
+
+			if tt.expectEmpty {
+				if !filter.IsEmpty() {
+					t.Errorf("Expected empty filter")
+				}
+			} else {
+				if filter.IsEmpty() {
+					t.Errorf("Expected non-empty filter")
+				}
+			}
+		})
+	}
+}
+
+func TestTimeFilterIncludeByTimeFilter(t *testing.T) {
+	loc, err := time.LoadLocation("America/Vancouver")
+	if err != nil {
+		t.Fatalf("Failed to load timezone: %v", err)
+	}
+
+	now := time.Date(2025, 8, 11, 12, 0, 0, 0, loc)
+
+	tests := []struct {
+		name          string
+		since         string
+		until         string
+		maxAge        string
+		minAge        string
+		fileMtime     string
+		expectInclude bool
+	}{
+		{
+			name:          "since filter - file after",
+			since:         "2025-08-10",
+			fileMtime:     "2025-08-11T10:00:00-07:00",
+			expectInclude: true,
+		},
+		{
+			name:          "since filter - file before",
+			since:         "2025-08-10",
+			fileMtime:     "2025-08-09T10:00:00-07:00",
+			expectInclude: false,
+		},
+		{
+			name:          "until filter - file before",
+			until:         "2025-08-12",
+			fileMtime:     "2025-08-11T10:00:00-07:00",
+			expectInclude: true,
+		},
+		{
+			name:          "until filter - file after",
+			until:         "2025-08-12",
+			fileMtime:     "2025-08-13T10:00:00-07:00",
+			expectInclude: false,
+		},
+		{
+			name:          "max-age filter - file recent",
+			maxAge:        "7d",
+			fileMtime:     "2025-08-10T12:00:00-07:00", // 1 day ago
+			expectInclude: true,
+		},
+		{
+			name:          "max-age filter - file old",
+			maxAge:        "7d",
+			fileMtime:     "2025-08-01T12:00:00-07:00", // 10 days ago
+			expectInclude: false,
+		},
+		{
+			name:          "min-age filter - file old",
+			minAge:        "7d",
+			fileMtime:     "2025-08-01T12:00:00-07:00", // 10 days ago
+			expectInclude: true,
+		},
+		{
+			name:          "min-age filter - file recent",
+			minAge:        "7d",
+			fileMtime:     "2025-08-10T12:00:00-07:00", // 1 day ago
+			expectInclude: false,
+		},
+		{
+			name:          "combined filters - all pass",
+			since:         "2025-08-01",
+			until:         "2025-08-15",
+			maxAge:        "30d",
+			minAge:        "1d",
+			fileMtime:     "2025-08-05T12:00:00-07:00", // 6 days ago
+			expectInclude: true,
+		},
+		{
+			name:          "combined filters - since fails",
+			since:         "2025-08-10",
+			until:         "2025-08-15",
+			maxAge:        "30d",
+			minAge:        "1d",
+			fileMtime:     "2025-08-05T12:00:00-07:00", // 6 days ago
+			expectInclude: false,
+		},
+		{
+			name:          "combined filters - until fails",
+			since:         "2025-08-01",
+			until:         "2025-08-10",
+			maxAge:        "30d",
+			minAge:        "1d",
+			fileMtime:     "2025-08-12T12:00:00-07:00", // future
+			expectInclude: false,
+		},
+		{
+			name:          "combined filters - max-age fails",
+			since:         "2025-08-01",
+			until:         "2025-08-15",
+			maxAge:        "5d",
+			minAge:        "1d",
+			fileMtime:     "2025-08-01T12:00:00-07:00", // 10 days ago
+			expectInclude: false,
+		},
+		{
+			name:          "combined filters - min-age fails",
+			since:         "2025-08-01",
+			until:         "2025-08-15",
+			maxAge:        "30d",
+			minAge:        "5d",
+			fileMtime:     "2025-08-10T12:00:00-07:00", // 1 day ago
+			expectInclude: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Parse file mtime
+			fileMtime, err := time.Parse(time.RFC3339, tt.fileMtime)
+			if err != nil {
+				t.Fatalf("Failed to parse file mtime: %v", err)
+			}
+
+			// Create time filter
+			filter, err := NewTimeFilter(tt.since, tt.until, tt.maxAge, tt.minAge, now, loc)
+			if err != nil {
+				t.Fatalf("Failed to create time filter: %v", err)
+			}
+
+			// Test inclusion
+			result := filter.IncludeByTimeFilter(fileMtime, now, loc)
+			if result != tt.expectInclude {
+				t.Errorf("Expected include=%v, got include=%v", tt.expectInclude, result)
+			}
+		})
+	}
+}
+
+func TestIncludeByTimeBound(t *testing.T) {
+	loc, err := time.LoadLocation("America/Vancouver")
+	if err != nil {
+		t.Fatalf("Failed to load timezone: %v", err)
+	}
+
+	tests := []struct {
+		name          string
+		boundArg      string
+		fileMtime     string
+		isUntil       bool
+		expectInclude bool
+	}{
+		{
+			name:          "since instant - file after",
+			boundArg:      "2025-08-11T10:00:00-07:00",
+			fileMtime:     "2025-08-11T11:00:00-07:00",
+			isUntil:       false,
+			expectInclude: true,
+		},
+		{
+			name:          "since instant - file before",
+			boundArg:      "2025-08-11T10:00:00-07:00",
+			fileMtime:     "2025-08-11T09:00:00-07:00",
+			isUntil:       false,
+			expectInclude: false,
+		},
+		{
+			name:          "since instant - file exactly at boundary",
+			boundArg:      "2025-08-11T10:00:00-07:00",
+			fileMtime:     "2025-08-11T10:00:00-07:00",
+			isUntil:       false,
+			expectInclude: true,
+		},
+		{
+			name:          "until instant - file before",
+			boundArg:      "2025-08-11T10:00:00-07:00",
+			fileMtime:     "2025-08-11T09:00:00-07:00",
+			isUntil:       true,
+			expectInclude: true,
+		},
+		{
+			name:          "until instant - file after",
+			boundArg:      "2025-08-11T10:00:00-07:00",
+			fileMtime:     "2025-08-11T11:00:00-07:00",
+			isUntil:       true,
+			expectInclude: false,
+		},
+		{
+			name:          "until instant - file exactly at boundary",
+			boundArg:      "2025-08-11T10:00:00-07:00",
+			fileMtime:     "2025-08-11T10:00:00-07:00",
+			isUntil:       true,
+			expectInclude: true,
+		},
+		{
+			name:          "since date - file on same day",
+			boundArg:      "2025-08-11",
+			fileMtime:     "2025-08-11T15:30:00-07:00",
+			isUntil:       false,
+			expectInclude: true,
+		},
+		{
+			name:          "since date - file on previous day",
+			boundArg:      "2025-08-11",
+			fileMtime:     "2025-08-10T23:59:00-07:00",
+			isUntil:       false,
+			expectInclude: false,
+		},
+		{
+			name:          "until date - file on same day",
+			boundArg:      "2025-08-11",
+			fileMtime:     "2025-08-11T15:30:00-07:00",
+			isUntil:       true,
+			expectInclude: true,
+		},
+		{
+			name:          "until date - file on next day",
+			boundArg:      "2025-08-11",
+			fileMtime:     "2025-08-12T00:01:00-07:00",
+			isUntil:       true,
+			expectInclude: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Parse time bound
+			bound, err := ParseTimeValue(tt.boundArg, loc)
+			if err != nil {
+				t.Fatalf("Failed to parse time bound: %v", err)
+			}
+
+			// Parse file mtime
+			fileMtime, err := time.Parse(time.RFC3339, tt.fileMtime)
+			if err != nil {
+				t.Fatalf("Failed to parse file mtime: %v", err)
+			}
+
+			// Test inclusion
+			result := IncludeByTimeBound(fileMtime, bound, loc, tt.isUntil)
+			if result != tt.expectInclude {
+				t.Errorf("Expected include=%v, got include=%v", tt.expectInclude, result)
+			}
+		})
+	}
+}

--- a/tui/show.go
+++ b/tui/show.go
@@ -170,6 +170,8 @@ func (ui *UI) showDir() {
 			strconv.Itoa(len(ui.markedRows)) + footerTextColor
 	}
 
+	timeFilterText := ui.formatTimeFilterInfo()
+	
 	ui.footerLabel.SetText(
 		selected + footerTextColor +
 			" Total disk usage: " +
@@ -180,7 +182,8 @@ func (ui *UI) showDir() {
 			ui.formatSize(totalSize, true, false) +
 			" Items: " + footerNumberColor + strconv.Itoa(itemCount) +
 			footerTextColor +
-			" Sorting by: " + ui.sortBy + " " + ui.sortOrder)
+			" Sorting by: " + ui.sortBy + " " + ui.sortOrder +
+			timeFilterText)
 
 	ui.table.Select(0, 0)
 	ui.table.ScrollToBeginning()
@@ -325,6 +328,9 @@ func (ui *UI) formatHelpTextFor() string {
 		if ui.noDelete && (strings.Contains(line, "Empty file or directory") ||
 			strings.Contains(line, "Delete file or directory")) {
 			lines[i] += " (disabled)"
+		} else if !ui.isDeleteAllowedWithFilter() && (strings.Contains(line, "Empty file or directory") ||
+			strings.Contains(line, "Delete file or directory")) {
+			lines[i] += " (disabled - active time filter)"
 		}
 	}
 

--- a/tui/show.go
+++ b/tui/show.go
@@ -171,7 +171,7 @@ func (ui *UI) showDir() {
 	}
 
 	timeFilterText := ui.formatTimeFilterInfo()
-	
+
 	ui.footerLabel.SetText(
 		selected + footerTextColor +
 			" Total disk usage: " +
@@ -325,12 +325,13 @@ func (ui *UI) formatHelpTextFor() string {
 			)
 		}
 
-		if ui.noDelete && (strings.Contains(line, "Empty file or directory") ||
-			strings.Contains(line, "Delete file or directory")) {
+		isFound := (strings.Contains(line, "Empty file or directory") ||
+			strings.Contains(line, "Delete file or directory"))
+
+		if ui.noDelete && isFound {
 			lines[i] += " (disabled)"
-		} else if !ui.isDeleteAllowedWithFilter() && (strings.Contains(line, "Empty file or directory") ||
-			strings.Contains(line, "Delete file or directory")) {
-			lines[i] += " (disabled - active time filter)"
+		} else if ui.noDeleteWithFilter && isFound {
+			lines[i] += " (disabled/filter)"
 		}
 	}
 

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -23,7 +23,6 @@ import (
 	"github.com/rivo/tview"
 )
 
-
 // UI struct
 type UI struct {
 	*common.UI
@@ -85,6 +84,7 @@ type UI struct {
 	deleteWorkersCount      int
 	timeFilter              *timefilter.TimeFilter
 	timeFilterLoc           *time.Location
+	noDeleteWithFilter      bool
 }
 
 type deleteQueueItem struct {
@@ -327,6 +327,11 @@ func (ui *UI) SetNoDelete() {
 	ui.noDelete = true
 }
 
+// SetNoDelete disables delete when time filters are active
+func (ui *UI) SetNoDeleteWithFilter() {
+	ui.noDeleteWithFilter = true
+}
+
 // SetDeleteInBackground sets the flag to delete files in background
 func (ui *UI) SetDeleteInBackground() {
 	ui.deleteInBackground = true
@@ -431,9 +436,10 @@ func (ui *UI) confirmDeletion(shouldEmpty bool) {
 	}
 
 	// Check if deletion is allowed with active time filters
-	if !ui.isDeleteAllowedWithFilter() {
+	if ui.noDeleteWithFilter {
 		modal := tview.NewModal().
-			SetText("Deletion is disabled when a time filter is active.\n\nTo override, set GDU_ALLOW_DELETE_WITH_FILTER=1").
+			SetText("Deletion is disabled when a time filter is active.\n\n" +
+				"To override, set GDU_ALLOW_DELETE_WITH_FILTER=1").
 			AddButtons([]string{"OK"}).
 			SetDoneFunc(func(buttonIndex int, buttonLabel string) {
 				ui.pages.RemovePage("confirm")
@@ -495,13 +501,16 @@ func (ui *UI) confirmDeletionSelected(shouldEmpty bool) {
 func (ui *UI) SetTimeFilterWithInfo(tf *timefilter.TimeFilter, loc *time.Location) {
 	ui.timeFilter = tf
 	ui.timeFilterLoc = loc
-	
+
 	if tf != nil && !tf.IsEmpty() {
 		now := time.Now()
 		timeFilterFunc := func(mtime time.Time) bool {
 			return tf.IncludeByTimeFilter(mtime, now, loc)
 		}
 		ui.SetTimeFilter(timeFilterFunc)
+		if !ui.isDeleteAllowedWithFilter() {
+			ui.SetNoDeleteWithFilter()
+		}
 	}
 }
 
@@ -515,7 +524,7 @@ func (ui *UI) formatTimeFilterInfo() string {
 	if !ui.hasActiveTimeFilter() {
 		return ""
 	}
-	
+
 	return ui.timeFilter.FormatForDisplay(ui.timeFilterLoc)
 }
 
@@ -524,11 +533,11 @@ func (ui *UI) isDeleteAllowedWithFilter() bool {
 	if !ui.hasActiveTimeFilter() {
 		return true
 	}
-	
+
 	// Check environment variable override
 	if os.Getenv("GDU_ALLOW_DELETE_WITH_FILTER") == "1" {
 		return true
 	}
-	
+
 	return false
 }

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -18,9 +18,11 @@ import (
 	"github.com/dundee/gdu/v5/pkg/device"
 	"github.com/dundee/gdu/v5/pkg/fs"
 	"github.com/dundee/gdu/v5/pkg/remove"
+	"github.com/dundee/gdu/v5/pkg/timefilter"
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 )
+
 
 // UI struct
 type UI struct {
@@ -81,6 +83,8 @@ type UI struct {
 	workersMut              sync.Mutex
 	statusMut               sync.RWMutex
 	deleteWorkersCount      int
+	timeFilter              *timefilter.TimeFilter
+	timeFilterLoc           *time.Location
 }
 
 type deleteQueueItem struct {
@@ -426,6 +430,24 @@ func (ui *UI) confirmDeletion(shouldEmpty bool) {
 		return
 	}
 
+	// Check if deletion is allowed with active time filters
+	if !ui.isDeleteAllowedWithFilter() {
+		previousHeaderText := ui.header.GetText(false)
+
+		// show feedback to user
+		ui.header.SetText(" Delete disabled (active time filter)")
+
+		go func() {
+			time.Sleep(2 * time.Second)
+			ui.app.QueueUpdateDraw(func() {
+				ui.header.Clear()
+				ui.header.SetText(previousHeaderText)
+			})
+		}()
+
+		return
+	}
+
 	if len(ui.markedRows) > 0 {
 		ui.confirmDeletionMarked(shouldEmpty)
 	} else {
@@ -470,4 +492,46 @@ func (ui *UI) confirmDeletionSelected(shouldEmpty bool) {
 	modal.SetBorderColor(tcell.ColorDefault)
 
 	ui.pages.AddPage("confirm", modal, true, true)
+}
+
+// SetTimeFilterWithInfo sets both the time filter function and stores the filter info for display
+func (ui *UI) SetTimeFilterWithInfo(tf *timefilter.TimeFilter, loc *time.Location) {
+	ui.timeFilter = tf
+	ui.timeFilterLoc = loc
+	
+	if tf != nil && !tf.IsEmpty() {
+		now := time.Now()
+		timeFilterFunc := func(mtime time.Time) bool {
+			return tf.IncludeByTimeFilter(mtime, now, loc)
+		}
+		ui.SetTimeFilter(timeFilterFunc)
+	}
+}
+
+// hasActiveTimeFilter returns true if any time filter is active
+func (ui *UI) hasActiveTimeFilter() bool {
+	return ui.timeFilter != nil && !ui.timeFilter.IsEmpty()
+}
+
+// formatTimeFilterInfo formats the time filter information for display
+func (ui *UI) formatTimeFilterInfo() string {
+	if !ui.hasActiveTimeFilter() {
+		return ""
+	}
+	
+	return ui.timeFilter.FormatForDisplay(ui.timeFilterLoc)
+}
+
+// isDeleteAllowedWithFilter checks if deletion is allowed when filters are active
+func (ui *UI) isDeleteAllowedWithFilter() bool {
+	if !ui.hasActiveTimeFilter() {
+		return true
+	}
+	
+	// Check environment variable override
+	if os.Getenv("GDU_ALLOW_DELETE_WITH_FILTER") == "1" {
+		return true
+	}
+	
+	return false
 }

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -432,19 +432,16 @@ func (ui *UI) confirmDeletion(shouldEmpty bool) {
 
 	// Check if deletion is allowed with active time filters
 	if !ui.isDeleteAllowedWithFilter() {
-		previousHeaderText := ui.header.GetText(false)
-
-		// show feedback to user
-		ui.header.SetText(" Delete disabled (active time filter)")
-
-		go func() {
-			time.Sleep(2 * time.Second)
-			ui.app.QueueUpdateDraw(func() {
-				ui.header.Clear()
-				ui.header.SetText(previousHeaderText)
+		modal := tview.NewModal().
+			SetText("Deletion is disabled when a time filter is active.\n\nTo override, set GDU_ALLOW_DELETE_WITH_FILTER=1").
+			AddButtons([]string{"OK"}).
+			SetDoneFunc(func(buttonIndex int, buttonLabel string) {
+				ui.pages.RemovePage("confirm")
 			})
-		}()
-
+		if !ui.UseColors {
+			modal.SetBackgroundColor(tcell.ColorGray)
+		}
+		ui.pages.AddPage("confirm", modal, true, true)
 		return
 	}
 


### PR DESCRIPTION
First off, love gdu, thank you!

### What?

```
--max-age string                Include files with mtime no older than DURATION (e.g., 7d, 2h30m, 1y2mo)
--min-age string                Include files with mtime at least DURATION old (e.g., 30d, 1w)
--since string                  Include files with mtime >= WHEN. WHEN accepts RFC3339 timestamp (e.g., 2025-08-11T01:00:00-07:00) or date only YYYY-MM-DD (calendar-day compare; includes the whole day)
--until string                  Include files with mtime <= WHEN. WHEN accepts RFC3339 timestamp or date only YYYY-MM-DD
```

E.g. `gdu --max-age=7d`

TUI status bar now states the time filter as well.  I also added a "no delete" when the time filter is active because I don't want any mishaps with someone deleting a folder that they only see a few files but they don't see the files that are filtered out.  This should be improved in the future to only apply to folders, but for now I played it safe.  There's a `GDU_ALLOW_DELETE_WITH_FILTER=1` env you can set if you really must.

### Why?

I've been wanting this for a while now, so here it is.  Basically it started with "what has taken my space recently", and with containers etc sometimes it's many small files instead of a few large files that could be easily found with `find . -type f -size +10M -mtime -7`.  Once I added `--since` I might as well add the other ones.

### Future scope

I don't want to complicate things too much, especially since this is a feature not everyone will use.  Possible additional flags could be `--older-than`/`--newer-than` (basically use timestamp of file), and comparing other than mtime (i.e. atime, ctime, btime? but has multi-os issues).  Maybe other filtering?

UI could also be improved, I was thinking `● ◐ ○` indicators for folders to show if you're seeing all files or if they're partially filtered.  I thought of that because I was thinking of adding an option to show all folders, but not show the contents that is filtered out.  That way you'd still get a full picture of the folder structure, but still applying the filters.

The timestamp and natural time code should probably be switched out with more mature packages, but I didn't want to add new dependencies right off the bat.