### PR TITLE
fix: broken link to the 'configuration.md' file in 'README.md'

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Gdu can read (and write) YAML configuration file.
 
 `$HOME/.config/gdu/gdu.yaml` and `$HOME/.gdu.yaml` are checked for the presence of the config file by default.
 
-See the [full list of all configuration options](configuration).
+See the [full list of all configuration options](configuration.md).
 
 ### Examples
 


### PR DESCRIPTION
Just added `.md`  to the line so that it correctly links.