### PR TITLE
chore: bump Go to 1.25.5 to fix crypto/x509 CVEs

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.25.0
+golang 1.25.5

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/golang:1.24.11 as builder
+FROM docker.io/library/golang:1.25.5 as builder
 
 WORKDIR /app
 


### PR DESCRIPTION
This PR upgrades the Go toolchain to Go [`1.25.5`](https://github.com/golang/go/issues?q=milestone%3AGo1.25.5+label%3ACherryPickApproved) to address security vulnerabilities in the Go standard library.

The upgrade fixes the following vulnerabilities affecting `crypto/x509`, which impact the gdu binary:

- **CVE-2025-61729** (High, CVSS 7.5)
- **CVE-2025-61727** (Medium, CVSS 6.5)
