### PR TITLE
fix: use smaller value log file size for 32bit systems

### DIFF
--- a/internal/common/const.go
+++ b/internal/common/const.go
@@ -1,0 +1,4 @@
+package common
+
+// Is64Bit returns true if the system is 64-bit
+const Is64Bit = (^uint(0) >> 63) == 1

--- a/pkg/analyze/storage.go
+++ b/pkg/analyze/storage.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/dgraph-io/badger/v4"
+	"github.com/dundee/gdu/v5/internal/common"
 	"github.com/dundee/gdu/v5/pkg/fs"
 	"github.com/pkg/errors"
 )
@@ -57,6 +58,13 @@ func (s *Storage) IsOpen() bool {
 func (s *Storage) Open() func() {
 	options := badger.DefaultOptions(s.storagePath)
 	options.Logger = nil
+
+	if !common.Is64Bit {
+		// For 32-bit systems, we need to set ValueLogFileSize to a smaller value to
+		// avoid "cannot allocate memory while mmapping" error
+		options.ValueLogFileSize = (1<<30 - 1) / 2
+	}
+
 	db, err := badger.Open(options)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
fixes #517