### PR TITLE
ci: drop support for golang 1.24

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.24.x, 1.25.x, 1.26.x]
+        go-version: [1.25.x, 1.26.x]
         platform: [ubuntu-latest]
         include:
           - go-version: 1.26.x

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dundee/gdu/v5
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/dgraph-io/badger/v4 v4.9.1


### PR DESCRIPTION
Golang 1.24 is not supported anymore since 1.26 is out.

Closes #518 