### PR TITLE
Improve SQLite analyzer and add archive browsing support

### DIFF
--- a/pkg/analyze/sqlite.go
+++ b/pkg/analyze/sqlite.go
@@ -251,7 +251,7 @@ func (s *SqliteStorage) GetRootItem() (*SqliteItem, error) {
 
 // InsertItem inserts a file/directory item into the database
 func (s *SqliteStorage) InsertItem(
-	parentID *int64, name string, isDir bool, size, usage int64, mtime time.Time, itemCount int, mli uint64, flag rune,
+	parentID *int64, name string, isDir bool, size, usage int64, mtime time.Time, itemCount int64, mli uint64, flag rune,
 ) (int64, error) {
 	isDirInt := 0
 	if isDir {
@@ -486,8 +486,9 @@ type SqliteItem struct {
 
 // GetPath returns the full path of the item
 func (i *SqliteItem) GetPath() string {
-	if i.parent != nil {
-		return filepath.Join(i.parent.GetPath(), i.name)
+	parent := i.GetParent()
+	if parent != nil {
+		return filepath.Join(parent.GetPath(), i.name)
 	}
 	// For root item, get basePath from metadata
 	basePath, err := i.storage.GetMetadata("top_dir_path")
@@ -1082,6 +1083,29 @@ func (a *SqliteAnalyzer) processDir(path string, parentID *int64) *SqliteItem {
 			totalUsage += fileUsage
 			filesSize += fileUsage
 			itemCount++
+
+			// Handle archive browsing
+			if a.archiveBrowsing {
+				var (
+					archiveItem fs.Item
+					err         error
+				)
+				if isZipFile(name) {
+					archiveItem, err = processZipFile(entryPath, info)
+				} else if isTarFile(name) {
+					archiveItem, err = processTarFile(entryPath, info)
+				}
+
+				if err != nil {
+					log.Errorf("Failed to process archive %s: %v", entryPath, err)
+				} else if archiveItem != nil {
+					// Archive content should be siblings of other items in the archive,
+					// so we persist its children into dirID.
+					for child := range archiveItem.GetFiles(fs.SortByName, fs.SortAsc) {
+						a.persistArchive(dirID, child)
+					}
+				}
+			}
 		}
 	}
 
@@ -1110,6 +1134,48 @@ func (a *SqliteAnalyzer) processDir(path string, parentID *int64) *SqliteItem {
 		mtime:     dirMtime,
 		itemCount: itemCount,
 		flag:      getDirFlag(err, len(files)),
+	}
+}
+
+func (a *SqliteAnalyzer) persistArchive(parentID int64, item fs.Item) {
+	if item.IsDir() {
+		// Insert directory
+		dirID, err := a.storage.InsertItem(
+			&parentID,
+			item.GetName(),
+			true,
+			item.GetSize(),
+			item.GetUsage(),
+			item.GetMtime(),
+			int64(item.GetItemCount()),
+			0,
+			item.GetFlag(),
+		)
+		if err != nil {
+			log.Errorf("Error persisting archive directory: %v", err)
+			return
+		}
+
+		// Recursively persist children
+		for child := range item.GetFiles(fs.SortByName, fs.SortAsc) {
+			a.persistArchive(dirID, child)
+		}
+	} else {
+		// Insert file
+		_, err := a.storage.InsertItem(
+			&parentID,
+			item.GetName(),
+			false,
+			item.GetSize(),
+			item.GetUsage(),
+			item.GetMtime(),
+			1,
+			item.GetMultiLinkedInode(),
+			item.GetFlag(),
+		)
+		if err != nil {
+			log.Errorf("Error persisting archive file: %v", err)
+		}
 	}
 }
 

--- a/pkg/analyze/sqlite_test.go
+++ b/pkg/analyze/sqlite_test.go
@@ -298,6 +298,32 @@ func TestSqliteItemGetPath(t *testing.T) {
 	assert.Equal(t, "/home/user/testdir/file.txt", child.GetPath())
 }
 
+func TestSqliteItemGetPathLazyLoad(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	storage, err := NewSqliteStorage(dbPath)
+	assert.NoError(t, err)
+	defer storage.Close()
+
+	// Set up metadata for path resolution
+	err = storage.SetMetadata("top_dir_path", "/home/user/testdir")
+	assert.NoError(t, err)
+
+	// Insert root
+	rootID, err := storage.InsertItem(nil, "testdir", true, 0, 0, time.Now(), 1, 0, ' ')
+	assert.NoError(t, err)
+
+	// Insert child
+	childID, err := storage.InsertItem(&rootID, "file.txt", false, 100, 4096, time.Now(), 1, 0, ' ')
+	assert.NoError(t, err)
+
+	// Get child (without setting parent manually)
+	child, err := storage.GetItemByID(childID)
+	assert.NoError(t, err)
+
+	// Path should still be correctly resolved via lazy loading of parent
+	assert.Equal(t, "/home/user/testdir/file.txt", child.GetPath())
+}
+
 func TestSqliteItemGetType(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "test.db")
 	storage, err := NewSqliteStorage(dbPath)


### PR DESCRIPTION
I have improved the SQLite-based disk usage analyzer by:
1. Ensuring type consistency: Changed `itemCount` from `int` to `int64` in `SqliteStorage.InsertItem`.
2. Enhancing path resolution: Updated `SqliteItem.GetPath` to lazily load parent items from the database, ensuring correct absolute paths even when the full tree is not in memory.
3. Adding archive support: Implemented ZIP and TAR browsing in `SqliteAnalyzer`, allowing the contents of archives to be recursively indexed into the SQLite database when the feature is enabled.
4. Adding verification: Included a new test case `TestSqliteItemGetPathLazyLoad` to verify the path reconstruction via lazy loading.
5. Improving logic: Refactored `persistArchive` to integrate archive contents into the database hierarchy correctly as siblings/children.

---
*PR created automatically by Jules for task [16352548310991150892](https://jules.google.com/task/16352548310991150892) started by @dundee*