### PR TITLE
Fix concurrency issues and refactor analyzers

### DIFF
--- a/pkg/analyze/analyzer.go
+++ b/pkg/analyze/analyzer.go
@@ -1,0 +1,82 @@
+package analyze
+
+import (
+	"github.com/dundee/gdu/v5/internal/common"
+)
+
+type BaseAnalyzer struct {
+	progress            *common.CurrentProgress
+	progressChan        chan common.CurrentProgress
+	progressOutChan     chan common.CurrentProgress
+	progressDoneChan    chan struct{}
+	doneChan            common.SignalGroup
+	wait                *WaitGroup
+	ignoreDir           common.ShouldDirBeIgnored
+	ignoreFileType      common.ShouldFileBeIgnored
+	followSymlinks      bool
+	gitAnnexedSize      bool
+	matchesTimeFilterFn common.TimeFilter
+	archiveBrowsing     bool
+}
+
+func (a *BaseAnalyzer) init() {
+	a.progress = &common.CurrentProgress{
+		ItemCount: 0,
+		TotalSize: int64(0),
+	}
+	a.progressChan = make(chan common.CurrentProgress, 1)
+	a.progressOutChan = make(chan common.CurrentProgress, 1)
+	a.progressDoneChan = make(chan struct{})
+	a.doneChan = make(common.SignalGroup)
+	a.wait = (&WaitGroup{}).Init()
+}
+
+func (a *BaseAnalyzer) SetFollowSymlinks(v bool) {
+	a.followSymlinks = v
+}
+
+func (a *BaseAnalyzer) SetShowAnnexedSize(v bool) {
+	a.gitAnnexedSize = v
+}
+
+func (a *BaseAnalyzer) SetTimeFilter(matchesTimeFilterFn common.TimeFilter) {
+	a.matchesTimeFilterFn = matchesTimeFilterFn
+}
+
+func (a *BaseAnalyzer) SetArchiveBrowsing(v bool) {
+	a.archiveBrowsing = v
+}
+
+func (a *BaseAnalyzer) SetFileTypeFilter(filter common.ShouldFileBeIgnored) {
+	a.ignoreFileType = filter
+}
+
+func (a *BaseAnalyzer) GetProgressChan() chan common.CurrentProgress {
+	return a.progressOutChan
+}
+
+func (a *BaseAnalyzer) GetDone() common.SignalGroup {
+	return a.doneChan
+}
+
+func (a *BaseAnalyzer) ResetProgress() {
+	a.init()
+}
+
+func (a *BaseAnalyzer) updateProgress() {
+	for {
+		select {
+		case <-a.progressDoneChan:
+			return
+		case progress := <-a.progressChan:
+			a.progress.CurrentItemName = progress.CurrentItemName
+			a.progress.ItemCount += progress.ItemCount
+			a.progress.TotalSize += progress.TotalSize
+		}
+
+		select {
+		case a.progressOutChan <- *a.progress:
+		default:
+		}
+	}
+}

--- a/pkg/analyze/file.go
+++ b/pkg/analyze/file.go
@@ -149,15 +149,20 @@ type Dir struct {
 
 // AddFile add item to files
 func (f *Dir) AddFile(item fs.Item) {
+	f.m.Lock()
+	defer f.m.Unlock()
 	f.Files = append(f.Files, item)
 }
 
 // GetFiles returns all files in directory as a sorted iterator
 func (f *Dir) GetFiles(sortBy fs.SortBy, order fs.SortOrder) iter.Seq[fs.Item] {
 	return func(yield func(fs.Item) bool) {
+		f.m.RLock()
 		// Make a copy to avoid modifying the original slice
 		sorted := make(fs.Files, len(f.Files))
 		copy(sorted, f.Files)
+		f.m.RUnlock()
+
 		sortFiles(sorted, sortBy, order)
 
 		for _, item := range sorted {
@@ -205,6 +210,27 @@ func (f *Dir) IsDir() bool {
 	return true
 }
 
+// GetSize returns size of the dir
+func (f *Dir) GetSize() int64 {
+	f.m.RLock()
+	defer f.m.RUnlock()
+	return f.Size
+}
+
+// GetUsage returns usage of the dir
+func (f *Dir) GetUsage() int64 {
+	f.m.RLock()
+	defer f.m.RUnlock()
+	return f.Usage
+}
+
+// GetMtime returns mtime of the dir
+func (f *Dir) GetMtime() time.Time {
+	f.m.RLock()
+	defer f.m.RUnlock()
+	return f.Mtime
+}
+
 // GetPath returns absolute path of the file
 func (f *Dir) GetPath() string {
 	if f.BasePath != "" {
@@ -224,6 +250,9 @@ func (f *Dir) GetItemStats(linkedItems fs.HardLinkedItems) (itemCount, size, usa
 
 // UpdateStats recursively updates size and item count
 func (f *Dir) UpdateStats(linkedItems fs.HardLinkedItems) {
+	f.m.Lock()
+	defer f.m.Unlock()
+
 	totalSize := int64(4096)
 	totalUsage := int64(4096)
 	var itemCount int64
@@ -252,15 +281,16 @@ func (f *Dir) UpdateStats(linkedItems fs.HardLinkedItems) {
 // RemoveFile removes item from dir, updates size and item count
 func (f *Dir) RemoveFile(item fs.Item) {
 	f.m.Lock()
-	defer f.m.Unlock()
-
 	f.Files = f.Files.Remove(item)
+	f.m.Unlock()
 
 	cur := f
 	for {
+		cur.m.Lock()
 		cur.ItemCount -= item.GetItemCount()
 		cur.Size -= item.GetSize()
 		cur.Usage -= item.GetUsage()
+		cur.m.Unlock()
 
 		if cur.Parent == nil {
 			break
@@ -301,20 +331,22 @@ func (f *Dir) RLock() func() {
 // RemoveFileByName removes item by name from dir
 func (f *Dir) RemoveFileByName(name string) {
 	f.m.Lock()
-	defer f.m.Unlock()
-
 	idx, ok := f.Files.FindByName(name)
 	if !ok {
+		f.m.Unlock()
 		return
 	}
 	item := f.Files[idx]
 	f.Files = append(f.Files[:idx], f.Files[idx+1:]...)
+	f.m.Unlock()
 
 	cur := f
 	for {
+		cur.m.Lock()
 		cur.ItemCount -= item.GetItemCount()
 		cur.Size -= item.GetSize()
 		cur.Usage -= item.GetUsage()
+		cur.m.Unlock()
 
 		if cur.Parent == nil {
 			break

--- a/pkg/analyze/parallel.go
+++ b/pkg/analyze/parallel.go
@@ -14,78 +14,14 @@ var concurrencyLimit = make(chan struct{}, 3*runtime.GOMAXPROCS(0))
 
 // ParallelAnalyzer implements Analyzer
 type ParallelAnalyzer struct {
-	progress            *common.CurrentProgress
-	progressChan        chan common.CurrentProgress
-	progressOutChan     chan common.CurrentProgress
-	progressDoneChan    chan struct{}
-	doneChan            common.SignalGroup
-	wait                *WaitGroup
-	ignoreDir           common.ShouldDirBeIgnored
-	ignoreFileType      common.ShouldFileBeIgnored
-	followSymlinks      bool
-	gitAnnexedSize      bool
-	matchesTimeFilterFn common.TimeFilter
-	archiveBrowsing     bool
+	BaseAnalyzer
 }
 
 // CreateAnalyzer returns Analyzer
 func CreateAnalyzer() *ParallelAnalyzer {
-	return &ParallelAnalyzer{
-		progress: &common.CurrentProgress{
-			ItemCount: 0,
-			TotalSize: int64(0),
-		},
-		progressChan:     make(chan common.CurrentProgress, 1),
-		progressOutChan:  make(chan common.CurrentProgress, 1),
-		progressDoneChan: make(chan struct{}),
-		doneChan:         make(common.SignalGroup),
-		wait:             (&WaitGroup{}).Init(),
-	}
-}
-
-// SetFollowSymlinks sets whether symlink to files should be followed
-func (a *ParallelAnalyzer) SetFollowSymlinks(v bool) {
-	a.followSymlinks = v
-}
-
-// SetShowAnnexedSize sets whether to use annexed size of git-annex files
-func (a *ParallelAnalyzer) SetShowAnnexedSize(v bool) {
-	a.gitAnnexedSize = v
-}
-
-// SetTimeFilter sets the time filter function for file inclusion
-func (a *ParallelAnalyzer) SetTimeFilter(matchesTimeFilterFn common.TimeFilter) {
-	a.matchesTimeFilterFn = matchesTimeFilterFn
-}
-
-// SetArchiveBrowsing sets whether browsing of zip/jar/tar archives is enabled
-func (a *ParallelAnalyzer) SetArchiveBrowsing(v bool) {
-	a.archiveBrowsing = v
-}
-
-// SetFileTypeFilter sets the file type filter function
-func (a *ParallelAnalyzer) SetFileTypeFilter(filter common.ShouldFileBeIgnored) {
-	a.ignoreFileType = filter
-}
-
-// GetProgressChan returns channel for getting progress
-func (a *ParallelAnalyzer) GetProgressChan() chan common.CurrentProgress {
-	return a.progressOutChan
-}
-
-// GetDone returns channel for checking when analysis is done
-func (a *ParallelAnalyzer) GetDone() common.SignalGroup {
-	return a.doneChan
-}
-
-// ResetProgress returns progress
-func (a *ParallelAnalyzer) ResetProgress() {
-	a.progress = &common.CurrentProgress{}
-	a.progressChan = make(chan common.CurrentProgress, 1)
-	a.progressOutChan = make(chan common.CurrentProgress, 1)
-	a.progressDoneChan = make(chan struct{})
-	a.doneChan = make(common.SignalGroup)
-	a.wait = (&WaitGroup{}).Init()
+	a := &ParallelAnalyzer{}
+	a.init()
+	return a
 }
 
 // AnalyzeDir analyzes given path
@@ -253,23 +189,6 @@ func (a *ParallelAnalyzer) processDir(path string) *Dir {
 	return dir
 }
 
-func (a *ParallelAnalyzer) updateProgress() {
-	for {
-		select {
-		case <-a.progressDoneChan:
-			return
-		case progress := <-a.progressChan:
-			a.progress.CurrentItemName = progress.CurrentItemName
-			a.progress.ItemCount += progress.ItemCount
-			a.progress.TotalSize += progress.TotalSize
-		}
-
-		select {
-		case a.progressOutChan <- *a.progress:
-		default:
-		}
-	}
-}
 
 func getDirFlag(err error, items int) rune {
 	switch {

--- a/pkg/analyze/parallel_stable.go
+++ b/pkg/analyze/parallel_stable.go
@@ -11,66 +11,14 @@ import (
 
 // ParallelStableOrderAnalyzer implements Analyzer
 type ParallelStableOrderAnalyzer struct {
-	progress         *common.CurrentProgress
-	progressChan     chan common.CurrentProgress
-	progressOutChan  chan common.CurrentProgress
-	progressDoneChan chan struct{}
-	doneChan         common.SignalGroup
-	wait             *WaitGroup
-	ignoreDir        common.ShouldDirBeIgnored
-	ignoreFileType   common.ShouldFileBeIgnored
-	followSymlinks   bool
-	gitAnnexedSize   bool
+	BaseAnalyzer
 }
 
 // CreateStableOrderAnalyzer returns parallel Analyzer which keeps stable order of files
 func CreateStableOrderAnalyzer() *ParallelStableOrderAnalyzer {
-	return &ParallelStableOrderAnalyzer{
-		progress: &common.CurrentProgress{
-			ItemCount: 0,
-			TotalSize: int64(0),
-		},
-		progressChan:     make(chan common.CurrentProgress, 1),
-		progressOutChan:  make(chan common.CurrentProgress, 1),
-		progressDoneChan: make(chan struct{}),
-		doneChan:         make(common.SignalGroup),
-		wait:             (&WaitGroup{}).Init(),
-	}
-}
-
-// SetFollowSymlinks sets whether symlink to files should be followed
-func (a *ParallelStableOrderAnalyzer) SetFollowSymlinks(v bool) {
-	a.followSymlinks = v
-}
-
-// SetShowAnnexedSize sets whether to use annexed size of git-annex files
-func (a *ParallelStableOrderAnalyzer) SetShowAnnexedSize(v bool) {
-	a.gitAnnexedSize = v
-}
-
-// SetFileTypeFilter sets the file type filter function
-func (a *ParallelStableOrderAnalyzer) SetFileTypeFilter(filter common.ShouldFileBeIgnored) {
-	a.ignoreFileType = filter
-}
-
-// GetProgressChan returns channel for getting progress
-func (a *ParallelStableOrderAnalyzer) GetProgressChan() chan common.CurrentProgress {
-	return a.progressOutChan
-}
-
-// GetDone returns channel for checking when analysis is done
-func (a *ParallelStableOrderAnalyzer) GetDone() common.SignalGroup {
-	return a.doneChan
-}
-
-// ResetProgress returns progress
-func (a *ParallelStableOrderAnalyzer) ResetProgress() {
-	a.progress = &common.CurrentProgress{}
-	a.progressChan = make(chan common.CurrentProgress, 1)
-	a.progressOutChan = make(chan common.CurrentProgress, 1)
-	a.progressDoneChan = make(chan struct{})
-	a.doneChan = make(common.SignalGroup)
-	a.wait = (&WaitGroup{}).Init()
+	a := &ParallelStableOrderAnalyzer{}
+	a.init()
+	return a
 }
 
 // AnalyzeDir analyzes given path
@@ -211,20 +159,3 @@ func (a *ParallelStableOrderAnalyzer) processDir(path string) *Dir {
 	return dir
 }
 
-func (a *ParallelStableOrderAnalyzer) updateProgress() {
-	for {
-		select {
-		case <-a.progressDoneChan:
-			return
-		case progress := <-a.progressChan:
-			a.progress.CurrentItemName = progress.CurrentItemName
-			a.progress.ItemCount += progress.ItemCount
-			a.progress.TotalSize += progress.TotalSize
-		}
-
-		select {
-		case a.progressOutChan <- *a.progress:
-		default:
-		}
-	}
-}

--- a/pkg/analyze/sequential.go
+++ b/pkg/analyze/sequential.go
@@ -11,77 +11,14 @@ import (
 
 // SequentialAnalyzer implements Analyzer
 type SequentialAnalyzer struct {
-	progress            *common.CurrentProgress
-	progressChan        chan common.CurrentProgress
-	progressOutChan     chan common.CurrentProgress
-	progressDoneChan    chan struct{}
-	doneChan            common.SignalGroup
-	wait                *WaitGroup
-	ignoreDir           common.ShouldDirBeIgnored
-	ignoreFileType      common.ShouldFileBeIgnored
-	followSymlinks      bool
-	gitAnnexedSize      bool
-	matchesTimeFilterFn common.TimeFilter
-	archiveBrowsing     bool
+	BaseAnalyzer
 }
 
 // CreateSeqAnalyzer returns Analyzer
 func CreateSeqAnalyzer() *SequentialAnalyzer {
-	return &SequentialAnalyzer{
-		progress: &common.CurrentProgress{
-			ItemCount: 0,
-			TotalSize: int64(0),
-		},
-		progressChan:     make(chan common.CurrentProgress, 1),
-		progressOutChan:  make(chan common.CurrentProgress, 1),
-		progressDoneChan: make(chan struct{}),
-		doneChan:         make(common.SignalGroup),
-		wait:             (&WaitGroup{}).Init(),
-	}
-}
-
-// SetFollowSymlinks sets whether symlink to files should be followed
-func (a *SequentialAnalyzer) SetFollowSymlinks(v bool) {
-	a.followSymlinks = v
-}
-
-// SetShowAnnexedSize sets whether to use annexed size of git-annex files
-func (a *SequentialAnalyzer) SetShowAnnexedSize(v bool) {
-	a.gitAnnexedSize = v
-}
-
-// SetTimeFilter sets the time filter function for file inclusion
-func (a *SequentialAnalyzer) SetTimeFilter(matchesTimeFilterFn common.TimeFilter) {
-	a.matchesTimeFilterFn = matchesTimeFilterFn
-}
-
-// SetArchiveBrowsing sets whether browsing of zip/jar/tar archives is enabled
-func (a *SequentialAnalyzer) SetArchiveBrowsing(v bool) {
-	a.archiveBrowsing = v
-}
-
-// SetFileTypeFilter sets the file type filter function
-func (a *SequentialAnalyzer) SetFileTypeFilter(filter common.ShouldFileBeIgnored) {
-	a.ignoreFileType = filter
-}
-
-// GetProgressChan returns channel for getting progress
-func (a *SequentialAnalyzer) GetProgressChan() chan common.CurrentProgress {
-	return a.progressOutChan
-}
-
-// GetDone returns channel for checking when analysis is done
-func (a *SequentialAnalyzer) GetDone() common.SignalGroup {
-	return a.doneChan
-}
-
-// ResetProgress returns progress
-func (a *SequentialAnalyzer) ResetProgress() {
-	a.progress = &common.CurrentProgress{}
-	a.progressChan = make(chan common.CurrentProgress, 1)
-	a.progressOutChan = make(chan common.CurrentProgress, 1)
-	a.progressDoneChan = make(chan struct{})
-	a.doneChan = make(common.SignalGroup)
+	a := &SequentialAnalyzer{}
+	a.init()
+	return a
 }
 
 // AnalyzeDir analyzes given path
@@ -229,20 +166,3 @@ func (a *SequentialAnalyzer) processDir(path string) *Dir {
 	return dir
 }
 
-func (a *SequentialAnalyzer) updateProgress() {
-	for {
-		select {
-		case <-a.progressDoneChan:
-			return
-		case progress := <-a.progressChan:
-			a.progress.CurrentItemName = progress.CurrentItemName
-			a.progress.ItemCount += progress.ItemCount
-			a.progress.TotalSize += progress.TotalSize
-		}
-
-		select {
-		case a.progressOutChan <- *a.progress:
-		default:
-		}
-	}
-}

--- a/pkg/analyze/sqlite.go
+++ b/pkg/analyze/sqlite.go
@@ -826,19 +826,8 @@ func (i *SqliteItem) RLock() func() {
 
 // SqliteAnalyzer implements Analyzer using SQLite storage
 type SqliteAnalyzer struct {
-	storage             *SqliteStorage
-	progress            *common.CurrentProgress
-	progressChan        chan common.CurrentProgress
-	progressOutChan     chan common.CurrentProgress
-	progressDoneChan    chan struct{}
-	doneChan            common.SignalGroup
-	wait                *WaitGroup
-	ignoreDir           common.ShouldDirBeIgnored
-	ignoreFileType      common.ShouldFileBeIgnored
-	followSymlinks      bool
-	gitAnnexedSize      bool
-	matchesTimeFilterFn common.TimeFilter
-	archiveBrowsing     bool
+	BaseAnalyzer
+	storage *SqliteStorage
 }
 
 // CreateSqliteAnalyzer creates a new SQLite analyzer
@@ -852,63 +841,11 @@ func CreateSqliteAnalyzer(dbPath string) (*SqliteAnalyzer, error) {
 		return nil, err
 	}
 
-	return &SqliteAnalyzer{
+	a := &SqliteAnalyzer{
 		storage: storage,
-		progress: &common.CurrentProgress{
-			ItemCount: 0,
-			TotalSize: int64(0),
-		},
-		progressChan:     make(chan common.CurrentProgress, 1),
-		progressOutChan:  make(chan common.CurrentProgress, 1),
-		progressDoneChan: make(chan struct{}),
-		doneChan:         make(common.SignalGroup),
-		wait:             (&WaitGroup{}).Init(),
-	}, nil
-}
-
-// SetFollowSymlinks sets whether symlinks should be followed
-func (a *SqliteAnalyzer) SetFollowSymlinks(v bool) {
-	a.followSymlinks = v
-}
-
-// SetShowAnnexedSize sets whether to use annexed size
-func (a *SqliteAnalyzer) SetShowAnnexedSize(v bool) {
-	a.gitAnnexedSize = v
-}
-
-// SetTimeFilter sets the time filter function
-func (a *SqliteAnalyzer) SetTimeFilter(matchesTimeFilterFn common.TimeFilter) {
-	a.matchesTimeFilterFn = matchesTimeFilterFn
-}
-
-// SetArchiveBrowsing sets whether archive browsing is enabled
-func (a *SqliteAnalyzer) SetArchiveBrowsing(v bool) {
-	a.archiveBrowsing = v
-}
-
-// SetFileTypeFilter sets the file type filter
-func (a *SqliteAnalyzer) SetFileTypeFilter(filter common.ShouldFileBeIgnored) {
-	a.ignoreFileType = filter
-}
-
-// GetProgressChan returns the progress channel
-func (a *SqliteAnalyzer) GetProgressChan() chan common.CurrentProgress {
-	return a.progressOutChan
-}
-
-// GetDone returns the done signal group
-func (a *SqliteAnalyzer) GetDone() common.SignalGroup {
-	return a.doneChan
-}
-
-// ResetProgress resets the progress state
-func (a *SqliteAnalyzer) ResetProgress() {
-	a.progress = &common.CurrentProgress{}
-	a.progressChan = make(chan common.CurrentProgress, 1)
-	a.progressOutChan = make(chan common.CurrentProgress, 1)
-	a.progressDoneChan = make(chan struct{})
-	a.doneChan = make(common.SignalGroup)
-	a.wait = (&WaitGroup{}).Init()
+	}
+	a.init()
+	return a, nil
 }
 
 // AnalyzeDir analyzes the given path and stores results in SQLite.
@@ -1113,20 +1050,3 @@ func (a *SqliteAnalyzer) processDir(path string, parentID *int64) *SqliteItem {
 	}
 }
 
-func (a *SqliteAnalyzer) updateProgress() {
-	for {
-		select {
-		case <-a.progressDoneChan:
-			return
-		case progress := <-a.progressChan:
-			a.progress.CurrentItemName = progress.CurrentItemName
-			a.progress.ItemCount += progress.ItemCount
-			a.progress.TotalSize += progress.TotalSize
-		}
-
-		select {
-		case a.progressOutChan <- *a.progress:
-		default:
-		}
-	}
-}

--- a/pkg/analyze/stored.go
+++ b/pkg/analyze/stored.go
@@ -15,79 +15,18 @@ import (
 
 // StoredAnalyzer implements Analyzer
 type StoredAnalyzer struct {
-	storage             *Storage
-	progress            *common.CurrentProgress
-	progressChan        chan common.CurrentProgress
-	progressOutChan     chan common.CurrentProgress
-	progressDoneChan    chan struct{}
-	doneChan            common.SignalGroup
-	wait                *WaitGroup
-	ignoreDir           common.ShouldDirBeIgnored
-	ignoreFileType      common.ShouldFileBeIgnored
-	storagePath         string
-	followSymlinks      bool
-	gitAnnexedSize      bool
-	matchesTimeFilterFn common.TimeFilter
-	archiveBrowsing     bool
+	BaseAnalyzer
+	storage     *Storage
+	storagePath string
 }
 
 // CreateStoredAnalyzer returns Analyzer
 func CreateStoredAnalyzer(storagePath string) *StoredAnalyzer {
-	return &StoredAnalyzer{
+	a := &StoredAnalyzer{
 		storagePath: storagePath,
-		progress: &common.CurrentProgress{
-			ItemCount: 0,
-			TotalSize: int64(0),
-		},
-		progressChan:     make(chan common.CurrentProgress, 1),
-		progressOutChan:  make(chan common.CurrentProgress, 1),
-		progressDoneChan: make(chan struct{}),
-		doneChan:         make(common.SignalGroup),
-		wait:             (&WaitGroup{}).Init(),
 	}
-}
-
-// GetProgressChan returns channel for getting progress
-func (a *StoredAnalyzer) GetProgressChan() chan common.CurrentProgress {
-	return a.progressOutChan
-}
-
-// GetDone returns channel for checking when analysis is done
-func (a *StoredAnalyzer) GetDone() common.SignalGroup {
-	return a.doneChan
-}
-
-func (a *StoredAnalyzer) SetFollowSymlinks(v bool) {
-	a.followSymlinks = v
-}
-
-func (a *StoredAnalyzer) SetShowAnnexedSize(v bool) {
-	a.gitAnnexedSize = v
-}
-
-// SetTimeFilter sets the time filter function for file inclusion
-func (a *StoredAnalyzer) SetTimeFilter(matchesTimeFilterFn common.TimeFilter) {
-	a.matchesTimeFilterFn = matchesTimeFilterFn
-}
-
-// SetArchiveBrowsing sets whether browsing of zip/jar archives is enabled
-func (a *StoredAnalyzer) SetArchiveBrowsing(v bool) {
-	a.archiveBrowsing = v
-}
-
-// SetFileTypeFilter sets the file type filter function
-func (a *StoredAnalyzer) SetFileTypeFilter(filter common.ShouldFileBeIgnored) {
-	a.ignoreFileType = filter
-}
-
-// ResetProgress returns progress
-func (a *StoredAnalyzer) ResetProgress() {
-	a.progress = &common.CurrentProgress{}
-	a.progressChan = make(chan common.CurrentProgress, 1)
-	a.progressOutChan = make(chan common.CurrentProgress, 1)
-	a.progressDoneChan = make(chan struct{})
-	a.doneChan = make(common.SignalGroup)
-	a.wait = (&WaitGroup{}).Init()
+	a.init()
+	return a
 }
 
 // AnalyzeDir analyzes given path
@@ -251,23 +190,6 @@ func (a *StoredAnalyzer) processDir(path string) *StoredDir {
 	return dir
 }
 
-func (a *StoredAnalyzer) updateProgress() {
-	for {
-		select {
-		case <-a.progressDoneChan:
-			return
-		case progress := <-a.progressChan:
-			a.progress.CurrentItemName = progress.CurrentItemName
-			a.progress.ItemCount += progress.ItemCount
-			a.progress.TotalSize += progress.TotalSize
-		}
-
-		select {
-		case a.progressOutChan <- *a.progress:
-		default:
-		}
-	}
-}
 
 // StoredDir implements Dir item stored on disk
 type StoredDir struct {

--- a/pkg/analyze/wait.go
+++ b/pkg/analyze/wait.go
@@ -5,30 +5,37 @@ import "sync"
 // A WaitGroup waits for a collection of goroutines to finish.
 // In contrast to sync.WaitGroup Add method can be called from a goroutine.
 type WaitGroup struct {
-	wait   sync.Mutex
 	value  int
 	access sync.Mutex
+	done   chan struct{}
 }
 
 // Init prepares the WaitGroup for usage, locks
 func (s *WaitGroup) Init() *WaitGroup {
-	s.wait.Lock()
+	s.done = make(chan struct{})
 	return s
 }
 
 // Add increments value
 func (s *WaitGroup) Add(value int) {
 	s.access.Lock()
+	defer s.access.Unlock()
 	s.value += value
-	s.access.Unlock()
 }
 
 // Done decrements the value by one, if value is 0, lock is released
 func (s *WaitGroup) Done() {
 	s.access.Lock()
+	defer s.access.Unlock()
 	s.value--
-	s.check()
-	s.access.Unlock()
+	if s.value == 0 {
+		select {
+		case <-s.done:
+			// already closed
+		default:
+			close(s.done)
+		}
+	}
 }
 
 // Wait blocks until value is 0
@@ -37,13 +44,6 @@ func (s *WaitGroup) Wait() {
 	isValue := s.value > 0
 	s.access.Unlock()
 	if isValue {
-		s.wait.Lock()
-	}
-}
-
-func (s *WaitGroup) check() {
-	if s.value == 0 {
-		s.wait.TryLock()
-		s.wait.Unlock()
+		<-s.done
 	}
 }


### PR DESCRIPTION
This PR addresses several areas for improvement in the `analyze` package:

1. **Concurrency Fixes**: The `Dir` struct now uses a `sync.RWMutex` to protect its `Files` slice and aggregate statistics (`Size`, `Usage`, `ItemCount`, `Mtime`). This is crucial because `ParallelAnalyzer` and `ParallelStableOrderAnalyzer` modify these fields concurrently. The `RemoveFile` and `RemoveFileByName` methods were also updated to safely update ancestor stats by locking each directory in the parent chain individually.

2. **Synchronization Reliability**: The custom `WaitGroup` implementation in `pkg/analyze/wait.go` was refactored to use a channel-based signaling mechanism (`done chan struct{}`). The previous mutex-based approach was prone to illegal `Unlock()` calls and panics. The new implementation is more idiomatic and correctly handles multiple waiters.

3. **Code Refactoring**: A new `BaseAnalyzer` struct was introduced to hold shared state and implement common methods for progress tracking and configuration. This allowed for significant reduction in code duplication across all analyzer implementations (`Parallel`, `Sequential`, `Sqlite`, `Stored`, and `ParallelStableOrder`). All analyzers were updated to embed `BaseAnalyzer` and use its methods for `SetFollowSymlinks`, `SetShowAnnexedSize`, `GetProgressChan`, etc.

All tests in the repository pass after these changes.

---
*PR created automatically by Jules for task [6897610794845935839](https://jules.google.com/task/6897610794845935839) started by @dundee*