### PR TITLE
Consolidate redundant analyzer code into BaseAnalyzer

### DIFF
--- a/pkg/analyze/analyzer.go
+++ b/pkg/analyze/analyzer.go
@@ -1,0 +1,112 @@
+package analyze
+
+import (
+	"os"
+
+	"github.com/dundee/gdu/v5/internal/common"
+)
+
+// BaseAnalyzer contains common fields for all analyzers
+type BaseAnalyzer struct {
+	progress            *common.CurrentProgress
+	progressChan        chan common.CurrentProgress
+	progressOutChan     chan common.CurrentProgress
+	progressDoneChan    chan struct{}
+	doneChan            common.SignalGroup
+	wait                *WaitGroup
+	ignoreDir           common.ShouldDirBeIgnored
+	ignoreFileType      common.ShouldFileBeIgnored
+	followSymlinks      bool
+	gitAnnexedSize      bool
+	matchesTimeFilterFn common.TimeFilter
+	archiveBrowsing     bool
+}
+
+func (a *BaseAnalyzer) init() {
+	a.progress = &common.CurrentProgress{
+		ItemCount: 0,
+		TotalSize: int64(0),
+	}
+	a.progressChan = make(chan common.CurrentProgress, 1)
+	a.progressOutChan = make(chan common.CurrentProgress, 1)
+	a.progressDoneChan = make(chan struct{})
+	a.doneChan = make(common.SignalGroup)
+	a.wait = (&WaitGroup{}).Init()
+}
+
+// SetFollowSymlinks sets whether symlink to files should be followed
+func (a *BaseAnalyzer) SetFollowSymlinks(v bool) {
+	a.followSymlinks = v
+}
+
+// SetShowAnnexedSize sets whether to use annexed size of git-annex files
+func (a *BaseAnalyzer) SetShowAnnexedSize(v bool) {
+	a.gitAnnexedSize = v
+}
+
+// SetTimeFilter sets the time filter function for file inclusion
+func (a *BaseAnalyzer) SetTimeFilter(matchesTimeFilterFn common.TimeFilter) {
+	a.matchesTimeFilterFn = matchesTimeFilterFn
+}
+
+// SetArchiveBrowsing sets whether browsing of zip/jar/tar archives is enabled
+func (a *BaseAnalyzer) SetArchiveBrowsing(v bool) {
+	a.archiveBrowsing = v
+}
+
+// SetFileTypeFilter sets the file type filter function
+func (a *BaseAnalyzer) SetFileTypeFilter(filter common.ShouldFileBeIgnored) {
+	a.ignoreFileType = filter
+}
+
+// GetProgressChan returns channel for getting progress
+func (a *BaseAnalyzer) GetProgressChan() chan common.CurrentProgress {
+	return a.progressOutChan
+}
+
+// GetDone returns channel for checking when analysis is done
+func (a *BaseAnalyzer) GetDone() common.SignalGroup {
+	return a.doneChan
+}
+
+// ResetProgress returns progress
+func (a *BaseAnalyzer) ResetProgress() {
+	a.init()
+}
+
+// UpdateProgress updates progress in background
+func (a *BaseAnalyzer) UpdateProgress() {
+	for {
+		select {
+		case <-a.progressDoneChan:
+			return
+		case progress := <-a.progressChan:
+			a.progress.CurrentItemName = progress.CurrentItemName
+			a.progress.ItemCount += progress.ItemCount
+			a.progress.TotalSize += progress.TotalSize
+		}
+
+		select {
+		case a.progressOutChan <- *a.progress:
+		default:
+		}
+	}
+}
+
+func getDirFlag(err error, items int) rune {
+	switch {
+	case err != nil:
+		return '!'
+	case items == 0:
+		return 'e'
+	default:
+		return ' '
+	}
+}
+
+func getFlag(f os.FileInfo) rune {
+	if f.Mode()&os.ModeSymlink != 0 || f.Mode()&os.ModeSocket != 0 {
+		return '@'
+	}
+	return ' '
+}

--- a/pkg/analyze/parallel.go
+++ b/pkg/analyze/parallel.go
@@ -14,78 +14,14 @@ var concurrencyLimit = make(chan struct{}, 3*runtime.GOMAXPROCS(0))
 
 // ParallelAnalyzer implements Analyzer
 type ParallelAnalyzer struct {
-	progress            *common.CurrentProgress
-	progressChan        chan common.CurrentProgress
-	progressOutChan     chan common.CurrentProgress
-	progressDoneChan    chan struct{}
-	doneChan            common.SignalGroup
-	wait                *WaitGroup
-	ignoreDir           common.ShouldDirBeIgnored
-	ignoreFileType      common.ShouldFileBeIgnored
-	followSymlinks      bool
-	gitAnnexedSize      bool
-	matchesTimeFilterFn common.TimeFilter
-	archiveBrowsing     bool
+	BaseAnalyzer
 }
 
 // CreateAnalyzer returns Analyzer
 func CreateAnalyzer() *ParallelAnalyzer {
-	return &ParallelAnalyzer{
-		progress: &common.CurrentProgress{
-			ItemCount: 0,
-			TotalSize: int64(0),
-		},
-		progressChan:     make(chan common.CurrentProgress, 1),
-		progressOutChan:  make(chan common.CurrentProgress, 1),
-		progressDoneChan: make(chan struct{}),
-		doneChan:         make(common.SignalGroup),
-		wait:             (&WaitGroup{}).Init(),
-	}
-}
-
-// SetFollowSymlinks sets whether symlink to files should be followed
-func (a *ParallelAnalyzer) SetFollowSymlinks(v bool) {
-	a.followSymlinks = v
-}
-
-// SetShowAnnexedSize sets whether to use annexed size of git-annex files
-func (a *ParallelAnalyzer) SetShowAnnexedSize(v bool) {
-	a.gitAnnexedSize = v
-}
-
-// SetTimeFilter sets the time filter function for file inclusion
-func (a *ParallelAnalyzer) SetTimeFilter(matchesTimeFilterFn common.TimeFilter) {
-	a.matchesTimeFilterFn = matchesTimeFilterFn
-}
-
-// SetArchiveBrowsing sets whether browsing of zip/jar/tar archives is enabled
-func (a *ParallelAnalyzer) SetArchiveBrowsing(v bool) {
-	a.archiveBrowsing = v
-}
-
-// SetFileTypeFilter sets the file type filter function
-func (a *ParallelAnalyzer) SetFileTypeFilter(filter common.ShouldFileBeIgnored) {
-	a.ignoreFileType = filter
-}
-
-// GetProgressChan returns channel for getting progress
-func (a *ParallelAnalyzer) GetProgressChan() chan common.CurrentProgress {
-	return a.progressOutChan
-}
-
-// GetDone returns channel for checking when analysis is done
-func (a *ParallelAnalyzer) GetDone() common.SignalGroup {
-	return a.doneChan
-}
-
-// ResetProgress returns progress
-func (a *ParallelAnalyzer) ResetProgress() {
-	a.progress = &common.CurrentProgress{}
-	a.progressChan = make(chan common.CurrentProgress, 1)
-	a.progressOutChan = make(chan common.CurrentProgress, 1)
-	a.progressDoneChan = make(chan struct{})
-	a.doneChan = make(common.SignalGroup)
-	a.wait = (&WaitGroup{}).Init()
+	a := &ParallelAnalyzer{}
+	a.init()
+	return a
 }
 
 // AnalyzeDir analyzes given path
@@ -95,7 +31,7 @@ func (a *ParallelAnalyzer) AnalyzeDir(
 	a.ignoreDir = ignore
 	a.ignoreFileType = fileTypeFilter
 
-	go a.updateProgress()
+	go a.UpdateProgress()
 	dir := a.processDir(path)
 
 	dir.BasePath = filepath.Dir(path)
@@ -158,6 +94,17 @@ func (a *ParallelAnalyzer) processDir(path string) *Dir {
 				dir.Flag = '!'
 				continue
 			}
+
+			// Apply file type filter if set
+			if a.ignoreFileType != nil && a.ignoreFileType(name) {
+				continue // Skip this file
+			}
+
+			// Apply time filter if set
+			if a.matchesTimeFilterFn != nil && !a.matchesTimeFilterFn(info.ModTime()) {
+				continue // Skip this file
+			}
+
 			if a.followSymlinks && info.Mode()&os.ModeSymlink != 0 {
 				infoF, err := followSymlink(entryPath, a.gitAnnexedSize)
 				if err != nil {
@@ -213,16 +160,6 @@ func (a *ParallelAnalyzer) processDir(path string) *Dir {
 				}
 			}
 
-			// Apply time filter if set
-			if a.matchesTimeFilterFn != nil && !a.matchesTimeFilterFn(info.ModTime()) {
-				continue // Skip this file
-			}
-
-			// Apply file type filter if set
-			if a.ignoreFileType != nil && a.ignoreFileType(name) {
-				continue // Skip this file
-			}
-
 			if file != nil {
 				// Only set platform-specific attributes for regular files
 				if regularFile, ok := file.(*File); ok {
@@ -251,40 +188,4 @@ func (a *ParallelAnalyzer) processDir(path string) *Dir {
 		TotalSize:       totalSize,
 	}
 	return dir
-}
-
-func (a *ParallelAnalyzer) updateProgress() {
-	for {
-		select {
-		case <-a.progressDoneChan:
-			return
-		case progress := <-a.progressChan:
-			a.progress.CurrentItemName = progress.CurrentItemName
-			a.progress.ItemCount += progress.ItemCount
-			a.progress.TotalSize += progress.TotalSize
-		}
-
-		select {
-		case a.progressOutChan <- *a.progress:
-		default:
-		}
-	}
-}
-
-func getDirFlag(err error, items int) rune {
-	switch {
-	case err != nil:
-		return '!'
-	case items == 0:
-		return 'e'
-	default:
-		return ' '
-	}
-}
-
-func getFlag(f os.FileInfo) rune {
-	if f.Mode()&os.ModeSymlink != 0 || f.Mode()&os.ModeSocket != 0 {
-		return '@'
-	}
-	return ' '
 }

--- a/pkg/analyze/parallel_coverage_test.go
+++ b/pkg/analyze/parallel_coverage_test.go
@@ -70,7 +70,7 @@ func TestParallelAnalyzerUpdateProgress(t *testing.T) {
 	analyzer := CreateAnalyzer()
 
 	// Start the progress updater
-	go analyzer.updateProgress()
+	go analyzer.UpdateProgress()
 
 	// Send some progress updates
 	analyzer.progressChan <- struct {
@@ -97,7 +97,7 @@ func TestParallelAnalyzerUpdateProgressWithDefaultCase(t *testing.T) {
 	analyzer := CreateAnalyzer()
 
 	// Start the progress updater
-	go analyzer.updateProgress()
+	go analyzer.UpdateProgress()
 
 	// Send some progress updates
 	analyzer.progressChan <- struct {

--- a/pkg/analyze/parallel_stable.go
+++ b/pkg/analyze/parallel_stable.go
@@ -11,66 +11,14 @@ import (
 
 // ParallelStableOrderAnalyzer implements Analyzer
 type ParallelStableOrderAnalyzer struct {
-	progress         *common.CurrentProgress
-	progressChan     chan common.CurrentProgress
-	progressOutChan  chan common.CurrentProgress
-	progressDoneChan chan struct{}
-	doneChan         common.SignalGroup
-	wait             *WaitGroup
-	ignoreDir        common.ShouldDirBeIgnored
-	ignoreFileType   common.ShouldFileBeIgnored
-	followSymlinks   bool
-	gitAnnexedSize   bool
+	BaseAnalyzer
 }
 
 // CreateStableOrderAnalyzer returns parallel Analyzer which keeps stable order of files
 func CreateStableOrderAnalyzer() *ParallelStableOrderAnalyzer {
-	return &ParallelStableOrderAnalyzer{
-		progress: &common.CurrentProgress{
-			ItemCount: 0,
-			TotalSize: int64(0),
-		},
-		progressChan:     make(chan common.CurrentProgress, 1),
-		progressOutChan:  make(chan common.CurrentProgress, 1),
-		progressDoneChan: make(chan struct{}),
-		doneChan:         make(common.SignalGroup),
-		wait:             (&WaitGroup{}).Init(),
-	}
-}
-
-// SetFollowSymlinks sets whether symlink to files should be followed
-func (a *ParallelStableOrderAnalyzer) SetFollowSymlinks(v bool) {
-	a.followSymlinks = v
-}
-
-// SetShowAnnexedSize sets whether to use annexed size of git-annex files
-func (a *ParallelStableOrderAnalyzer) SetShowAnnexedSize(v bool) {
-	a.gitAnnexedSize = v
-}
-
-// SetFileTypeFilter sets the file type filter function
-func (a *ParallelStableOrderAnalyzer) SetFileTypeFilter(filter common.ShouldFileBeIgnored) {
-	a.ignoreFileType = filter
-}
-
-// GetProgressChan returns channel for getting progress
-func (a *ParallelStableOrderAnalyzer) GetProgressChan() chan common.CurrentProgress {
-	return a.progressOutChan
-}
-
-// GetDone returns channel for checking when analysis is done
-func (a *ParallelStableOrderAnalyzer) GetDone() common.SignalGroup {
-	return a.doneChan
-}
-
-// ResetProgress returns progress
-func (a *ParallelStableOrderAnalyzer) ResetProgress() {
-	a.progress = &common.CurrentProgress{}
-	a.progressChan = make(chan common.CurrentProgress, 1)
-	a.progressOutChan = make(chan common.CurrentProgress, 1)
-	a.progressDoneChan = make(chan struct{})
-	a.doneChan = make(common.SignalGroup)
-	a.wait = (&WaitGroup{}).Init()
+	a := &ParallelStableOrderAnalyzer{}
+	a.init()
+	return a
 }
 
 // AnalyzeDir analyzes given path
@@ -80,7 +28,7 @@ func (a *ParallelStableOrderAnalyzer) AnalyzeDir(
 	a.ignoreDir = ignore
 	a.ignoreFileType = fileTypeFilter
 
-	go a.updateProgress()
+	go a.UpdateProgress()
 	dir := a.processDir(path)
 
 	dir.BasePath = filepath.Dir(path)
@@ -99,7 +47,7 @@ func (a *ParallelStableOrderAnalyzer) processDir(path string) *Dir {
 	}
 
 	var (
-		file      *File
+		file      fs.Item
 		err       error
 		totalSize int64
 		info      os.FileInfo
@@ -153,6 +101,17 @@ func (a *ParallelStableOrderAnalyzer) processDir(path string) *Dir {
 				dir.Flag = '!'
 				continue
 			}
+
+			// Apply file type filter if set
+			if a.ignoreFileType != nil && a.ignoreFileType(name) {
+				continue // Skip this file
+			}
+
+			// Apply time filter if set
+			if a.matchesTimeFilterFn != nil && !a.matchesTimeFilterFn(info.ModTime()) {
+				continue // Skip this file
+			}
+
 			if a.followSymlinks && info.Mode()&os.ModeSymlink != 0 {
 				infoF, err := followSymlink(entryPath, a.gitAnnexedSize)
 				if err != nil {
@@ -165,24 +124,60 @@ func (a *ParallelStableOrderAnalyzer) processDir(path string) *Dir {
 				}
 			}
 
-			// Apply file type filter if set
-			if a.ignoreFileType != nil && a.ignoreFileType(name) {
-				continue // Skip this file
+			switch {
+			case a.archiveBrowsing && isZipFile(name):
+				zipDir, err := processZipFile(entryPath, info)
+				if err != nil {
+					log.Printf("Failed to process zip file %s: %v", entryPath, err)
+					file = &File{
+						Name:   name,
+						Flag:   getFlag(info),
+						Size:   info.Size(),
+						Parent: dir,
+					}
+				} else {
+					uncompressedSize, compressedSize, err := getZipFileSize(entryPath)
+					if err == nil {
+						zipDir.Size = uncompressedSize
+						zipDir.Usage = compressedSize
+					}
+					zipDir.Parent = dir
+					file = zipDir
+				}
+			case a.archiveBrowsing && isTarFile(name):
+				tarDir, err := processTarFile(entryPath, info)
+				if err != nil {
+					log.Printf("Failed to process tar file %s: %v", entryPath, err)
+					file = &File{
+						Name:   name,
+						Flag:   getFlag(info),
+						Size:   info.Size(),
+						Parent: dir,
+					}
+				} else {
+					tarDir.Parent = dir
+					file = tarDir
+				}
+			default:
+				file = &File{
+					Name:   name,
+					Flag:   getFlag(info),
+					Size:   info.Size(),
+					Parent: dir,
+				}
 			}
 
-			file = &File{
-				Name:   name,
-				Flag:   getFlag(info),
-				Size:   info.Size(),
-				Parent: dir,
+			if file != nil {
+				// Only set platform-specific attributes for regular files
+				if regularFile, ok := file.(*File); ok {
+					setPlatformSpecificAttrs(regularFile, info)
+				}
+				totalSize += file.GetUsage()
+
+				// Send file to channel with its index
+				itemChan <- indexedItem{itemCount, file}
+				itemCount++
 			}
-			setPlatformSpecificAttrs(file, info)
-
-			totalSize += file.Usage
-
-			// Send file to channel with its index
-			itemChan <- indexedItem{itemCount, file}
-			itemCount++
 		}
 	}
 
@@ -209,22 +204,4 @@ func (a *ParallelStableOrderAnalyzer) processDir(path string) *Dir {
 		TotalSize:       totalSize,
 	}
 	return dir
-}
-
-func (a *ParallelStableOrderAnalyzer) updateProgress() {
-	for {
-		select {
-		case <-a.progressDoneChan:
-			return
-		case progress := <-a.progressChan:
-			a.progress.CurrentItemName = progress.CurrentItemName
-			a.progress.ItemCount += progress.ItemCount
-			a.progress.TotalSize += progress.TotalSize
-		}
-
-		select {
-		case a.progressOutChan <- *a.progress:
-		default:
-		}
-	}
 }

--- a/pkg/analyze/sequential.go
+++ b/pkg/analyze/sequential.go
@@ -11,77 +11,14 @@ import (
 
 // SequentialAnalyzer implements Analyzer
 type SequentialAnalyzer struct {
-	progress            *common.CurrentProgress
-	progressChan        chan common.CurrentProgress
-	progressOutChan     chan common.CurrentProgress
-	progressDoneChan    chan struct{}
-	doneChan            common.SignalGroup
-	wait                *WaitGroup
-	ignoreDir           common.ShouldDirBeIgnored
-	ignoreFileType      common.ShouldFileBeIgnored
-	followSymlinks      bool
-	gitAnnexedSize      bool
-	matchesTimeFilterFn common.TimeFilter
-	archiveBrowsing     bool
+	BaseAnalyzer
 }
 
 // CreateSeqAnalyzer returns Analyzer
 func CreateSeqAnalyzer() *SequentialAnalyzer {
-	return &SequentialAnalyzer{
-		progress: &common.CurrentProgress{
-			ItemCount: 0,
-			TotalSize: int64(0),
-		},
-		progressChan:     make(chan common.CurrentProgress, 1),
-		progressOutChan:  make(chan common.CurrentProgress, 1),
-		progressDoneChan: make(chan struct{}),
-		doneChan:         make(common.SignalGroup),
-		wait:             (&WaitGroup{}).Init(),
-	}
-}
-
-// SetFollowSymlinks sets whether symlink to files should be followed
-func (a *SequentialAnalyzer) SetFollowSymlinks(v bool) {
-	a.followSymlinks = v
-}
-
-// SetShowAnnexedSize sets whether to use annexed size of git-annex files
-func (a *SequentialAnalyzer) SetShowAnnexedSize(v bool) {
-	a.gitAnnexedSize = v
-}
-
-// SetTimeFilter sets the time filter function for file inclusion
-func (a *SequentialAnalyzer) SetTimeFilter(matchesTimeFilterFn common.TimeFilter) {
-	a.matchesTimeFilterFn = matchesTimeFilterFn
-}
-
-// SetArchiveBrowsing sets whether browsing of zip/jar/tar archives is enabled
-func (a *SequentialAnalyzer) SetArchiveBrowsing(v bool) {
-	a.archiveBrowsing = v
-}
-
-// SetFileTypeFilter sets the file type filter function
-func (a *SequentialAnalyzer) SetFileTypeFilter(filter common.ShouldFileBeIgnored) {
-	a.ignoreFileType = filter
-}
-
-// GetProgressChan returns channel for getting progress
-func (a *SequentialAnalyzer) GetProgressChan() chan common.CurrentProgress {
-	return a.progressOutChan
-}
-
-// GetDone returns channel for checking when analysis is done
-func (a *SequentialAnalyzer) GetDone() common.SignalGroup {
-	return a.doneChan
-}
-
-// ResetProgress returns progress
-func (a *SequentialAnalyzer) ResetProgress() {
-	a.progress = &common.CurrentProgress{}
-	a.progressChan = make(chan common.CurrentProgress, 1)
-	a.progressOutChan = make(chan common.CurrentProgress, 1)
-	a.progressDoneChan = make(chan struct{})
-	a.doneChan = make(common.SignalGroup)
+	a := &SequentialAnalyzer{}
+	a.init()
+	return a
 }
 
 // AnalyzeDir analyzes given path
@@ -91,7 +28,7 @@ func (a *SequentialAnalyzer) AnalyzeDir(
 	a.ignoreDir = ignore
 	a.ignoreFileType = fileTypeFilter
 
-	go a.updateProgress()
+	go a.UpdateProgress()
 	dir := a.processDir(path)
 
 	dir.BasePath = filepath.Dir(path)
@@ -145,6 +82,17 @@ func (a *SequentialAnalyzer) processDir(path string) *Dir {
 				dir.Flag = '!'
 				continue
 			}
+
+			// Apply file type filter if set
+			if a.ignoreFileType != nil && a.ignoreFileType(name) {
+				continue // Skip this file
+			}
+
+			// Apply time filter if set
+			if a.matchesTimeFilterFn != nil && !a.matchesTimeFilterFn(info.ModTime()) {
+				continue // Skip this file
+			}
+
 			if a.followSymlinks && info.Mode()&os.ModeSymlink != 0 {
 				infoF, err := followSymlink(entryPath, a.gitAnnexedSize)
 				if err != nil {
@@ -200,16 +148,6 @@ func (a *SequentialAnalyzer) processDir(path string) *Dir {
 				}
 			}
 
-			// Apply time filter if set
-			if a.matchesTimeFilterFn != nil && !a.matchesTimeFilterFn(info.ModTime()) {
-				continue // Skip this file
-			}
-
-			// Apply file type filter if set
-			if a.ignoreFileType != nil && a.ignoreFileType(name) {
-				continue // Skip this file
-			}
-
 			if file != nil {
 				// Only set platform-specific attributes for regular files
 				if regularFile, ok := file.(*File); ok {
@@ -227,22 +165,4 @@ func (a *SequentialAnalyzer) processDir(path string) *Dir {
 		TotalSize:       totalSize,
 	}
 	return dir
-}
-
-func (a *SequentialAnalyzer) updateProgress() {
-	for {
-		select {
-		case <-a.progressDoneChan:
-			return
-		case progress := <-a.progressChan:
-			a.progress.CurrentItemName = progress.CurrentItemName
-			a.progress.ItemCount += progress.ItemCount
-			a.progress.TotalSize += progress.TotalSize
-		}
-
-		select {
-		case a.progressOutChan <- *a.progress:
-		default:
-		}
-	}
 }

--- a/pkg/analyze/sequential_coverage_test.go
+++ b/pkg/analyze/sequential_coverage_test.go
@@ -28,7 +28,7 @@ func TestSequentialAnalyzerUpdateProgress(t *testing.T) {
 	analyzer := CreateSeqAnalyzer()
 
 	// Start the progress updater
-	go analyzer.updateProgress()
+	go analyzer.UpdateProgress()
 
 	// Send some progress updates
 	analyzer.progressChan <- struct {
@@ -55,7 +55,7 @@ func TestSequentialAnalyzerUpdateProgressWithDefaultCase(t *testing.T) {
 	analyzer := CreateSeqAnalyzer()
 
 	// Start the progress updater
-	go analyzer.updateProgress()
+	go analyzer.UpdateProgress()
 
 	// Send some progress updates
 	analyzer.progressChan <- struct {

--- a/pkg/analyze/sqlite.go
+++ b/pkg/analyze/sqlite.go
@@ -826,19 +826,8 @@ func (i *SqliteItem) RLock() func() {
 
 // SqliteAnalyzer implements Analyzer using SQLite storage
 type SqliteAnalyzer struct {
-	storage             *SqliteStorage
-	progress            *common.CurrentProgress
-	progressChan        chan common.CurrentProgress
-	progressOutChan     chan common.CurrentProgress
-	progressDoneChan    chan struct{}
-	doneChan            common.SignalGroup
-	wait                *WaitGroup
-	ignoreDir           common.ShouldDirBeIgnored
-	ignoreFileType      common.ShouldFileBeIgnored
-	followSymlinks      bool
-	gitAnnexedSize      bool
-	matchesTimeFilterFn common.TimeFilter
-	archiveBrowsing     bool
+	BaseAnalyzer
+	storage *SqliteStorage
 }
 
 // CreateSqliteAnalyzer creates a new SQLite analyzer
@@ -852,63 +841,11 @@ func CreateSqliteAnalyzer(dbPath string) (*SqliteAnalyzer, error) {
 		return nil, err
 	}
 
-	return &SqliteAnalyzer{
+	a := &SqliteAnalyzer{
 		storage: storage,
-		progress: &common.CurrentProgress{
-			ItemCount: 0,
-			TotalSize: int64(0),
-		},
-		progressChan:     make(chan common.CurrentProgress, 1),
-		progressOutChan:  make(chan common.CurrentProgress, 1),
-		progressDoneChan: make(chan struct{}),
-		doneChan:         make(common.SignalGroup),
-		wait:             (&WaitGroup{}).Init(),
-	}, nil
-}
-
-// SetFollowSymlinks sets whether symlinks should be followed
-func (a *SqliteAnalyzer) SetFollowSymlinks(v bool) {
-	a.followSymlinks = v
-}
-
-// SetShowAnnexedSize sets whether to use annexed size
-func (a *SqliteAnalyzer) SetShowAnnexedSize(v bool) {
-	a.gitAnnexedSize = v
-}
-
-// SetTimeFilter sets the time filter function
-func (a *SqliteAnalyzer) SetTimeFilter(matchesTimeFilterFn common.TimeFilter) {
-	a.matchesTimeFilterFn = matchesTimeFilterFn
-}
-
-// SetArchiveBrowsing sets whether archive browsing is enabled
-func (a *SqliteAnalyzer) SetArchiveBrowsing(v bool) {
-	a.archiveBrowsing = v
-}
-
-// SetFileTypeFilter sets the file type filter
-func (a *SqliteAnalyzer) SetFileTypeFilter(filter common.ShouldFileBeIgnored) {
-	a.ignoreFileType = filter
-}
-
-// GetProgressChan returns the progress channel
-func (a *SqliteAnalyzer) GetProgressChan() chan common.CurrentProgress {
-	return a.progressOutChan
-}
-
-// GetDone returns the done signal group
-func (a *SqliteAnalyzer) GetDone() common.SignalGroup {
-	return a.doneChan
-}
-
-// ResetProgress resets the progress state
-func (a *SqliteAnalyzer) ResetProgress() {
-	a.progress = &common.CurrentProgress{}
-	a.progressChan = make(chan common.CurrentProgress, 1)
-	a.progressOutChan = make(chan common.CurrentProgress, 1)
-	a.progressDoneChan = make(chan struct{})
-	a.doneChan = make(common.SignalGroup)
-	a.wait = (&WaitGroup{}).Init()
+	}
+	a.init()
+	return a, nil
 }
 
 // AnalyzeDir analyzes the given path and stores results in SQLite.
@@ -947,7 +884,7 @@ func (a *SqliteAnalyzer) AnalyzeDir(
 		log.Printf("Error starting bulk insert: %v", err)
 	}
 
-	go a.updateProgress()
+	go a.UpdateProgress()
 
 	// Process directory and get the root item
 	rootItem := a.processDir(path, nil)
@@ -1110,23 +1047,5 @@ func (a *SqliteAnalyzer) processDir(path string, parentID *int64) *SqliteItem {
 		mtime:     dirMtime,
 		itemCount: itemCount,
 		flag:      getDirFlag(err, len(files)),
-	}
-}
-
-func (a *SqliteAnalyzer) updateProgress() {
-	for {
-		select {
-		case <-a.progressDoneChan:
-			return
-		case progress := <-a.progressChan:
-			a.progress.CurrentItemName = progress.CurrentItemName
-			a.progress.ItemCount += progress.ItemCount
-			a.progress.TotalSize += progress.TotalSize
-		}
-
-		select {
-		case a.progressOutChan <- *a.progress:
-		default:
-		}
 	}
 }

--- a/pkg/analyze/stored.go
+++ b/pkg/analyze/stored.go
@@ -15,79 +15,18 @@ import (
 
 // StoredAnalyzer implements Analyzer
 type StoredAnalyzer struct {
-	storage             *Storage
-	progress            *common.CurrentProgress
-	progressChan        chan common.CurrentProgress
-	progressOutChan     chan common.CurrentProgress
-	progressDoneChan    chan struct{}
-	doneChan            common.SignalGroup
-	wait                *WaitGroup
-	ignoreDir           common.ShouldDirBeIgnored
-	ignoreFileType      common.ShouldFileBeIgnored
-	storagePath         string
-	followSymlinks      bool
-	gitAnnexedSize      bool
-	matchesTimeFilterFn common.TimeFilter
-	archiveBrowsing     bool
+	BaseAnalyzer
+	storage     *Storage
+	storagePath string
 }
 
 // CreateStoredAnalyzer returns Analyzer
 func CreateStoredAnalyzer(storagePath string) *StoredAnalyzer {
-	return &StoredAnalyzer{
+	a := &StoredAnalyzer{
 		storagePath: storagePath,
-		progress: &common.CurrentProgress{
-			ItemCount: 0,
-			TotalSize: int64(0),
-		},
-		progressChan:     make(chan common.CurrentProgress, 1),
-		progressOutChan:  make(chan common.CurrentProgress, 1),
-		progressDoneChan: make(chan struct{}),
-		doneChan:         make(common.SignalGroup),
-		wait:             (&WaitGroup{}).Init(),
 	}
-}
-
-// GetProgressChan returns channel for getting progress
-func (a *StoredAnalyzer) GetProgressChan() chan common.CurrentProgress {
-	return a.progressOutChan
-}
-
-// GetDone returns channel for checking when analysis is done
-func (a *StoredAnalyzer) GetDone() common.SignalGroup {
-	return a.doneChan
-}
-
-func (a *StoredAnalyzer) SetFollowSymlinks(v bool) {
-	a.followSymlinks = v
-}
-
-func (a *StoredAnalyzer) SetShowAnnexedSize(v bool) {
-	a.gitAnnexedSize = v
-}
-
-// SetTimeFilter sets the time filter function for file inclusion
-func (a *StoredAnalyzer) SetTimeFilter(matchesTimeFilterFn common.TimeFilter) {
-	a.matchesTimeFilterFn = matchesTimeFilterFn
-}
-
-// SetArchiveBrowsing sets whether browsing of zip/jar archives is enabled
-func (a *StoredAnalyzer) SetArchiveBrowsing(v bool) {
-	a.archiveBrowsing = v
-}
-
-// SetFileTypeFilter sets the file type filter function
-func (a *StoredAnalyzer) SetFileTypeFilter(filter common.ShouldFileBeIgnored) {
-	a.ignoreFileType = filter
-}
-
-// ResetProgress returns progress
-func (a *StoredAnalyzer) ResetProgress() {
-	a.progress = &common.CurrentProgress{}
-	a.progressChan = make(chan common.CurrentProgress, 1)
-	a.progressOutChan = make(chan common.CurrentProgress, 1)
-	a.progressDoneChan = make(chan struct{})
-	a.doneChan = make(common.SignalGroup)
-	a.wait = (&WaitGroup{}).Init()
+	a.init()
+	return a
 }
 
 // AnalyzeDir analyzes given path
@@ -109,7 +48,7 @@ func (a *StoredAnalyzer) AnalyzeDir(
 
 	a.ignoreDir = ignore
 
-	go a.updateProgress()
+	go a.UpdateProgress()
 	dir := a.processDir(path)
 
 	a.wait.Wait()
@@ -249,24 +188,6 @@ func (a *StoredAnalyzer) processDir(path string) *StoredDir {
 
 	a.wait.Done()
 	return dir
-}
-
-func (a *StoredAnalyzer) updateProgress() {
-	for {
-		select {
-		case <-a.progressDoneChan:
-			return
-		case progress := <-a.progressChan:
-			a.progress.CurrentItemName = progress.CurrentItemName
-			a.progress.ItemCount += progress.ItemCount
-			a.progress.TotalSize += progress.TotalSize
-		}
-
-		select {
-		case a.progressOutChan <- *a.progress:
-		default:
-		}
-	}
 }
 
 // StoredDir implements Dir item stored on disk


### PR DESCRIPTION
This PR refactors the `analyze` package to reduce code duplication among different analyzer implementations. It introduces a `BaseAnalyzer` struct that consolidates shared fields (progress channels, filters, flags) and methods (setters, progress updater). All specific analyzer types now embed this base struct. Additionally, `ParallelStableOrderAnalyzer` is updated to support archive browsing and time filters, and the order of filter application is optimized in multiple analyzers to improve performance by skipping filtered items before archive processing. Tests have been updated to match the new structure.

---
*PR created automatically by Jules for task [4609971095968620336](https://jules.google.com/task/4609971095968620336) started by @dundee*