### PR TITLE
fix: respect --show-apparent-size for file paths in non-interactive mode

### DIFF
--- a/pkg/analyze/file.go
+++ b/pkg/analyze/file.go
@@ -2,6 +2,7 @@ package analyze
 
 import (
 	"iter"
+	"os"
 	"path/filepath"
 	"sort"
 	"sync"
@@ -95,6 +96,17 @@ func (f *File) alreadyCounted(linkedItems fs.HardLinkedItems) bool {
 		linkedItems[mli] = append(linkedItems[mli], f)
 	}
 	return counted
+}
+
+// CreateFileItem creates a File from an os.FileInfo with correct platform-specific attributes
+func CreateFileItem(name string, info os.FileInfo) *File {
+	file := &File{
+		Name: name,
+		Size: info.Size(),
+		Flag: getFlag(info),
+	}
+	setPlatformSpecificAttrs(file, info)
+	return file
 }
 
 // GetItemStats returns 1 as count of items, apparent usage and real usage of this file

--- a/stdout/stdout.go
+++ b/stdout/stdout.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"os"
+	"path/filepath"
 	"runtime"
 	"sync"
 	"time"
@@ -187,6 +189,17 @@ func (ui *UI) ListDevices(getter device.DevicesInfoGetter) error {
 
 // AnalyzePath analyzes recursively disk usage in given path
 func (ui *UI) AnalyzePath(path string, _ fs.Item) error {
+	// When path is a regular file, create a File item directly so that
+	// apparent-size (GetSize) and disk-usage (GetUsage) are both correct.
+	// Running a file through AnalyzeDir + UpdateStats would report the
+	// default 4096-byte directory overhead instead of the real values.
+	info, err := os.Stat(path)
+	if err == nil && info.Mode().IsRegular() {
+		file := analyze.CreateFileItem(filepath.Base(path), info)
+		ui.printTotalItem(file)
+		return nil
+	}
+
 	var (
 		dir             fs.Item
 		wait            sync.WaitGroup

--- a/stdout/stdout_test.go
+++ b/stdout/stdout_test.go
@@ -84,6 +84,46 @@ func TestShowItemCountInNonInteractiveModeWithColorsAndFile(t *testing.T) {
 	assert.Regexp(t, regexp.MustCompile(`(?m)\s+1\s+single$`), out)
 }
 
+
+
+func TestShowSummaryApparentSizeForFilePath(t *testing.T) {
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "small.txt")
+	err := os.WriteFile(filePath, []byte("hello"), 0o644)
+	assert.Nil(t, err)
+
+	output := bytes.NewBuffer(make([]byte, 10))
+
+	// showApparentSize=true, summarize=true
+	ui := CreateStdoutUI(output, false, false, true, false, true, false, false, "", 0, false, 0)
+	err = ui.AnalyzePath(filePath, nil)
+	assert.Nil(t, err)
+
+	out := output.String()
+	// With apparent size, a 5-byte file should show "5 B", not "4.0 KiB"
+	assert.Contains(t, out, "5 B")
+	assert.Contains(t, out, "small.txt")
+}
+
+func TestShowSummaryDiskUsageForFilePath(t *testing.T) {
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "small.txt")
+	err := os.WriteFile(filePath, []byte("hello"), 0o644)
+	assert.Nil(t, err)
+
+	output := bytes.NewBuffer(make([]byte, 10))
+
+	// showApparentSize=false, summarize=true
+	ui := CreateStdoutUI(output, false, false, false, false, true, false, false, "", 0, false, 0)
+	err = ui.AnalyzePath(filePath, nil)
+	assert.Nil(t, err)
+
+	out := output.String()
+	// Without apparent size, should show disk usage (>= 5 bytes, typically 4 KiB)
+	assert.Contains(t, out, "small.txt")
+	assert.NotContains(t, out, "5 B")
+}
+
 func TestShowSummary(t *testing.T) {
 	fin := testdir.CreateTestDir()
 	defer fin()

--- a/stdout/stdout_test.go
+++ b/stdout/stdout_test.go
@@ -84,8 +84,6 @@ func TestShowItemCountInNonInteractiveModeWithColorsAndFile(t *testing.T) {
 	assert.Regexp(t, regexp.MustCompile(`(?m)\s+1\s+single$`), out)
 }
 
-
-
 func TestShowSummaryApparentSizeForFilePath(t *testing.T) {
 	tmpDir := t.TempDir()
 	filePath := filepath.Join(tmpDir, "small.txt")


### PR DESCRIPTION
## Problem

When `gdu` is given a file path directly in non-interactive summarize mode (`-nps`), the `--show-apparent-size` (`-a`) flag is silently ignored. It always returns the disk block size (minimum 4.0 KiB on APFS) instead of the actual file content size.

The flag works correctly for directory paths in the same mode, and works correctly for files when gdu scans a parent directory (`-nap`).

### Reproduce

```sh
# Create a small file (e.g. 6 bytes)
echo "hello" > /tmp/test.txt

# Non-interactive summarize — with -a flag (apparent size, expected: ~6 B, actual: still 4.0 KiB)
gdu -nps -a /tmp/test.txt
```

## Root Cause

When a file path is passed to `AnalyzePath`, it goes through `AnalyzeDir` which calls `processDir`. Since the path is a file, `os.ReadDir` fails and creates an empty `Dir`. `UpdateStats` then sets both `Size` and `Usage` to 4096 (the default directory overhead), overwriting any real values.

The directory-listing code path respects the `--show-apparent-size` flag, but the single-file path does not.

## Fix

- Added `CreateFileItem()` helper in `pkg/analyze/file.go` to build a `File` from `os.FileInfo` with correct platform-specific `Size` and `Usage` attributes.
- In `stdout.AnalyzePath()`, detect when the path is a regular file via `os.Stat` and create a `File` item directly, bypassing the directory analysis pipeline.
- This ensures both `GetSize()` (apparent) and `GetUsage()` (disk) are correct for the single-file case.

## Tests

Added two regression tests in `stdout/stdout_test.go`:
- `TestShowSummaryApparentSizeForFilePath`: verifies `-nps -a /file` shows apparent size (e.g. 5 B)
- `TestShowSummaryDiskUsageForFilePath`: verifies `-nps /file` shows disk usage (not 5 B)

## Note

This fix was AI-assisted.

Fixes #550
