### PR TITLE
feat: load /etc/gdu.yaml as system-wide config

### DIFF
--- a/cmd/gdu/main.go
+++ b/cmd/gdu/main.go
@@ -19,6 +19,11 @@ import (
 	"github.com/dundee/gdu/v5/pkg/device"
 )
 
+const (
+	osWindows = "windows"
+	osPlan9   = "plan9"
+)
+
 var (
 	af        *app.Flags
 	configErr error

--- a/cmd/gdu/main.go
+++ b/cmd/gdu/main.go
@@ -121,7 +121,7 @@ func loadConfig(path string) error {
 
 func initConfig() {
 	// Load system-wide config first (ignored on Windows/Plan9 and when absent).
-	if runtime.GOOS != "windows" && runtime.GOOS != "plan9" {
+	if runtime.GOOS != osWindows && runtime.GOOS != osPlan9 {
 		if err := loadConfig(systemConfigPath); err != nil && !os.IsNotExist(err) {
 			configErr = err
 			return
@@ -213,7 +213,7 @@ func runE(command *cobra.Command, args []string) error {
 		}
 	}
 
-	if runtime.GOOS == "windows" && af.LogFile == "/dev/null" {
+	if runtime.GOOS == osWindows && af.LogFile == "/dev/null" {
 		af.LogFile = "nul"
 	}
 
@@ -241,7 +241,7 @@ func runE(command *cobra.Command, args []string) error {
 	istty := isatty.IsTerminal(os.Stdout.Fd())
 
 	// we are not able to analyze disk usage on Windows and Plan9
-	if runtime.GOOS == "windows" || runtime.GOOS == "plan9" {
+	if runtime.GOOS == osWindows || runtime.GOOS == osPlan9 {
 		af.ShowApparentSize = true
 	}
 

--- a/cmd/gdu/main.go
+++ b/cmd/gdu/main.go
@@ -109,15 +109,33 @@ func init() {
 	setDefaults()
 }
 
-func initConfig() {
-	setConfigFilePath()
-	data, err := os.ReadFile(af.CfgFile)
+var systemConfigPath = "/etc/gdu.yaml"
+
+func loadConfig(path string) error {
+	data, err := os.ReadFile(path)
 	if err != nil {
-		configErr = err
-		return // config file does not exist, return
+		return err
+	}
+	return yaml.Unmarshal(data, &af)
+}
+
+func initConfig() {
+	// Load system-wide config first (ignored on Windows/Plan9 and when absent).
+	if runtime.GOOS != "windows" && runtime.GOOS != "plan9" {
+		if err := loadConfig(systemConfigPath); err != nil && !os.IsNotExist(err) {
+			configErr = err
+			return
+		}
 	}
 
-	configErr = yaml.Unmarshal(data, &af)
+	// Load user config; its values overwrite whatever the system config set.
+	setConfigFilePath()
+	if err := loadConfig(af.CfgFile); err != nil {
+		if !os.IsNotExist(err) {
+			configErr = err
+		}
+		return
+	}
 }
 
 func setDefaults() {

--- a/cmd/gdu/main_test.go
+++ b/cmd/gdu/main_test.go
@@ -1,6 +1,12 @@
 package main
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dundee/gdu/v5/pkg/app"
+)
 
 func TestNoViewFileFlagRegistered(t *testing.T) {
 	flag := rootCmd.Flags().Lookup("no-view-file")
@@ -43,5 +49,63 @@ func TestInteractiveFlagCanBeSet(t *testing.T) {
 
 	if !af.Interactive {
 		t.Fatal("expected Interactive to be true after setting flag")
+	}
+}
+
+func TestInitConfigMalformedSystemConfig(t *testing.T) {
+	// Write invalid YAML to a temp file and point systemConfigPath at it.
+	tmp := filepath.Join(t.TempDir(), "gdu.yaml")
+	if err := os.WriteFile(tmp, []byte(":\tinvalid: yaml: {"), 0o600); err != nil {
+		t.Fatalf("could not write temp config: %v", err)
+	}
+
+	origPath := systemConfigPath
+	origErr := configErr
+	origAf := af
+	t.Cleanup(func() {
+		systemConfigPath = origPath
+		configErr = origErr
+		af = origAf
+	})
+
+	systemConfigPath = tmp
+	af = &app.Flags{}
+	configErr = nil
+
+	initConfig()
+
+	if configErr == nil {
+		t.Fatal("expected configErr to be set for malformed system config, got nil")
+	}
+}
+
+func TestInitConfigMalformedUserConfig(t *testing.T) {
+	// Write invalid YAML to a temp file and pass it via --config-file.
+	tmp := filepath.Join(t.TempDir(), "user.yaml")
+	if err := os.WriteFile(tmp, []byte(":\tinvalid: yaml: {"), 0o600); err != nil {
+		t.Fatalf("could not write temp config: %v", err)
+	}
+
+	origArgs := os.Args
+	origPath := systemConfigPath
+	origErr := configErr
+	origAf := af
+	t.Cleanup(func() {
+		os.Args = origArgs
+		systemConfigPath = origPath
+		configErr = origErr
+		af = origAf
+	})
+
+	// Point system config at a nonexistent path so it is skipped cleanly.
+	systemConfigPath = filepath.Join(t.TempDir(), "nonexistent.yaml")
+	os.Args = []string{"gdu", "--config-file=" + tmp}
+	af = &app.Flags{}
+	configErr = nil
+
+	initConfig()
+
+	if configErr == nil {
+		t.Fatal("expected configErr to be set for malformed user config, got nil")
 	}
 }

--- a/cmd/gdu/main_test.go
+++ b/cmd/gdu/main_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/dundee/gdu/v5/pkg/app"
+	"github.com/dundee/gdu/v5/cmd/gdu/app"
 )
 
 func TestNoViewFileFlagRegistered(t *testing.T) {


### PR DESCRIPTION
Load /etc/gdu.yaml before the user config so admins can set org-wide defaults. User config (~/.gdu.yaml or --config-file) still takes full precedence.

Useful for example on OpenWrt where no-unicode: true should be set for all users.