### PR TITLE
tui: match ncdu delete button order

### DIFF
--- a/tui/marked.go
+++ b/tui/marked.go
@@ -125,13 +125,13 @@ func (ui *UI) confirmDeletionMarked(shouldEmpty bool) {
 				strconv.Itoa(len(ui.markedRows)) +
 				"[::-] items?",
 		).
-		AddButtons([]string{"no", "yes", "don't ask me again"}).
+		AddButtons([]string{"yes", "no", "don't ask me again"}).
 		SetDoneFunc(func(buttonIndex int, buttonLabel string) {
 			switch buttonIndex {
 			case 2:
 				ui.askBeforeDelete = false
 				fallthrough
-			case 1:
+			case 0:
 				ui.deleteMarked(shouldEmpty)
 			}
 			ui.pages.RemovePage("confirm")

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -544,13 +544,13 @@ func (ui *UI) confirmDeletionSelected(shouldEmpty bool) {
 				tview.Escape(selectedFile.GetName()) +
 				"\"?",
 		).
-		AddButtons([]string{"no", "yes", "don't ask me again"}).
+		AddButtons([]string{"yes", "no", "don't ask me again"}).
 		SetDoneFunc(func(buttonIndex int, buttonLabel string) {
 			switch buttonIndex {
 			case 2:
 				ui.askBeforeDelete = false
 				fallthrough
-			case 1:
+			case 0:
 				ui.deleteSelected(shouldEmpty)
 			}
 			ui.pages.RemovePage("confirm")


### PR DESCRIPTION
Users switching from ncdu are accustomed to seeing yes be the first button in the delete confirmation dialog. This commit aligns gdu's UX with ncdu's convention.