### PR TITLE
feat: preview results found so far during a scan (Tab)

### DIFF
--- a/pkg/analyze/analyzer.go
+++ b/pkg/analyze/analyzer.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/dundee/gdu/v5/internal/common"
+	"github.com/dundee/gdu/v5/pkg/fs"
 )
 
 // BaseAnalyzer provides common logic for all analyzers
@@ -14,6 +15,7 @@ type BaseAnalyzer struct {
 	progressItemCount       atomic.Int64
 	progressTotalUsage      atomic.Int64
 	progressCurrentItemName atomic.Value
+	currentDir              atomic.Value
 	doneChan                common.SignalGroup
 	wait                    *WaitGroup
 	ignoreDir               common.ShouldDirBeIgnored
@@ -34,7 +36,26 @@ func (a *BaseAnalyzer) Init() {
 	a.progressItemCount.Store(0)
 	a.progressTotalUsage.Store(0)
 	a.progressCurrentItemName.Store("")
+	a.currentDir.Store((*Dir)(nil))
 	a.progressTicker = time.NewTicker(50 * time.Millisecond)
+}
+
+// setCurrentDir stores the root directory currently being analyzed so it can be
+// inspected (e.g. previewed) while the scan is still running.
+func (a *BaseAnalyzer) setCurrentDir(dir *Dir) {
+	a.currentDir.Store(dir)
+}
+
+// GetCurrentDir returns the root directory being built by the running analysis,
+// or nil if no analysis has started yet. The returned tree is still being
+// mutated by the analyzer, so callers must only read it through the locked
+// accessors (e.g. GetFilesLocked / UpdateStats).
+func (a *BaseAnalyzer) GetCurrentDir() fs.Item {
+	dir, _ := a.currentDir.Load().(*Dir)
+	if dir == nil {
+		return nil
+	}
+	return dir
 }
 
 // SetFollowSymlinks sets whether symlink to files should be followed

--- a/pkg/analyze/file.go
+++ b/pkg/analyze/file.go
@@ -162,6 +162,8 @@ type Dir struct {
 
 // AddFile add item to files
 func (f *Dir) AddFile(item fs.Item) {
+	f.m.Lock()
+	defer f.m.Unlock()
 	f.Files = append(f.Files, item)
 }
 
@@ -245,11 +247,19 @@ func (f *Dir) UpdateStatsWithFileFiltering(linkedItems fs.HardLinkedItems) {
 
 // UpdateStats recursively updates size and item count
 func (f *Dir) updateStats(linkedItems fs.HardLinkedItems, filteringFiles bool) {
+	// Snapshot the file list under the read lock so it is safe to compute stats
+	// even while the analyzer is still appending items in another goroutine
+	// (e.g. when previewing a directory mid-scan).
+	f.m.RLock()
+	files := make(fs.Files, len(f.Files))
+	copy(files, f.Files)
+	f.m.RUnlock()
+
 	totalSize := int64(0)
 	totalUsage := int64(0)
 	var itemCount int64 = 1
 	var hasFiles bool
-	for _, entry := range f.Files {
+	for _, entry := range files {
 		count, size, usage := entry.GetItemStats(linkedItems, filteringFiles)
 		totalSize += size
 		totalUsage += usage
@@ -272,7 +282,7 @@ func (f *Dir) updateStats(linkedItems fs.HardLinkedItems, filteringFiles bool) {
 	}
 
 	// no files, or just empty dirs
-	if len(f.Files) == 0 || (!hasFiles && filteringFiles && itemCount == int64(len(f.Files)+1)) {
+	if len(files) == 0 || (!hasFiles && filteringFiles && itemCount == int64(len(files)+1)) {
 		f.ItemCount = 1
 		f.Size = totalSize + 512
 		f.Usage = 0

--- a/pkg/analyze/parallel.go
+++ b/pkg/analyze/parallel.go
@@ -37,6 +37,7 @@ func (a *ParallelAnalyzer) AnalyzeDir(
 	dir := a.processDir(path)
 
 	dir.BasePath = filepath.Dir(path)
+	a.setCurrentDir(dir)
 	a.wait.Wait()
 
 	a.progressDoneChan <- struct{}{}

--- a/pkg/analyze/preview_race_test.go
+++ b/pkg/analyze/preview_race_test.go
@@ -1,0 +1,83 @@
+package analyze
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/dundee/gdu/v5/internal/common"
+	"github.com/dundee/gdu/v5/pkg/fs"
+	"github.com/stretchr/testify/assert"
+)
+
+// createWideTree builds a tree large enough to keep the parallel analyzer busy
+// so that GetCurrentDir can be read while the scan is still appending to it.
+func createWideTree(t *testing.T) (string, func()) {
+	t.Helper()
+	root, err := os.MkdirTemp("", "gdu-preview-race")
+	assert.NoError(t, err)
+	for i := 0; i < 40; i++ {
+		sub := filepath.Join(root, "dir"+strconv.Itoa(i))
+		assert.NoError(t, os.MkdirAll(filepath.Join(sub, "nested"), os.ModePerm))
+		for j := 0; j < 20; j++ {
+			f := filepath.Join(sub, "f"+strconv.Itoa(j))
+			assert.NoError(t, os.WriteFile(f, []byte("data"), 0o600))
+			nf := filepath.Join(sub, "nested", "f"+strconv.Itoa(j))
+			assert.NoError(t, os.WriteFile(nf, []byte("data"), 0o600))
+		}
+	}
+	return root, func() { _ = os.RemoveAll(root) }
+}
+
+// TestPreviewWhileScanning exercises reading and computing stats on the live
+// directory tree while the analyzer is still building it. Run with -race to
+// detect any unsynchronized access between AddFile and the preview readers.
+func TestPreviewWhileScanning(t *testing.T) {
+	root, fin := createWideTree(t)
+	defer fin()
+
+	analyzer := CreateAnalyzer()
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	// concurrently peek at the partial tree, mirroring what the TUI preview does
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			if cur := analyzer.GetCurrentDir(); cur != nil {
+				cur.UpdateStats(make(fs.HardLinkedItems))
+				var total int64
+				for item := range cur.GetFilesLocked(fs.SortBySize, fs.SortDesc) {
+					total += item.GetSize()
+				}
+				_ = total
+			}
+		}
+	}()
+
+	dir := analyzer.AnalyzeDir(
+		root,
+		func(_, _ string) bool { return false },
+		func(_ string) bool { return false },
+	)
+	close(stop)
+	wg.Wait()
+
+	dir.UpdateStats(make(fs.HardLinkedItems))
+	assert.Equal(t, root, dir.GetPath())
+	// 40 dirs * (20 files + nested dir with 20 files) + nested dirs + root
+	assert.Greater(t, dir.GetItemCount(), int64(40*40))
+
+	// the analyzer must expose the same root it returned
+	var _ common.Analyzer = analyzer
+	assert.Equal(t, dir.GetPath(), analyzer.GetCurrentDir().GetPath())
+}

--- a/pkg/analyze/sequential.go
+++ b/pkg/analyze/sequential.go
@@ -32,6 +32,7 @@ func (a *SequentialAnalyzer) AnalyzeDir(
 	dir := a.processDir(path)
 
 	dir.BasePath = filepath.Dir(path)
+	a.setCurrentDir(dir)
 
 	a.progressDoneChan <- struct{}{}
 	a.doneChan.Broadcast()

--- a/tui/actions.go
+++ b/tui/actions.go
@@ -77,6 +77,7 @@ func (ui *UI) AnalyzePath(path string, parentDir fs.Item) error {
 		AddItem(nil, 0, 1, false)
 
 	ui.pages.AddPage("progress", flex, true, true)
+	ui.progressFlex = flex
 
 	analyzer := ui.Analyzer
 	doneChan := analyzer.GetDone()
@@ -110,6 +111,9 @@ func (ui *UI) AnalyzePath(path string, parentDir fs.Item) error {
 			if d := time.Since(ui.scanStart); d > ui.scanDuration {
 				ui.scanDuration = d
 			}
+			// the finished scan replaces any mid-scan preview
+			ui.previewing = false
+			ui.previewSavedDir = nil
 			ui.currentDir = currentDir
 			ui.showDir()
 			ui.pages.RemovePage("progress")

--- a/tui/keys.go
+++ b/tui/keys.go
@@ -43,9 +43,18 @@ func (ui *UI) keyPressed(key *tcell.EventKey) *tcell.EventKey {
 		return ui.handleConfirmation(key)
 	}
 
+	if ui.previewing {
+		return ui.handlePreviewKeys(key)
+	}
+
 	if ui.pages.HasPage("progress") ||
 		ui.pages.HasPage("deleting") ||
 		ui.pages.HasPage("emptying") {
+		// allow peeking at the results found so far during a scan
+		if key.Key() == tcell.KeyTab && ui.pages.HasPage("progress") {
+			ui.enterPreview()
+			return nil
+		}
 		return key
 	}
 
@@ -239,6 +248,99 @@ func (ui *UI) confirmQuitDialog(printCurrentDirPath bool) {
 	modal.SetBorderColor(tcell.ColorDefault)
 
 	ui.pages.AddPage("confirm", modal, true, true)
+}
+
+// enterPreview switches from the scanning progress modal to a read-only,
+// point-in-time view of the directory tree discovered so far. The view does not
+// auto-refresh: pressing Tab again returns to the progress modal, and entering
+// the preview once more takes a fresh snapshot.
+func (ui *UI) enterPreview() {
+	analyzer, ok := ui.Analyzer.(interface{ GetCurrentDir() fs.Item })
+	if !ok {
+		return
+	}
+	root := analyzer.GetCurrentDir()
+	if root == nil {
+		return // nothing scanned yet
+	}
+
+	// compute aggregated sizes on the partial tree using a throwaway hard-link
+	// map so the running scan's accounting is left untouched
+	root.UpdateStats(make(fs.HardLinkedItems))
+
+	ui.previewing = true
+	ui.previewSavedDir = ui.currentDir
+	ui.currentDir = root
+	ui.markedRows = make(map[int]struct{})
+	ui.ignoredRows = make(map[int]struct{})
+	ui.pages.RemovePage("progress")
+	ui.showDir()
+	ui.table.Select(0, 0)
+	ui.app.SetFocus(ui.table)
+}
+
+// exitPreview leaves the mid-scan preview and restores the scanning progress modal.
+func (ui *UI) exitPreview() {
+	ui.previewing = false
+	ui.currentDir = ui.previewSavedDir
+	ui.previewSavedDir = nil
+	if ui.progressFlex != nil {
+		ui.pages.AddPage("progress", ui.progressFlex, true, true)
+	}
+	ui.app.SetFocus(ui.table)
+}
+
+// handlePreviewKeys handles input while a mid-scan preview is shown. Navigation
+// and sorting are allowed; destructive or external actions are intentionally
+// ignored because the tree is still being built.
+func (ui *UI) handlePreviewKeys(key *tcell.EventKey) *tcell.EventKey {
+	if ui.pages.HasPage("help") {
+		return key
+	}
+
+	if key.Key() == tcell.KeyTab || key.Key() == tcell.KeyEsc {
+		ui.exitPreview()
+		return nil
+	}
+	if key.Key() == tcell.KeyLeft {
+		ui.previewLeft()
+		return nil
+	}
+	if key.Key() == tcell.KeyRight {
+		ui.handleRight()
+		return nil
+	}
+
+	switch key.Rune() {
+	case '?':
+		ui.showHelp()
+		return nil
+	case 'h':
+		ui.previewLeft()
+		return nil
+	case 'l':
+		ui.handleRight()
+		return nil
+	case 's', 'C', 'n', 'M':
+		ui.handleSorting(key)
+		return nil
+	case 'a', 'B', 'c', 'm':
+		ui.handleToggles(key)
+		return nil
+	}
+
+	// up/down/pgup/pgdn and Enter are handled by the table itself
+	return key
+}
+
+// previewLeft navigates to the parent dir within the preview, or leaves the
+// preview when already at its root.
+func (ui *UI) previewLeft() {
+	if ui.currentDir == nil || ui.currentDir.GetParent() == nil {
+		ui.exitPreview()
+		return
+	}
+	ui.fileItemSelected(0, 0)
 }
 
 func (ui *UI) handleHelp(key *tcell.EventKey) *tcell.EventKey {

--- a/tui/keys_test.go
+++ b/tui/keys_test.go
@@ -335,8 +335,8 @@ func TestStopWithPrintingPath(t *testing.T) {
 	assert.Equal(t, "test_dir\n", buff.String())
 }
 
-// analyzedUIForQuit returns a UI with a finished scan so quit behaviour can be tested.
-func analyzedUIForQuit(t *testing.T, buff *bytes.Buffer) *UI {
+// analyzedUI returns a UI with a finished scan, ready for preview tests.
+func analyzedUI(t *testing.T, buff *bytes.Buffer) *UI {
 	t.Helper()
 	simScreen := testapp.CreateSimScreen()
 	t.Cleanup(simScreen.Fini)
@@ -357,7 +357,7 @@ func TestQuitConfirmsAfterLongScan(t *testing.T) {
 	fin := testdir.CreateTestDir()
 	defer fin()
 
-	ui := analyzedUIForQuit(t, &bytes.Buffer{})
+	ui := analyzedUI(t, &bytes.Buffer{})
 	ui.scanDuration = 10 * time.Second // simulate a long scan
 
 	key := ui.keyPressed(tcell.NewEventKey(tcell.KeyRune, 'q', 0))
@@ -369,7 +369,7 @@ func TestQuitImmediateAfterShortScan(t *testing.T) {
 	fin := testdir.CreateTestDir()
 	defer fin()
 
-	ui := analyzedUIForQuit(t, &bytes.Buffer{})
+	ui := analyzedUI(t, &bytes.Buffer{})
 	ui.scanDuration = time.Second // below the confirmation threshold
 
 	key := ui.keyPressed(tcell.NewEventKey(tcell.KeyRune, 'q', 0))
@@ -381,7 +381,7 @@ func TestQuitImmediateWhenConfirmDisabled(t *testing.T) {
 	fin := testdir.CreateTestDir()
 	defer fin()
 
-	ui := analyzedUIForQuit(t, &bytes.Buffer{})
+	ui := analyzedUI(t, &bytes.Buffer{})
 	ui.SetConfirmQuit(false)
 	ui.scanDuration = 10 * time.Second
 
@@ -394,7 +394,7 @@ func TestQuitNotRetriggeredWhileConfirmOpen(t *testing.T) {
 	fin := testdir.CreateTestDir()
 	defer fin()
 
-	ui := analyzedUIForQuit(t, &bytes.Buffer{})
+	ui := analyzedUI(t, &bytes.Buffer{})
 	ui.scanDuration = 10 * time.Second
 
 	assert.Nil(t, ui.keyPressed(tcell.NewEventKey(tcell.KeyRune, 'q', 0)))
@@ -410,7 +410,7 @@ func TestQuitConfirmsDuringLongRunningScan(t *testing.T) {
 	fin := testdir.CreateTestDir()
 	defer fin()
 
-	ui := analyzedUIForQuit(t, &bytes.Buffer{})
+	ui := analyzedUI(t, &bytes.Buffer{})
 	// simulate a scan that is still running and started long ago
 	ui.scanning = true
 	ui.scanStart = time.Now().Add(-10 * time.Second)
@@ -424,7 +424,7 @@ func TestQuitImmediateDuringShortRunningScan(t *testing.T) {
 	fin := testdir.CreateTestDir()
 	defer fin()
 
-	ui := analyzedUIForQuit(t, &bytes.Buffer{})
+	ui := analyzedUI(t, &bytes.Buffer{})
 	// a scan that just started should not block quitting
 	ui.scanning = true
 	ui.scanStart = time.Now()
@@ -439,10 +439,103 @@ func TestDoQuitPrintsCurrentDirPath(t *testing.T) {
 	defer fin()
 
 	buff := &bytes.Buffer{}
-	ui := analyzedUIForQuit(t, buff)
+	ui := analyzedUI(t, buff)
 
 	ui.doQuit(true)
 	assert.Equal(t, "test_dir\n", buff.String())
+}
+
+func TestEnterAndExitPreview(t *testing.T) {
+	fin := testdir.CreateTestDir()
+	defer fin()
+
+	ui := analyzedUI(t, &bytes.Buffer{})
+
+	ui.enterPreview()
+	assert.True(t, ui.previewing)
+	assert.NotNil(t, ui.currentDir)
+	assert.False(t, ui.pages.HasPage("progress"))
+
+	// Tab leaves the preview and restores the scanning progress modal
+	key := ui.keyPressed(tcell.NewEventKey(tcell.KeyTab, 0, 0))
+	assert.Nil(t, key)
+	assert.False(t, ui.previewing)
+	assert.True(t, ui.pages.HasPage("progress"))
+}
+
+func TestTabDuringScanEntersPreview(t *testing.T) {
+	fin := testdir.CreateTestDir()
+	defer fin()
+
+	ui := analyzedUI(t, &bytes.Buffer{})
+	// simulate a scan still in progress: the progress modal is shown
+	ui.pages.AddPage("progress", ui.progressFlex, true, true)
+
+	key := ui.keyPressed(tcell.NewEventKey(tcell.KeyTab, 0, 0))
+	assert.Nil(t, key)
+	assert.True(t, ui.previewing)
+	assert.False(t, ui.pages.HasPage("progress"))
+}
+
+func TestPreviewIgnoresDestructiveKeys(t *testing.T) {
+	fin := testdir.CreateTestDir()
+	defer fin()
+
+	ui := analyzedUI(t, &bytes.Buffer{})
+	ui.enterPreview()
+
+	// delete must not open a confirmation dialog while previewing
+	ui.keyPressed(tcell.NewEventKey(tcell.KeyRune, 'd', 0))
+	assert.False(t, ui.pages.HasPage("confirm"))
+	assert.True(t, ui.previewing)
+}
+
+func TestPreviewNavigation(t *testing.T) {
+	fin := testdir.CreateTestDir()
+	defer fin()
+
+	ui := analyzedUI(t, &bytes.Buffer{})
+	ui.enterPreview()
+	root := ui.currentDir
+	rootPath := ui.currentDirPath
+
+	// drill into the first subdirectory
+	ui.table.Select(0, 0)
+	ui.keyPressed(tcell.NewEventKey(tcell.KeyRune, 'l', 0))
+	assert.NotEqual(t, rootPath, ui.currentDirPath)
+	assert.True(t, ui.previewing)
+
+	// go back up to the root
+	ui.keyPressed(tcell.NewEventKey(tcell.KeyRune, 'h', 0))
+	assert.Equal(t, root, ui.currentDir)
+
+	// at the root, going up again leaves the preview
+	ui.keyPressed(tcell.NewEventKey(tcell.KeyRune, 'h', 0))
+	assert.False(t, ui.previewing)
+}
+
+func TestEnterPreviewNoopWithoutScan(t *testing.T) {
+	simScreen := testapp.CreateSimScreen()
+	defer simScreen.Fini()
+
+	app := testapp.CreateMockedApp(false)
+	ui := CreateUI(app, simScreen, &bytes.Buffer{}, true, true, false, false)
+
+	// nothing has been scanned yet -> no tree to preview
+	ui.enterPreview()
+	assert.False(t, ui.previewing)
+}
+
+func TestEnterPreviewNoopWithUnsupportedAnalyzer(t *testing.T) {
+	simScreen := testapp.CreateSimScreen()
+	defer simScreen.Fini()
+
+	app := testapp.CreateMockedApp(false)
+	ui := CreateUI(app, simScreen, &bytes.Buffer{}, true, true, false, false)
+	ui.Analyzer = &testanalyze.MockedAnalyzer{} // does not expose GetCurrentDir
+
+	ui.enterPreview()
+	assert.False(t, ui.previewing)
 }
 
 func TestSpawnShell(t *testing.T) {

--- a/tui/progress.go
+++ b/tui/progress.go
@@ -61,7 +61,8 @@ func (ui *UI) updateProgress(analyzer common.Analyzer, doneChan common.SignalGro
 					color +
 					delta.String() +
 					"[white:black:-]\nCurrent item: [white:black:b]" +
-					path.ShortenPath(currentItem, ui.currentItemNameMaxLen))
+					path.ShortenPath(currentItem, ui.currentItemNameMaxLen) +
+					"[white:black:-]\n\nPress Tab to preview results found so far")
 			})
 		}(progress.ItemCount, progress.TotalUsage, progress.CurrentItemName)
 	}

--- a/tui/show.go
+++ b/tui/show.go
@@ -50,6 +50,20 @@ Sort by (twice toggles asc/desc):
                [::b]M     [white:black:-]Sort by mtime (asc/desc)`
 )
 
+// currentDirLabelText builds the breadcrumb label shown above the table,
+// annotated when a mid-scan preview is being displayed.
+func (ui *UI) currentDirLabelText() string {
+	label := "[::b] --- " +
+		tview.Escape(
+			strings.TrimPrefix(ui.currentDirPath, build.RootPathPrefix),
+		) +
+		" ---"
+	if ui.previewing {
+		label += "  [::b][yellow]scanning… (preview, Tab to resume)[-]"
+	}
+	return label
+}
+
 // nolint: funlen // Why: complex function
 func (ui *UI) showDir() {
 	var (
@@ -70,11 +84,7 @@ func (ui *UI) showDir() {
 		log.Printf("changing cwd to %s", ui.currentDirPath)
 	}
 
-	ui.currentDirLabel.SetText("[::b] --- " +
-		tview.Escape(
-			strings.TrimPrefix(ui.currentDirPath, build.RootPathPrefix),
-		) +
-		" ---").SetDynamicColors(true)
+	ui.currentDirLabel.SetText(ui.currentDirLabelText()).SetDynamicColors(true)
 
 	ui.table.Clear()
 

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -102,6 +102,9 @@ type UI struct {
 	scanning                bool
 	scanStart               time.Time
 	scanDuration            time.Duration
+	previewing              bool
+	previewSavedDir         fs.Item
+	progressFlex            *tview.Flex
 }
 
 type deleteQueueItem struct {
@@ -446,6 +449,12 @@ func (ui *UI) fileItemSelected(row, column int) {
 	ui.markedRows = make(map[int]struct{})
 	ui.ignoredRows = make(map[int]struct{})
 	ui.showDir()
+
+	// while previewing a mid-scan snapshot there is no stable top dir to anchor
+	// the "select last visited" logic to, so just render the navigated dir
+	if ui.previewing {
+		return
+	}
 
 	if row != 0 || origDir.GetPath() == ui.topDir.GetPath() {
 		return


### PR DESCRIPTION
## Problem

During a scan there is currently no way to look at what has been found — you
have to wait for the whole scan to finish. For very large / slow targets that
can be a long time (see #150, where users describe 53–60 TB scans).

## Change

Pressing **Tab** during a scan opens a read-only, point-in-time view of the
directory tree discovered so far, with real aggregated directory sizes. Pressing
**Tab** (or **Esc**) returns to the progress modal. The scan keeps running in
the background the whole time.

- The preview does **not** auto-refresh — re-entering it takes a fresh snapshot
  (so sizes/sorting do not jump around while you read).
- Navigation (arrows / `hjkl` / Enter) and sorting work; destructive or external
  actions are ignored while previewing, since the tree is still being built.
- The scanning modal shows a `Press Tab to preview results found so far` hint.

## Relation to #150

#150 asks to *stop* a scan and keep the results (to save RAM / time). This PR is
a related step — you can now *inspect* partial results during a scan — but it
intentionally keeps the scan running rather than stopping it. Happy to extend
this toward fully resolving #150 (stop-and-keep) if you would like.

## Implementation

- `analyze`: expose the in-progress root via `BaseAnalyzer.GetCurrentDir`. The
  TUI reads it through an **optional interface assertion**, so the
  `common.Analyzer` interface and its other implementations are untouched.
- `analyze`: `Dir.AddFile` now takes the write lock and `Dir.updateStats` reads
  the file list under the read lock, so computing stats on the live tree while
  the analyzer is still appending is race-free (paired with the existing
  `RLock` in `showDir`). Verified with a dedicated concurrent `-race` test
  (`TestPreviewWhileScanning`).
- `tui`: enter/exit preview, snapshot stats with a throwaway hard-link map, and
  preview-only key handling.

All tests pass under `go test -race ./...`.

Companion PR #593 adds a confirmation before quitting when a long scan would be lost.
