### PR TITLE
fix(report): make JSON export respect -t, --depth and --summarize filters

### DIFF
--- a/cmd/gdu/app/app.go
+++ b/cmd/gdu/app/app.go
@@ -381,6 +381,9 @@ func (a *App) createUI() (UI, error) {
 			!a.Flags.NoColor && a.Istty,
 			!a.Flags.NoProgress && a.Istty,
 			a.Flags.UseSIPrefix,
+			a.Flags.Top,
+			a.Flags.Depth,
+			a.Flags.Summarize,
 		)
 	case a.Flags.ShouldRunInNonInteractiveMode(a.Istty):
 		fixedUnit := ""

--- a/cmd/gdu/app/app_test.go
+++ b/cmd/gdu/app/app_test.go
@@ -437,6 +437,76 @@ func TestAnalyzePathWithExport(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+func TestAnalyzePathWithExportAndTop(t *testing.T) {
+	fin := testdir.CreateTestDir()
+	defer fin()
+	defer func() {
+		os.Remove("output.json")
+	}()
+
+	out, err := runApp(
+		&Flags{LogFile: "/dev/null", OutputFile: "output.json", Top: 2},
+		[]string{"test_dir"},
+		false,
+		testdev.DevicesInfoGetterMock{},
+	)
+
+	assert.Empty(t, out)
+	assert.Nil(t, err)
+
+	content, err := os.ReadFile("output.json")
+	assert.Nil(t, err)
+	assert.Contains(t, string(content), `"name":"file"`)
+	assert.Contains(t, string(content), `"name":"file2"`)
+	assert.NotContains(t, string(content), `"name":"nested"`)
+}
+
+func TestAnalyzePathWithExportAndDepth(t *testing.T) {
+	fin := testdir.CreateTestDir()
+	defer fin()
+	defer func() {
+		os.Remove("output.json")
+	}()
+
+	out, err := runApp(
+		&Flags{LogFile: "/dev/null", OutputFile: "output.json", Depth: 1},
+		[]string{"test_dir"},
+		false,
+		testdev.DevicesInfoGetterMock{},
+	)
+
+	assert.Empty(t, out)
+	assert.Nil(t, err)
+
+	content, err := os.ReadFile("output.json")
+	assert.Nil(t, err)
+	assert.Contains(t, string(content), `"name":"nested"`)
+	assert.NotContains(t, string(content), `"name":"subnested"`)
+}
+
+func TestAnalyzePathWithExportAndSummarize(t *testing.T) {
+	fin := testdir.CreateTestDir()
+	defer fin()
+	defer func() {
+		os.Remove("output.json")
+	}()
+
+	out, err := runApp(
+		&Flags{LogFile: "/dev/null", OutputFile: "output.json", Summarize: true},
+		[]string{"test_dir"},
+		false,
+		testdev.DevicesInfoGetterMock{},
+	)
+
+	assert.Empty(t, out)
+	assert.Nil(t, err)
+
+	content, err := os.ReadFile("output.json")
+	assert.Nil(t, err)
+	assert.Contains(t, string(content), "test_dir")
+	assert.NotContains(t, string(content), `"name":"nested"`)
+}
+
 func TestAnalyzePathWithChdir(t *testing.T) {
 	fin := testdir.CreateTestDir()
 	defer fin()

--- a/report/export.go
+++ b/report/export.go
@@ -27,6 +27,9 @@ type UI struct {
 	red          *color.Color
 	orange       *color.Color
 	writtenChan  chan struct{}
+	top          int
+	depth        int
+	summarize    bool
 }
 
 // CreateExportUI creates UI for stdout
@@ -36,6 +39,9 @@ func CreateExportUI(
 	useColors bool,
 	showProgress bool,
 	useSIPrefix bool,
+	top int,
+	depth int,
+	summarize bool,
 ) *UI {
 	ui := &UI{
 		UI: &common.UI{
@@ -46,6 +52,9 @@ func CreateExportUI(
 		output:       output,
 		exportOutput: exportOutput,
 		writtenChan:  make(chan struct{}),
+		top:          top,
+		depth:        depth,
+		summarize:    summarize,
 	}
 	ui.red = color.New(color.FgRed).Add(color.Bold)
 	ui.orange = color.New(color.FgYellow).Add(color.Bold)
@@ -131,6 +140,78 @@ func (ui *UI) AnalyzePath(path string, _ fs.Item) error {
 	return ui.exportDir(dir, &waitWritten)
 }
 
+func (ui *UI) topDir(dir fs.Item) fs.Item {
+	files := analyze.CollectTopFiles(dir, ui.top)
+
+	topDir := &analyze.Dir{
+		File: &analyze.File{
+			Name:  dir.GetName(),
+			Mtime: dir.GetMtime(),
+		},
+	}
+	if d, ok := dir.(*analyze.Dir); ok {
+		topDir.BasePath = d.BasePath
+	}
+	for _, f := range files {
+		file := *f.(*analyze.File)
+		file.Parent = topDir
+		topDir.AddFile(&file)
+	}
+	topDir.UpdateStats(make(fs.HardLinkedItems, 10))
+	return topDir
+}
+
+func (ui *UI) limitDirByDepth(dir fs.Item, currentDepth int) fs.Item {
+	if d, ok := dir.(*analyze.Dir); ok {
+		limited := &analyze.Dir{
+			File: &analyze.File{
+				Name:   d.GetName(),
+				Mtime:  d.GetMtime(),
+				Parent: d.GetParent(),
+				Size:   d.GetSize(),
+				Usage:  d.GetUsage(),
+			},
+			BasePath:  d.BasePath,
+			ItemCount: d.ItemCount,
+		}
+		if currentDepth == ui.depth {
+			return limited
+		}
+		for f := range d.GetFiles(fs.SortBySize, fs.SortDesc) {
+			if f.IsDir() {
+				child := ui.limitDirByDepth(f, currentDepth+1)
+				if child != nil {
+					child.SetParent(limited)
+					limited.AddFile(child)
+				}
+			} else if currentDepth+1 <= ui.depth {
+				file := *f.(*analyze.File)
+				file.Parent = limited
+				limited.AddFile(&file)
+			}
+		}
+		return limited
+	}
+
+	return dir
+}
+
+func (ui *UI) summarizeDir(dir fs.Item) fs.Item {
+	summary := &analyze.Dir{
+		File: &analyze.File{
+			Name:  dir.GetName(),
+			Mtime: dir.GetMtime(),
+		},
+	}
+	if d, ok := dir.(*analyze.Dir); ok {
+		summary.BasePath = d.BasePath
+		summary.ItemCount = d.ItemCount
+		summary.Size = d.GetSize()
+		summary.Usage = d.GetUsage()
+	}
+	return summary
+}
+
 func (ui *UI) exportDir(dir fs.Item, waitWritten *sync.WaitGroup) error {
 	// Sorting is now handled by GetFiles with sort parameters
 
@@ -144,6 +225,15 @@ func (ui *UI) exportDir(dir fs.Item, waitWritten *sync.WaitGroup) error {
 	buff.Write([]byte(`","timestamp":`))
 	buff.Write([]byte(strconv.FormatInt(time.Now().Unix(), 10)))
 	buff.Write([]byte("},\n"))
+
+	switch {
+	case ui.summarize:
+		dir = ui.summarizeDir(dir)
+	case ui.top > 0:
+		dir = ui.topDir(dir)
+	case ui.depth > 0:
+		dir = ui.limitDirByDepth(dir, 0)
+	}
 
 	if err := dir.EncodeJSON(&buff, true); err != nil {
 		return err

--- a/report/export_linux_test.go
+++ b/report/export_linux_test.go
@@ -27,7 +27,7 @@ func TestReadFromStorage(t *testing.T) {
 	output := bytes.NewBuffer(make([]byte, 10))
 	reportOutput := bytes.NewBuffer(make([]byte, 10))
 
-	ui := CreateExportUI(output, reportOutput, false, true, false)
+	ui := CreateExportUI(output, reportOutput, false, true, false, 0, 0, false)
 	ui.SetIgnoreDirPaths([]string{"/xxx"})
 	ui.SetAnalyzer(analyze.CreateStoredAnalyzer(storagePath))
 	err := ui.AnalyzePath("test_dir", nil)
@@ -47,7 +47,7 @@ func TestReadFromStorageWithErr(t *testing.T) {
 	output := bytes.NewBuffer(make([]byte, 10))
 	reportOutput := bytes.NewBuffer(make([]byte, 10))
 
-	ui := CreateExportUI(output, reportOutput, false, false, false)
+	ui := CreateExportUI(output, reportOutput, false, false, false, 0, 0, false)
 	ui.SetIgnoreDirPaths([]string{"/xxx"})
 	err := ui.ReadFromStorage(storagePath, "test_dir")
 

--- a/report/export_test.go
+++ b/report/export_test.go
@@ -8,7 +8,9 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/dundee/gdu/v5/internal/testdir"
+	"github.com/dundee/gdu/v5/pkg/analyze"
 	"github.com/dundee/gdu/v5/pkg/device"
+	"github.com/dundee/gdu/v5/pkg/fs"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -23,7 +25,7 @@ func TestAnalyzePath(t *testing.T) {
 	output := bytes.NewBuffer(make([]byte, 10))
 	reportOutput := bytes.NewBuffer(make([]byte, 10))
 
-	ui := CreateExportUI(output, reportOutput, false, false, false)
+	ui := CreateExportUI(output, reportOutput, false, false, false, 0, 0, false)
 	ui.SetIgnoreDirPaths([]string{"/xxx"})
 	err := ui.AnalyzePath("test_dir", nil)
 	assert.Nil(t, err)
@@ -33,14 +35,258 @@ func TestAnalyzePath(t *testing.T) {
 	assert.Contains(t, reportOutput.String(), `"name":"nested"`)
 }
 
-func TestAnalyzePathWithProgress(t *testing.T) {
+func TestAnalyzePathWithTop(t *testing.T) {
 	fin := testdir.CreateTestDir()
 	defer fin()
 
 	output := bytes.NewBuffer(make([]byte, 10))
 	reportOutput := bytes.NewBuffer(make([]byte, 10))
 
-	ui := CreateExportUI(output, reportOutput, true, true, true)
+	ui := CreateExportUI(output, reportOutput, false, false, false, 2, 0, false)
+	ui.SetIgnoreDirPaths([]string{"/xxx"})
+	err := ui.AnalyzePath("test_dir", nil)
+	assert.Nil(t, err)
+	err = ui.StartUILoop()
+
+	assert.Nil(t, err)
+	assert.Contains(t, reportOutput.String(), `"name":"file"`)
+	assert.Contains(t, reportOutput.String(), `"name":"file2"`)
+	assert.NotContains(t, reportOutput.String(), `"name":"nested"`)
+	assert.NotContains(t, reportOutput.String(), `"name":"subnested"`)
+}
+
+func TestAnalyzePathWithTopAndTypeFilter(t *testing.T) {
+	fin := testdir.CreateTestDir()
+	defer fin()
+
+	output := bytes.NewBuffer(make([]byte, 10))
+	reportOutput := bytes.NewBuffer(make([]byte, 10))
+
+	ui := CreateExportUI(output, reportOutput, false, false, false, 10, 0, false)
+	ui.SetIgnoreDirPaths([]string{"/xxx"})
+	ui.SetIncludeTypes([]string{"none"})
+	err := ui.AnalyzePath("test_dir", nil)
+	assert.Nil(t, err)
+	err = ui.StartUILoop()
+
+	assert.Nil(t, err)
+	assert.NotContains(t, reportOutput.String(), `"name":"file"`)
+	assert.NotContains(t, reportOutput.String(), `"name":"file2"`)
+}
+
+func TestAnalyzePathWithDepth(t *testing.T) {
+	fin := testdir.CreateTestDir()
+	defer fin()
+
+	var output bytes.Buffer
+	var reportOutput bytes.Buffer
+
+	ui := CreateExportUI(&output, &reportOutput, false, false, false, 0, 2, false)
+	ui.SetIgnoreDirPaths([]string{"/xxx"})
+	err := ui.AnalyzePath("test_dir", nil)
+	assert.Nil(t, err)
+	err = ui.StartUILoop()
+
+	assert.Nil(t, err)
+	assert.Contains(t, reportOutput.String(), `"name":"nested"`)
+	assert.Contains(t, reportOutput.String(), `"name":"file2"`)
+	assert.Contains(t, reportOutput.String(), `"name":"subnested"`)
+}
+
+func TestAnalyzePathWithDepthOne(t *testing.T) {
+	fin := testdir.CreateTestDir()
+	defer fin()
+
+	var output bytes.Buffer
+	var reportOutput bytes.Buffer
+
+	ui := CreateExportUI(&output, &reportOutput, false, false, false, 0, 1, false)
+	ui.SetIgnoreDirPaths([]string{"/xxx"})
+	err := ui.AnalyzePath("test_dir", nil)
+	assert.Nil(t, err)
+	err = ui.StartUILoop()
+
+	assert.Nil(t, err)
+	assert.Contains(t, reportOutput.String(), `"name":"nested"`)
+	assert.NotContains(t, reportOutput.String(), `"name":"file2"`)
+	assert.NotContains(t, reportOutput.String(), `"name":"subnested"`)
+	assert.NotContains(t, reportOutput.String(), `"name":"file"`)
+
+	readDir, err := ReadAnalysis(bytes.NewReader(reportOutput.Bytes()))
+	assert.Nil(t, err)
+	assert.Equal(t, "test_dir", readDir.GetName())
+
+	var nested fs.Item
+	for f := range readDir.GetFiles(fs.SortByName, fs.SortAsc) {
+		if f.GetName() == "nested" {
+			nested = f
+		}
+	}
+	assert.NotNil(t, nested)
+	assert.True(t, nested.IsDir())
+}
+
+func TestAnalyzePathWithSummarize(t *testing.T) {
+	fin := testdir.CreateTestDir()
+	defer fin()
+
+	var output bytes.Buffer
+	var reportOutput bytes.Buffer
+
+	ui := CreateExportUI(&output, &reportOutput, false, false, false, 0, 0, true)
+	ui.SetIgnoreDirPaths([]string{"/xxx"})
+	err := ui.AnalyzePath("test_dir", nil)
+	assert.Nil(t, err)
+	err = ui.StartUILoop()
+
+	assert.Nil(t, err)
+	assert.Contains(t, reportOutput.String(), `"name":"test_dir"`)
+	assert.NotContains(t, reportOutput.String(), `"name":"nested"`)
+	assert.NotContains(t, reportOutput.String(), `"name":"file"`)
+}
+
+func TestAnalyzePathWithTopRoundTrip(t *testing.T) {
+	fin := testdir.CreateTestDir()
+	defer fin()
+
+	var output bytes.Buffer
+	var reportOutput bytes.Buffer
+
+	ui := CreateExportUI(&output, &reportOutput, false, false, false, 2, 0, false)
+	ui.SetIgnoreDirPaths([]string{"/xxx"})
+	err := ui.AnalyzePath("test_dir", nil)
+	assert.Nil(t, err)
+	err = ui.StartUILoop()
+	assert.Nil(t, err)
+
+	result := reportOutput.Bytes()
+	assert.Contains(t, string(result), `"name":"file"`)
+	assert.Contains(t, string(result), `"name":"file2"`)
+
+	readDir, err := ReadAnalysis(bytes.NewReader(result))
+	assert.Nil(t, err)
+	assert.Equal(t, "test_dir", readDir.GetName())
+
+	var names []string
+	for f := range readDir.GetFiles(fs.SortByName, fs.SortAsc) {
+		names = append(names, f.GetName())
+	}
+	assert.Equal(t, []string{"file", "file2"}, names)
+}
+
+func TestAnalyzePathWithTopLargerThanFileCount(t *testing.T) {
+	fin := testdir.CreateTestDir()
+	defer fin()
+
+	var output bytes.Buffer
+	var reportOutput bytes.Buffer
+
+	ui := CreateExportUI(&output, &reportOutput, false, false, false, 100, 0, false)
+	ui.SetIgnoreDirPaths([]string{"/xxx"})
+	err := ui.AnalyzePath("test_dir", nil)
+	assert.Nil(t, err)
+	err = ui.StartUILoop()
+
+	assert.Nil(t, err)
+	assert.Contains(t, reportOutput.String(), `"name":"file"`)
+	assert.Contains(t, reportOutput.String(), `"name":"file2"`)
+}
+
+func TestAnalyzePathWithDepthLargerThanTreeDepth(t *testing.T) {
+	fin := testdir.CreateTestDir()
+	defer fin()
+
+	var output bytes.Buffer
+	var reportOutput bytes.Buffer
+
+	ui := CreateExportUI(&output, &reportOutput, false, false, false, 0, 100, false)
+	ui.SetIgnoreDirPaths([]string{"/xxx"})
+	err := ui.AnalyzePath("test_dir", nil)
+	assert.Nil(t, err)
+	err = ui.StartUILoop()
+
+	assert.Nil(t, err)
+	assert.Contains(t, reportOutput.String(), `"name":"nested"`)
+	assert.Contains(t, reportOutput.String(), `"name":"subnested"`)
+	assert.Contains(t, reportOutput.String(), `"name":"file"`)
+}
+
+func TestAnalyzePathWithSummarizeAndTop(t *testing.T) {
+	fin := testdir.CreateTestDir()
+	defer fin()
+
+	var output bytes.Buffer
+	var reportOutput bytes.Buffer
+
+	ui := CreateExportUI(&output, &reportOutput, false, false, false, 2, 0, true)
+	ui.SetIgnoreDirPaths([]string{"/xxx"})
+	err := ui.AnalyzePath("test_dir", nil)
+	assert.Nil(t, err)
+	err = ui.StartUILoop()
+
+	assert.Nil(t, err)
+	assert.Contains(t, reportOutput.String(), `"name":"test_dir"`)
+	assert.NotContains(t, reportOutput.String(), `"name":"file"`)
+	assert.NotContains(t, reportOutput.String(), `"name":"nested"`)
+}
+
+func TestAnalyzePathWithSummarizeAndDepth(t *testing.T) {
+	fin := testdir.CreateTestDir()
+	defer fin()
+
+	var output bytes.Buffer
+	var reportOutput bytes.Buffer
+
+	ui := CreateExportUI(&output, &reportOutput, false, false, false, 0, 1, true)
+	ui.SetIgnoreDirPaths([]string{"/xxx"})
+	err := ui.AnalyzePath("test_dir", nil)
+	assert.Nil(t, err)
+	err = ui.StartUILoop()
+
+	assert.Nil(t, err)
+	assert.Contains(t, reportOutput.String(), `"name":"test_dir"`)
+	assert.NotContains(t, reportOutput.String(), `"name":"nested"`)
+	assert.NotContains(t, reportOutput.String(), `"name":"file"`)
+}
+
+func TestLimitDirByDepthWithNonDir(t *testing.T) {
+	var output bytes.Buffer
+	var reportOutput bytes.Buffer
+
+	ui := CreateExportUI(&output, &reportOutput, false, false, false, 0, 1, false)
+	file := &analyze.File{Name: "file"}
+	result := ui.limitDirByDepth(file, 0)
+
+	assert.Equal(t, file, result)
+}
+
+func TestAnalyzePathWithDepthZeroIsIgnored(t *testing.T) {
+	fin := testdir.CreateTestDir()
+	defer fin()
+
+	var output bytes.Buffer
+	var reportOutput bytes.Buffer
+
+	ui := CreateExportUI(&output, &reportOutput, false, false, false, 0, 0, false)
+	ui.SetIgnoreDirPaths([]string{"/xxx"})
+	err := ui.AnalyzePath("test_dir", nil)
+	assert.Nil(t, err)
+	err = ui.StartUILoop()
+
+	assert.Nil(t, err)
+	assert.Contains(t, reportOutput.String(), `"name":"nested"`)
+	assert.Contains(t, reportOutput.String(), `"name":"subnested"`)
+	assert.Contains(t, reportOutput.String(), `"name":"file"`)
+}
+
+func TestAnalyzePathWithProgress(t *testing.T) {
+	fin := testdir.CreateTestDir()
+	defer fin()
+
+	var output bytes.Buffer
+	var reportOutput bytes.Buffer
+
+	ui := CreateExportUI(&output, &reportOutput, true, true, true, 0, 0, false)
 	ui.SetIgnoreDirPaths([]string{"/xxx"})
 	err := ui.AnalyzePath("test_dir", nil)
 	assert.Nil(t, err)
@@ -51,21 +297,21 @@ func TestAnalyzePathWithProgress(t *testing.T) {
 }
 
 func TestShowDevices(t *testing.T) {
-	output := bytes.NewBuffer(make([]byte, 10))
-	reportOutput := bytes.NewBuffer(make([]byte, 10))
+	var output bytes.Buffer
+	var reportOutput bytes.Buffer
 
-	ui := CreateExportUI(output, reportOutput, false, true, false)
+	ui := CreateExportUI(&output, &reportOutput, false, true, false, 0, 0, false)
 	err := ui.ListDevices(device.Getter)
 
 	assert.Contains(t, err.Error(), "not supported")
 }
 
 func TestReadAnalysisWhileExporting(t *testing.T) {
-	output := bytes.NewBuffer(make([]byte, 10))
-	reportOutput := bytes.NewBuffer(make([]byte, 10))
+	var output bytes.Buffer
+	var reportOutput bytes.Buffer
 
-	ui := CreateExportUI(output, reportOutput, false, true, false)
-	err := ui.ReadAnalysis(output)
+	ui := CreateExportUI(&output, &reportOutput, false, true, false, 0, 0, false)
+	err := ui.ReadAnalysis(&output)
 
 	assert.Contains(t, err.Error(), "not possible while exporting")
 }
@@ -80,9 +326,9 @@ func TestExportToFile(t *testing.T) {
 		os.Remove("output.json")
 	}()
 
-	output := bytes.NewBuffer(make([]byte, 10))
+	var output bytes.Buffer
 
-	ui := CreateExportUI(output, reportOutput, false, true, false)
+	ui := CreateExportUI(&output, reportOutput, false, true, false, 0, 0, false)
 	ui.SetIgnoreDirPaths([]string{"/xxx"})
 	err = ui.AnalyzePath("test_dir", nil)
 	assert.Nil(t, err)
@@ -100,11 +346,81 @@ func TestExportToFile(t *testing.T) {
 	assert.Contains(t, string(buff), `"name":"nested"`)
 }
 
-func TestFormatSize(t *testing.T) {
-	output := bytes.NewBuffer(make([]byte, 10))
-	reportOutput := bytes.NewBuffer(make([]byte, 10))
+func TestExportToFileWithTop(t *testing.T) {
+	fin := testdir.CreateTestDir()
+	defer fin()
+	defer func() {
+		os.Remove("output.json")
+	}()
 
-	ui := CreateExportUI(output, reportOutput, false, true, false)
+	reportOutput, err := os.OpenFile("output.json", os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+	assert.Nil(t, err)
+
+	var output bytes.Buffer
+
+	ui := CreateExportUI(&output, reportOutput, false, true, false, 2, 0, false)
+	ui.SetIgnoreDirPaths([]string{"/xxx"})
+	err = ui.AnalyzePath("test_dir", nil)
+	assert.Nil(t, err)
+	err = ui.StartUILoop()
+	assert.Nil(t, err)
+
+	reportOutput, err = os.OpenFile("output.json", os.O_RDONLY, 0o644)
+	assert.Nil(t, err)
+	_, err = reportOutput.Seek(0, 0)
+	assert.Nil(t, err)
+	buff := make([]byte, 200)
+	_, err = reportOutput.Read(buff)
+	assert.Nil(t, err)
+
+	assert.Contains(t, string(buff), `"name":"file"`)
+	assert.Contains(t, string(buff), `"name":"file2"`)
+	assert.NotContains(t, string(buff), `"name":"nested"`)
+}
+
+func TestExportToFileWithDepth(t *testing.T) {
+	fin := testdir.CreateTestDir()
+	defer fin()
+	defer func() {
+		os.Remove("output.json")
+	}()
+
+	reportOutput, err := os.OpenFile("output.json", os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+	assert.Nil(t, err)
+
+	var output bytes.Buffer
+
+	ui := CreateExportUI(&output, reportOutput, false, true, false, 0, 2, false)
+	ui.SetIgnoreDirPaths([]string{"/xxx"})
+	err = ui.AnalyzePath("test_dir", nil)
+	assert.Nil(t, err)
+	err = ui.StartUILoop()
+	assert.Nil(t, err)
+
+	reportOutput, err = os.OpenFile("output.json", os.O_RDONLY, 0o644)
+	assert.Nil(t, err)
+	_, err = reportOutput.Seek(0, 0)
+	assert.Nil(t, err)
+	buff := make([]byte, 400)
+	_, err = reportOutput.Read(buff)
+	assert.Nil(t, err)
+
+	assert.Contains(t, string(buff), `"name":"nested"`)
+	assert.Contains(t, string(buff), `"name":"file2"`)
+	assert.Contains(t, string(buff), `"name":"subnested"`)
+
+	_, err = reportOutput.Seek(0, 0)
+	assert.Nil(t, err)
+	readDir, err := ReadAnalysis(reportOutput)
+	assert.Nil(t, err)
+	assert.Equal(t, "test_dir", readDir.GetName())
+}
+
+func TestFormatSize(t *testing.T) {
+	var output bytes.Buffer
+	var reportOutput bytes.Buffer
+
+	ui := CreateExportUI(&output, &reportOutput, false, true, false, 0, 0, false)
 
 	assert.Contains(t, ui.formatSize(1), "B")
 	assert.Contains(t, ui.formatSize(1<<10+1), "KiB")
@@ -117,10 +433,10 @@ func TestFormatSize(t *testing.T) {
 }
 
 func TestFormatSizeDec(t *testing.T) {
-	output := bytes.NewBuffer(make([]byte, 10))
-	reportOutput := bytes.NewBuffer(make([]byte, 10))
+	var output bytes.Buffer
+	var reportOutput bytes.Buffer
 
-	ui := CreateExportUI(output, reportOutput, false, true, true)
+	ui := CreateExportUI(&output, &reportOutput, false, true, true, 0, 0, false)
 
 	assert.Contains(t, ui.formatSize(1), "B")
 	assert.Contains(t, ui.formatSize(1<<10+1), "kB")


### PR DESCRIPTION
JSON export (`-o`) previously ignored the `-t`/--top, `--depth` and `-s`/--summarize flags that work in non-interactive stdout mode. This change makes the export path respect the same filters, so the generated JSON only contains the requested subset of data while preserving the existing top-level schema.

Changes:
- Added `top`, `depth` and `summarize` support to `report.CreateExportUI`
- Added `topDir`, `limitDirByDepth` and `summarizeDir` helpers
- Wired flags through `cmd/gdu/app/app.go`
- Added unit and end-to-end tests for all filter combinations

Verification:
- `go test -v -covermode=count ./...` passes
- `golangci-lint run ./report/... ./cmd/gdu/app/... ./cmd/gdu/...` reports no issues

Closes #595