### PR TITLE
docs: fix typo "relase" -> "release" in release run-book

### DIFF
--- a/docs/run-books.md
+++ b/docs/run-books.md
@@ -8,6 +8,6 @@
 1. `make`
 1. `git push --tags`
 1. `git push`
-1. release is created on Github from the tag, or `make release`
+1. release is created on GitHub from the tag, or `make release`
 1. update `gdu.spec`
 1. Release snapcraft, AUR, ...

--- a/docs/run-books.md
+++ b/docs/run-books.md
@@ -8,6 +8,6 @@
 1. `make`
 1. `git push --tags`
 1. `git push`
-1. relase is created on Github from the tag, or `make release`
+1. release is created on Github from the tag, or `make release`
 1. update `gdu.spec`
 1. Release snapcraft, AUR, ...


### PR DESCRIPTION
## Summary

Fixes a small spelling typo in the release run-book documentation.

## Changes

| File | Before | After |
| --- | --- | --- |
| `docs/run-books.md` | `relase is created on Github from the tag` | `release is created on Github from the tag` |

No functional changes - documentation prose only.