### PR TITLE
fix(report): preserve directory stats in JSON export

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.26.1
+golang 1.26.5

--- a/cmd/gdu/app/app_test.go
+++ b/cmd/gdu/app/app_test.go
@@ -482,6 +482,8 @@ func TestAnalyzePathWithExportAndDepth(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Contains(t, string(content), `"name":"nested"`)
 	assert.NotContains(t, string(content), `"name":"subnested"`)
+	assert.Contains(t, string(content), `"name":"nested","asize":`)
+	assert.Contains(t, string(content), `"items":`)
 }
 
 func TestAnalyzePathWithExportAndSummarize(t *testing.T) {

--- a/pkg/analyze/encode.go
+++ b/pkg/analyze/encode.go
@@ -22,6 +22,12 @@ func (f *Dir) EncodeJSON(writer io.Writer, topLevel bool) error {
 		}
 	}
 
+	buff = append(buff, []byte(`,"asize":`)...)
+	buff = append(buff, []byte(strconv.FormatInt(f.GetSize(), 10))...)
+	buff = append(buff, []byte(`,"dsize":`)...)
+	buff = append(buff, []byte(strconv.FormatInt(f.GetUsage(), 10))...)
+	buff = append(buff, []byte(`,"items":`)...)
+	buff = append(buff, []byte(strconv.FormatInt(f.GetItemCount(), 10))...)
 	if !f.GetMtime().IsZero() {
 		buff = append(buff, []byte(`,"mtime":`)...)
 		buff = append(buff, []byte(strconv.FormatInt(f.GetMtime().Unix(), 10))...)

--- a/pkg/analyze/encode_test.go
+++ b/pkg/analyze/encode_test.go
@@ -65,4 +65,16 @@ func TestEncode(t *testing.T) {
 	assert.Contains(t, buff.String(), `"mtime":1629333600`)
 	assert.Contains(t, buff.String(), `"ino":1234`)
 	assert.Contains(t, buff.String(), `"hlnkc":true`)
+	assert.Contains(t, buff.String(), `"asize":10,"dsize":18,"items":4`)
+	assert.Contains(t, buff.String(), `"name":"nested","asize":9,"dsize":14,"items":3`)
+}
+
+func TestEncodeEmptyDir(t *testing.T) {
+	dir := &Dir{File: &File{Name: "empty"}}
+
+	var buff bytes.Buffer
+	err := dir.EncodeJSON(&buff, false)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "[{\"name\":\"empty\",\"asize\":0,\"dsize\":0,\"items\":0}\n]", buff.String())
 }

--- a/pkg/analyze/file.go
+++ b/pkg/analyze/file.go
@@ -162,6 +162,13 @@ func (f *File) RemoveFileByName(name string) {
 	panic("RemoveFileByName should not be called on file")
 }
 
+// EmptyDirSize is the apparent size gdu assigns to a directory that has no
+// counted children. It is a fixed sentinel (not the real filesystem block
+// size) written by updateStats, SimpleDir.UpdateStats and the parallel top-dir
+// analyzer, and recognised again on import. Keep every producer and consumer
+// of this value referencing this constant so they can never drift apart.
+const EmptyDirSize int64 = 512
+
 // Dir struct
 type Dir struct {
 	*File
@@ -274,6 +281,19 @@ func (f *Dir) SetFlag(flag rune) {
 // SetStatsFromJSON marks directory statistics decoded from an export as authoritative.
 func (f *Dir) SetStatsFromJSON() {
 	f.statsFromJSON = true
+}
+
+// HasEmptyDirPlaceholderStats reports whether this directory's stats are
+// indistinguishable from the placeholder updateStats produces for a directory
+// with no counted children (see EmptyDirSize). Such stats carry no information
+// worth pinning from an import: recomputation reproduces exactly the same
+// values, so callers should let updateStats run rather than preserving them.
+//
+// The items == 1 check is load-bearing: a depth-truncated directory that held
+// real content always exports with ItemCount >= 2, so it can never be mistaken
+// for a placeholder and its stats are always preserved.
+func (f *Dir) HasEmptyDirPlaceholderStats() bool {
+	return f.Size == EmptyDirSize && f.Usage == 0 && f.ItemCount == 1
 }
 
 // GetFiles returns all files in directory as a sorted iterator
@@ -433,7 +453,7 @@ func (f *Dir) updateStats(linkedItems fs.HardLinkedItems, filteringFiles bool) {
 	// no files, or just empty dirs
 	if len(files) == 0 || (!hasFiles && filteringFiles && itemCount == int64(len(files)+1)) {
 		f.ItemCount = 1
-		f.Size = totalSize + 512
+		f.Size = totalSize + EmptyDirSize
 		f.Usage = 0
 	} else {
 		f.ItemCount = itemCount

--- a/pkg/analyze/file.go
+++ b/pkg/analyze/file.go
@@ -165,10 +165,11 @@ func (f *File) RemoveFileByName(name string) {
 // Dir struct
 type Dir struct {
 	*File
-	BasePath  string
-	Files     fs.Files
-	ItemCount int64
-	m         sync.RWMutex
+	BasePath      string
+	Files         fs.Files
+	ItemCount     int64
+	statsFromJSON bool
+	m             sync.RWMutex
 }
 
 func snapshotDir(source *Dir, parent fs.Item) *Dir {
@@ -268,6 +269,11 @@ func (f *Dir) SetFlag(flag rune) {
 	f.m.Lock()
 	f.Flag = flag
 	f.m.Unlock()
+}
+
+// SetStatsFromJSON marks directory statistics decoded from an export as authoritative.
+func (f *Dir) SetStatsFromJSON() {
+	f.statsFromJSON = true
 }
 
 // GetFiles returns all files in directory as a sorted iterator
@@ -378,6 +384,10 @@ func (f *Dir) UpdateStatsWithFileFiltering(linkedItems fs.HardLinkedItems) {
 
 // UpdateStats recursively updates size and item count
 func (f *Dir) updateStats(linkedItems fs.HardLinkedItems, filteringFiles bool) {
+	if f.statsFromJSON {
+		return
+	}
+
 	// Snapshot the file list under the read lock so it is safe to compute stats
 	// even while the analyzer is still appending items in another goroutine
 	// (e.g. when previewing a directory mid-scan).

--- a/pkg/analyze/file_test.go
+++ b/pkg/analyze/file_test.go
@@ -381,3 +381,26 @@ func TestAddFilePanicsOnFile(t *testing.T) {
 		file.AddFile(file)
 	})
 }
+
+func TestStatsFromJSONArePreserved(t *testing.T) {
+	dir := &Dir{
+		File: &File{
+			Name:  "summary",
+			Size:  4096,
+			Usage: 2048,
+		},
+		ItemCount: 2,
+	}
+	dir.SetStatsFromJSON()
+
+	dir.UpdateStats(make(fs.HardLinkedItems, 10))
+	assert.Equal(t, int64(4096), dir.GetSize())
+	assert.Equal(t, int64(2048), dir.GetUsage())
+	assert.Equal(t, int64(2), dir.GetItemCount())
+
+	dir.UpdateStatsWithFileFiltering(make(fs.HardLinkedItems, 10))
+	count, size, usage := dir.GetItemStats(make(fs.HardLinkedItems, 10), true)
+	assert.Equal(t, int64(2), count)
+	assert.Equal(t, int64(4096), size)
+	assert.Equal(t, int64(2048), usage)
+}

--- a/pkg/analyze/parallel_top_dir.go
+++ b/pkg/analyze/parallel_top_dir.go
@@ -244,7 +244,7 @@ func (a *TopDirAnalyzer) processSubDir(path string, topDir *TopDir) {
 	}
 
 	if len(files) == 0 {
-		totalSize = 512
+		totalSize = EmptyDirSize
 		totalUsage = 0
 	}
 

--- a/pkg/analyze/sqlite.go
+++ b/pkg/analyze/sqlite.go
@@ -651,14 +651,12 @@ func (i *SqliteItem) encodeDirJSON(writer io.Writer, topLevel bool) error {
 		return err
 	}
 
-	if i.GetSize() > 0 {
-		buff = append(buff, []byte(`,"asize":`)...)
-		buff = append(buff, []byte(strconv.FormatInt(i.GetSize(), 10))...)
-	}
-	if i.GetUsage() > 0 {
-		buff = append(buff, []byte(`,"dsize":`)...)
-		buff = append(buff, []byte(strconv.FormatInt(i.GetUsage(), 10))...)
-	}
+	buff = append(buff, []byte(`,"asize":`)...)
+	buff = append(buff, []byte(strconv.FormatInt(i.GetSize(), 10))...)
+	buff = append(buff, []byte(`,"dsize":`)...)
+	buff = append(buff, []byte(strconv.FormatInt(i.GetUsage(), 10))...)
+	buff = append(buff, []byte(`,"items":`)...)
+	buff = append(buff, []byte(strconv.FormatInt(i.GetItemCount(), 10))...)
 	if !i.GetMtime().IsZero() {
 		buff = append(buff, []byte(`,"mtime":`)...)
 		buff = append(buff, []byte(strconv.FormatInt(i.GetMtime().Unix(), 10))...)

--- a/pkg/analyze/sqlite_test.go
+++ b/pkg/analyze/sqlite_test.go
@@ -658,9 +658,24 @@ func TestSqliteItemEncodeJSON(t *testing.T) {
 	err = root.EncodeJSON(&buf, false)
 	assert.NoError(t, err)
 
-	expected := `[{"name":"root","asize":100,"dsize":200,"mtime":1600000000},
+	expected := `[{"name":"root","asize":100,"dsize":200,"items":2,"mtime":1600000000},
 {"name":"file.txt","asize":10,"dsize":20,"mtime":1600000000}]`
 	assert.Equal(t, expected, buf.String())
+}
+
+func TestSqliteItemEncodeEmptyDirJSON(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	storage, err := NewSqliteStorage(dbPath)
+	assert.NoError(t, err)
+	defer storage.Close()
+
+	rootID, _ := storage.InsertItem(nil, "empty", true, 0, 0, time.Time{}, 0, 0, ' ')
+	root, _ := storage.GetItemByID(rootID)
+
+	var buf bytes.Buffer
+	err = root.EncodeJSON(&buf, false)
+	assert.NoError(t, err)
+	assert.Equal(t, "[{\"name\":\"empty\",\"asize\":0,\"dsize\":0,\"items\":0}\n]", buf.String())
 }
 
 func TestCreateSqliteAnalyzer(t *testing.T) {

--- a/pkg/analyze/top_dir.go
+++ b/pkg/analyze/top_dir.go
@@ -110,7 +110,7 @@ func (d *SimpleDir) updateStats(_ fs.HardLinkedItems, _ bool) {
 	}
 	if len(d.Files) == 0 {
 		d.ItemCount = 0
-		d.Size = 512
+		d.Size = EmptyDirSize
 		d.Usage = 0
 	} else {
 		d.ItemCount = itemCount + 1

--- a/report/export_test.go
+++ b/report/export_test.go
@@ -371,12 +371,7 @@ func TestExportToFileWithTop(t *testing.T) {
 	err = ui.StartUILoop()
 	assert.Nil(t, err)
 
-	reportOutput, err = os.OpenFile("output.json", os.O_RDONLY, 0o644)
-	assert.Nil(t, err)
-	_, err = reportOutput.Seek(0, 0)
-	assert.Nil(t, err)
-	buff := make([]byte, 200)
-	_, err = reportOutput.Read(buff)
+	buff, err := os.ReadFile("output.json")
 	assert.Nil(t, err)
 
 	assert.Contains(t, string(buff), `"name":"file"`)

--- a/report/import.go
+++ b/report/import.go
@@ -44,29 +44,10 @@ func processDir(items []any) (dir *analyze.Dir, err error) {
 		return nil, errors.New("directory array is empty")
 	}
 
-	dir = &analyze.Dir{
-		File: &analyze.File{
-			Flag: ' ',
-		},
-	}
-	dirMap, ok := items[0].(map[string]any)
-	if !ok {
-		return nil, errors.New("directory item is not a map")
-	}
-	name, ok := dirMap["name"].(string)
-	if !ok {
-		return nil, errors.New("directory name is not a string")
-	}
-	if mtime, ok := dirMap["mtime"].(float64); ok {
-		dir.Mtime = time.Unix(int64(mtime), 0)
-	}
-
-	slashPos := strings.LastIndex(name, "/")
-	if slashPos > -1 {
-		dir.Name = name[slashPos+1:]
-		dir.BasePath = name[:slashPos+1]
-	} else {
-		dir.Name = name
+	var hasSize, hasUsage, hasItemCount bool
+	dir, hasSize, hasUsage, hasItemCount, err = parseDirectoryMetadata(items[0])
+	if err != nil {
+		return nil, err
 	}
 
 	for _, v := range items[1:] {
@@ -112,6 +93,61 @@ func processDir(items []any) (dir *analyze.Dir, err error) {
 			dir.AddFile(subdir)
 		}
 	}
+	preserveTruncatedStats(dir, hasSize, hasUsage, hasItemCount)
 
 	return dir, nil
+}
+
+func parseDirectoryMetadata(item any) (
+	dir *analyze.Dir,
+	hasSize bool,
+	hasUsage bool,
+	hasItemCount bool,
+	err error,
+) {
+	dirMap, ok := item.(map[string]any)
+	if !ok {
+		return nil, false, false, false, errors.New("directory item is not a map")
+	}
+	name, ok := dirMap["name"].(string)
+	if !ok {
+		return nil, false, false, false, errors.New("directory name is not a string")
+	}
+
+	dir = &analyze.Dir{File: &analyze.File{Flag: ' '}}
+	if mtime, ok := dirMap["mtime"].(float64); ok {
+		dir.Mtime = time.Unix(int64(mtime), 0)
+	}
+	if asize, ok := dirMap["asize"].(float64); ok {
+		dir.Size = int64(asize)
+		hasSize = true
+	}
+	if dsize, ok := dirMap["dsize"].(float64); ok {
+		dir.Usage = int64(dsize)
+		hasUsage = true
+	}
+	if itemCount, ok := dirMap["items"].(float64); ok {
+		dir.ItemCount = int64(itemCount)
+		hasItemCount = true
+	}
+
+	slashPos := strings.LastIndex(name, "/")
+	if slashPos > -1 {
+		dir.Name = name[slashPos+1:]
+		dir.BasePath = name[:slashPos+1]
+	} else {
+		dir.Name = name
+	}
+
+	return dir, hasSize, hasUsage, hasItemCount, nil
+}
+
+func preserveTruncatedStats(dir *analyze.Dir, hasSize, hasUsage, hasItemCount bool) {
+	if !hasSize || !hasUsage || !hasItemCount || len(dir.Files) != 0 {
+		return
+	}
+	if dir.Size == 512 && dir.Usage == 0 && dir.ItemCount == 1 {
+		return
+	}
+	dir.SetStatsFromJSON()
 }

--- a/report/import.go
+++ b/report/import.go
@@ -146,7 +146,11 @@ func preserveTruncatedStats(dir *analyze.Dir, hasSize, hasUsage, hasItemCount bo
 	if !hasSize || !hasUsage || !hasItemCount || len(dir.Files) != 0 {
 		return
 	}
-	if dir.Size == 512 && dir.Usage == 0 && dir.ItemCount == 1 {
+	// A leaf directory whose imported stats match the empty-dir placeholder
+	// carries nothing worth pinning: recomputation reproduces the same values.
+	// Only genuinely-empty leaves reach this point with placeholder stats;
+	// depth-truncated directories that held content export with items >= 2.
+	if dir.HasEmptyDirPlaceholderStats() {
 		return
 	}
 	dir.SetStatsFromJSON()

--- a/report/import_test.go
+++ b/report/import_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/dundee/gdu/v5/pkg/analyze"
+	"github.com/dundee/gdu/v5/pkg/fs"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/stretchr/testify/assert"
@@ -18,10 +19,10 @@ func init() {
 func TestReadAnalysis(t *testing.T) {
 	buff := bytes.NewBuffer([]byte(`
 		[1,2,{"progname":"gdu","progver":"development","timestamp":1626806293},
-		[{"name":"/home/xxx","mtime":1629333600},
+		[{"name":"/home/xxx","asize":47000000,"dsize":64000000,"items":6,"mtime":1629333600},
 		{"name":"gdu.json","asize":33805233,"dsize":33808384},
 		{"name":"sock","notreg":true},
-		[{"name":"app"},
+		[{"name":"app","asize":10022,"dsize":20480,"items":4},
 		{"name":"app.go","asize":4638,"dsize":8192},
 		{"name":"app_linux_test.go","asize":1410,"dsize":4096},
 		{"name":"app_linux_test2.go","ino":1234,"hlnkc":true,"asize":1410,"dsize":4096},
@@ -34,12 +35,40 @@ func TestReadAnalysis(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, "xxx", dir.GetName())
 	assert.Equal(t, "/home/xxx", dir.GetPath())
-	assert.Equal(t, 2021, dir.GetMtime().Year())
-	assert.Equal(t, 2021, dir.Files[3].GetMtime().Year())
+	assert.Equal(t, int64(47000000), dir.GetSize())
+	assert.Equal(t, int64(64000000), dir.GetUsage())
+	assert.Equal(t, int64(6), dir.GetItemCount())
+	assert.Equal(t, int64(10022), dir.Files[2].GetSize())
+	assert.Equal(t, int64(20480), dir.Files[2].GetUsage())
+	assert.Equal(t, int64(4), dir.Files[2].GetItemCount())
 	alt2 := dir.Files[2].(*analyze.Dir).Files[2].(*analyze.File)
 	assert.Equal(t, "app_linux_test2.go", alt2.Name)
 	assert.Equal(t, uint64(1234), alt2.Mli)
 	assert.Equal(t, 'H', alt2.Flag)
+}
+
+func TestReadAnalysisPreservesTruncatedDirectoryStats(t *testing.T) {
+	input := bytes.NewBufferString(`
+		[1,2,{"progname":"gdu","progver":"development","timestamp":0},
+		[{"name":"/root","asize":4096,"dsize":4096,"items":3},
+		[{"name":"summary","asize":4096,"dsize":4096,"items":2}]]]
+	`)
+
+	dir, err := ReadAnalysis(input)
+	assert.NoError(t, err)
+	dir.UpdateStats(make(fs.HardLinkedItems, 10))
+
+	assert.Equal(t, int64(4096), dir.GetSize())
+	assert.Equal(t, int64(4096), dir.GetUsage())
+	assert.Equal(t, int64(3), dir.GetItemCount())
+	summary := dir.Files[0].(*analyze.Dir)
+	assert.Equal(t, int64(4096), summary.GetSize())
+	assert.Equal(t, int64(4096), summary.GetUsage())
+	assert.Equal(t, int64(2), summary.GetItemCount())
+	dir.UpdateStatsWithFileFiltering(make(fs.HardLinkedItems, 10))
+	assert.Equal(t, int64(4096), dir.GetSize())
+	assert.Equal(t, int64(4096), dir.GetUsage())
+	assert.Equal(t, int64(3), dir.GetItemCount())
 }
 
 func TestReadAnalysisWithEmptyInput(t *testing.T) {

--- a/report/import_test.go
+++ b/report/import_test.go
@@ -71,6 +71,21 @@ func TestReadAnalysisPreservesTruncatedDirectoryStats(t *testing.T) {
 	assert.Equal(t, int64(3), dir.GetItemCount())
 }
 
+func TestReadAnalysisRecomputesEmptyDirStats(t *testing.T) {
+	input := bytes.NewBufferString(`
+		[1,2,{"progname":"gdu","progver":"development","timestamp":0},
+		[{"name":"/empty","asize":512,"dsize":0,"items":1}]]
+	`)
+
+	dir, err := ReadAnalysis(input)
+	assert.NoError(t, err)
+	dir.UpdateStats(make(fs.HardLinkedItems, 10))
+
+	assert.Equal(t, int64(512), dir.GetSize())
+	assert.Equal(t, int64(0), dir.GetUsage())
+	assert.Equal(t, int64(1), dir.GetItemCount())
+}
+
 func TestReadAnalysisWithEmptyInput(t *testing.T) {
 	buff := bytes.NewBuffer([]byte(``))
 

--- a/report/import_test.go
+++ b/report/import_test.go
@@ -86,6 +86,27 @@ func TestReadAnalysisRecomputesEmptyDirStats(t *testing.T) {
 	assert.Equal(t, int64(1), dir.GetItemCount())
 }
 
+// A depth-truncated directory that held real content exports with items >= 2,
+// so even when its apparent size coincides with the empty-dir placeholder its
+// stats must be preserved (not recomputed to zero). This pins the items == 1
+// discriminator in HasEmptyDirPlaceholderStats as intentional.
+func TestReadAnalysisPreservesTruncatedDirWithPlaceholderSize(t *testing.T) {
+	input := bytes.NewBufferString(`
+		[1,2,{"progname":"gdu","progver":"development","timestamp":0},
+		[{"name":"/root","asize":1024,"dsize":0,"items":3},
+		[{"name":"truncated","asize":512,"dsize":0,"items":2}]]]
+	`)
+
+	dir, err := ReadAnalysis(input)
+	assert.NoError(t, err)
+	dir.UpdateStats(make(fs.HardLinkedItems, 10))
+
+	truncated := dir.Files[0].(*analyze.Dir)
+	assert.Equal(t, int64(512), truncated.GetSize())
+	assert.Equal(t, int64(0), truncated.GetUsage())
+	assert.Equal(t, int64(2), truncated.GetItemCount())
+}
+
 func TestReadAnalysisWithEmptyInput(t *testing.T) {
 	buff := bytes.NewBuffer([]byte(``))
 


### PR DESCRIPTION
## Summary

- include apparent size, disk usage, and item count in directory JSON metadata
- preserve aggregate statistics for depth-truncated and summarized directories when reports are reloaded
- keep full report recomputation behavior unchanged and retain aggregate cutoffs under file filtering
- add JSON export/import regression coverage, including empty directories

## Verification

- `go test -v -covermode=count ./...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.2 run ./report/... ./cmd/gdu/app/... ./cmd/gdu/...`
- CLI export/import smoke tests for a depth-limited report

Closes #325