### PR TITLE
feat: honor block size environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ When `--top` or `--depth` flags are used, the full directory tree is built in me
 
 Export mode (flag `-o`) outputs all usage data as JSON, which can be later opened using the `-f` flag.
 
+Gdu honors `BLOCK_SIZE` and `BLOCKSIZE` in terminal output. `BLOCK_SIZE` takes precedence; both accept GNU coreutils block-size values such as `1K`, `kB`, `human-readable`, and `si`. Explicit size-format flags override these environment variables. Exported JSON always retains raw byte values.
+
 Hard links are counted only once.
 
 ## File flags

--- a/internal/common/ui.go
+++ b/internal/common/ui.go
@@ -3,6 +3,7 @@
 package common
 
 import (
+	"os"
 	"regexp"
 	"strconv"
 )
@@ -21,6 +22,8 @@ type UI struct {
 	ShowApparentSize      bool
 	ShowRelativeSize      bool
 	FilteringFiles        bool
+	blockSize             int64
+	blockSuffix           string
 }
 
 // SetAnalyzer sets analyzer instance
@@ -47,6 +50,109 @@ func (ui *UI) SetTimeFilter(timeFilter TimeFilter) {
 // SetArchiveBrowsing sets whether browsing of zip/jar archives is enabled
 func (ui *UI) SetArchiveBrowsing(v bool) {
 	ui.Analyzer.SetArchiveBrowsing(v)
+}
+
+// SetBlockSizeFromEnvironment applies the BLOCK_SIZE or BLOCKSIZE output format.
+func (ui *UI) SetBlockSizeFromEnvironment() {
+	value, ok := os.LookupEnv("BLOCK_SIZE")
+	if !ok {
+		value, ok = os.LookupEnv("BLOCKSIZE")
+	}
+	if !ok {
+		return
+	}
+
+	switch value {
+	case "human-readable":
+		return
+	case "si":
+		ui.UseSIPrefix = true
+		return
+	}
+
+	blockSize, suffix, ok := parseBlockSize(value)
+	if !ok {
+		return
+	}
+	ui.blockSize = blockSize
+	ui.blockSuffix = suffix
+}
+
+// FormatBlockSize formats size as a rounded-up count of configured blocks.
+func (ui *UI) FormatBlockSize(size int64) (string, bool) {
+	if ui.blockSize == 0 {
+		return "", false
+	}
+
+	blocks := size / ui.blockSize
+	if size > 0 && size%ui.blockSize != 0 {
+		blocks++
+	}
+	return strconv.FormatInt(blocks, 10) + ui.blockSuffix, true
+}
+
+func parseBlockSize(value string) (blockSize int64, suffix string, ok bool) {
+	if value == "" {
+		return 0, "", false
+	}
+
+	index := 0
+	for index < len(value) && value[index] >= '0' && value[index] <= '9' {
+		index++
+	}
+	plainUnit := index == 0
+	count := int64(1)
+	if !plainUnit {
+		var err error
+		count, err = strconv.ParseInt(value[:index], 10, 64)
+		if err != nil || count < 1 {
+			return 0, "", false
+		}
+	}
+
+	unit := value[index:]
+	multiplier, valid := blockSizeMultiplier(unit)
+	if !valid || count > int64(^uint64(0)>>1)/multiplier {
+		return 0, "", false
+	}
+	if plainUnit {
+		suffix = unit
+	}
+
+	return count * multiplier, suffix, true
+}
+
+func blockSizeMultiplier(unit string) (int64, bool) {
+	switch unit {
+	case "":
+		return 1, true
+	case "k", "K", "Ki", "KiB":
+		return 1 << 10, true
+	case "kB":
+		return 1e3, true
+	case "M", "Mi", "MiB":
+		return 1 << 20, true
+	case "MB":
+		return 1e6, true
+	case "G", "Gi", "GiB":
+		return 1 << 30, true
+	case "GB":
+		return 1e9, true
+	case "T", "Ti", "TiB":
+		return 1 << 40, true
+	case "TB":
+		return 1e12, true
+	case "P", "Pi", "PiB":
+		return 1 << 50, true
+	case "PB":
+		return 1e15, true
+	case "E", "Ei", "EiB":
+		return 1 << 60, true
+	case "EB":
+		return 1e18, true
+	default:
+		return 0, false
+	}
 }
 
 // binary multiplies prefixes (IEC)

--- a/internal/common/ui_test.go
+++ b/internal/common/ui_test.go
@@ -105,3 +105,23 @@ func (a *MockedAnalyzer) SetTimeFilter(timeFilter TimeFilter) {}
 func (a *MockedAnalyzer) SetArchiveBrowsing(v bool) {
 	a.ArchiveBrowsing = v
 }
+
+func TestBlockSizeEnvironment(t *testing.T) {
+	t.Setenv("BLOCK_SIZE", "1K")
+	t.Setenv("BLOCKSIZE", "1MB")
+	ui := &UI{}
+	ui.SetBlockSizeFromEnvironment()
+
+	formatted, ok := ui.FormatBlockSize(1025)
+	assert.True(t, ok)
+	assert.Equal(t, "2", formatted)
+}
+
+func TestParseBlockSizeRejectsInvalidValues(t *testing.T) {
+	for _, value := range []string{"", "0", "-1", "1Z", "16E", "'1"} {
+		t.Run(value, func(t *testing.T) {
+			_, _, ok := parseBlockSize(value)
+			assert.False(t, ok)
+		})
+	}
+}

--- a/internal/common/ui_test.go
+++ b/internal/common/ui_test.go
@@ -3,6 +3,7 @@
 package common
 
 import (
+	"os"
 	"testing"
 
 	"github.com/dundee/gdu/v5/pkg/fs"
@@ -106,22 +107,144 @@ func (a *MockedAnalyzer) SetArchiveBrowsing(v bool) {
 	a.ArchiveBrowsing = v
 }
 
-func TestBlockSizeEnvironment(t *testing.T) {
-	t.Setenv("BLOCK_SIZE", "1K")
-	t.Setenv("BLOCKSIZE", "1MB")
-	ui := &UI{}
-	ui.SetBlockSizeFromEnvironment()
+func TestSetBlockSizeFromEnvironment(t *testing.T) {
+	t.Run("BLOCK_SIZE takes precedence", func(t *testing.T) {
+		t.Setenv("BLOCK_SIZE", "1K")
+		t.Setenv("BLOCKSIZE", "1MB")
+		ui := &UI{}
+		ui.SetBlockSizeFromEnvironment()
 
-	formatted, ok := ui.FormatBlockSize(1025)
-	assert.True(t, ok)
-	assert.Equal(t, "2", formatted)
+		formatted, ok := ui.FormatBlockSize(1025)
+		assert.True(t, ok)
+		assert.Equal(t, "2", formatted)
+	})
+
+	t.Run("BLOCKSIZE fallback", func(t *testing.T) {
+		unsetBlockSizeEnvironment(t)
+		t.Setenv("BLOCKSIZE", "2kB")
+		ui := &UI{}
+		ui.SetBlockSizeFromEnvironment()
+
+		formatted, ok := ui.FormatBlockSize(2001)
+		assert.True(t, ok)
+		assert.Equal(t, "2", formatted)
+	})
+
+	t.Run("human readable", func(t *testing.T) {
+		t.Setenv("BLOCK_SIZE", "human-readable")
+		ui := &UI{}
+		ui.SetBlockSizeFromEnvironment()
+
+		_, ok := ui.FormatBlockSize(1)
+		assert.False(t, ok)
+		assert.False(t, ui.UseSIPrefix)
+	})
+
+	t.Run("si", func(t *testing.T) {
+		t.Setenv("BLOCK_SIZE", "si")
+		ui := &UI{}
+		ui.SetBlockSizeFromEnvironment()
+
+		assert.True(t, ui.UseSIPrefix)
+	})
+
+	t.Run("invalid value", func(t *testing.T) {
+		t.Setenv("BLOCK_SIZE", "invalid")
+		ui := &UI{}
+		ui.SetBlockSizeFromEnvironment()
+
+		_, ok := ui.FormatBlockSize(1)
+		assert.False(t, ok)
+	})
+
+	t.Run("absent", func(t *testing.T) {
+		unsetBlockSizeEnvironment(t)
+		ui := &UI{}
+		ui.SetBlockSizeFromEnvironment()
+
+		_, ok := ui.FormatBlockSize(1)
+		assert.False(t, ok)
+	})
 }
 
-func TestParseBlockSizeRejectsInvalidValues(t *testing.T) {
-	for _, value := range []string{"", "0", "-1", "1Z", "16E", "'1"} {
-		t.Run(value, func(t *testing.T) {
-			_, _, ok := parseBlockSize(value)
-			assert.False(t, ok)
+func TestFormatBlockSize(t *testing.T) {
+	ui := &UI{blockSize: 1000, blockSuffix: "kB"}
+
+	tests := []struct {
+		size     int64
+		expected string
+	}{
+		{size: -1, expected: "0kB"},
+		{size: 0, expected: "0kB"},
+		{size: 1000, expected: "1kB"},
+		{size: 1001, expected: "2kB"},
+	}
+
+	for _, test := range tests {
+		formatted, ok := ui.FormatBlockSize(test.size)
+		assert.True(t, ok)
+		assert.Equal(t, test.expected, formatted)
+	}
+}
+
+func TestParseBlockSize(t *testing.T) {
+	tests := []struct {
+		value  string
+		size   int64
+		suffix string
+		valid  bool
+	}{
+		{value: "1", size: 1, valid: true},
+		{value: "k", size: 1 << 10, suffix: "k", valid: true},
+		{value: "kB", size: 1e3, suffix: "kB", valid: true},
+		{value: "1K", size: 1 << 10, valid: true},
+		{value: "1M", size: 1 << 20, valid: true},
+		{value: "1MB", size: 1e6, valid: true},
+		{value: "1G", size: 1 << 30, valid: true},
+		{value: "1GB", size: 1e9, valid: true},
+		{value: "1T", size: 1 << 40, valid: true},
+		{value: "1TB", size: 1e12, valid: true},
+		{value: "1P", size: 1 << 50, valid: true},
+		{value: "1PB", size: 1e15, valid: true},
+		{value: "1E", size: 1 << 60, valid: true},
+		{value: "1EB", size: 1e18, valid: true},
+		{value: "", valid: false},
+		{value: "0", valid: false},
+		{value: "-1", valid: false},
+		{value: "1Z", valid: false},
+		{value: "8E", valid: false},
+		{value: "999999999999999999999", valid: false},
+		{value: "'1", valid: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.value, func(t *testing.T) {
+			size, suffix, ok := parseBlockSize(test.value)
+			assert.Equal(t, test.valid, ok)
+			if ok {
+				assert.Equal(t, test.size, size)
+				assert.Equal(t, test.suffix, suffix)
+			}
 		})
 	}
+}
+
+func unsetBlockSizeEnvironment(t *testing.T) {
+	t.Helper()
+	blockSize, blockSizeSet := os.LookupEnv("BLOCK_SIZE")
+	legacyBlockSize, legacyBlockSizeSet := os.LookupEnv("BLOCKSIZE")
+	os.Unsetenv("BLOCK_SIZE")
+	os.Unsetenv("BLOCKSIZE")
+	t.Cleanup(func() {
+		if blockSizeSet {
+			os.Setenv("BLOCK_SIZE", blockSize)
+		} else {
+			os.Unsetenv("BLOCK_SIZE")
+		}
+		if legacyBlockSizeSet {
+			os.Setenv("BLOCKSIZE", legacyBlockSize)
+		} else {
+			os.Unsetenv("BLOCKSIZE")
+		}
+	})
 }

--- a/report/export.go
+++ b/report/export.go
@@ -56,6 +56,9 @@ func CreateExportUI(
 		depth:        depth,
 		summarize:    summarize,
 	}
+	if !useSIPrefix {
+		ui.SetBlockSizeFromEnvironment()
+	}
 	ui.red = color.New(color.FgRed).Add(color.Bold)
 	ui.orange = color.New(color.FgYellow).Add(color.Bold)
 
@@ -306,6 +309,9 @@ func (ui *UI) updateProgress() {
 }
 
 func (ui *UI) formatSize(size int64) string {
+	if formatted, ok := ui.FormatBlockSize(size); ok {
+		return ui.orange.Sprint(formatted)
+	}
 	if ui.UseSIPrefix {
 		return ui.formatWithDecPrefix(size)
 	}

--- a/report/export_test.go
+++ b/report/export_test.go
@@ -18,6 +18,12 @@ func init() {
 	log.SetLevel(log.WarnLevel)
 }
 
+func TestMain(m *testing.M) {
+	os.Unsetenv("BLOCK_SIZE")
+	os.Unsetenv("BLOCKSIZE")
+	os.Exit(m.Run())
+}
+
 func TestAnalyzePath(t *testing.T) {
 	fin := testdir.CreateTestDir()
 	defer fin()
@@ -430,6 +436,15 @@ func TestFormatSize(t *testing.T) {
 	assert.Contains(t, ui.formatSize(1<<50+1), "PiB")
 	assert.Contains(t, ui.formatSize(1<<60+1), "EiB")
 	assert.Contains(t, ui.formatSize(-1<<10-1), "KiB")
+}
+
+func TestFormatSizeWithBlockSizeEnvironment(t *testing.T) {
+	t.Setenv("BLOCK_SIZE", "1K")
+	var output bytes.Buffer
+	var reportOutput bytes.Buffer
+
+	ui := CreateExportUI(&output, &reportOutput, false, true, false, 0, 0, false)
+	assert.Equal(t, "2", ui.formatSize(1025))
 }
 
 func TestFormatSizeDec(t *testing.T) {

--- a/stdout/stdout.go
+++ b/stdout/stdout.go
@@ -74,6 +74,8 @@ func CreateStdoutUI(
 	}
 	if fixedUnit != "" {
 		ui.SetFixedUnit(fixedUnit)
+	} else if !noPrefix && !useSIPrefix {
+		ui.SetBlockSizeFromEnvironment()
 	}
 	ui.red = color.New(color.FgRed).Add(color.Bold)
 	ui.orange = color.New(color.FgYellow).Add(color.Bold)
@@ -560,6 +562,9 @@ func (ui *UI) formatCount(count int64) string {
 func (ui *UI) formatSize(size int64) string {
 	if ui.noPrefix {
 		return ui.orange.Sprintf("%d", size)
+	}
+	if formatted, ok := ui.FormatBlockSize(size); ok {
+		return ui.orange.Sprint(formatted)
 	}
 	if ui.fixedBase > 0 {
 		val := float64(size) / ui.fixedBase

--- a/stdout/stdout_test.go
+++ b/stdout/stdout_test.go
@@ -22,6 +22,12 @@ func init() {
 	log.SetLevel(log.WarnLevel)
 }
 
+func TestMain(m *testing.M) {
+	os.Unsetenv("BLOCK_SIZE")
+	os.Unsetenv("BLOCKSIZE")
+	os.Exit(m.Run())
+}
+
 func TestAnalyzePath(t *testing.T) {
 	fin := testdir.CreateTestDir()
 	defer fin()
@@ -665,4 +671,57 @@ func TestAnalyzePathWithTopDirAnalyzer(t *testing.T) {
 	err = ui.StartUILoop()
 	assert.Nil(t, err)
 	assert.Contains(t, output.String(), "nested")
+}
+
+func TestBlockSizeEnvironment(t *testing.T) {
+	t.Setenv("BLOCK_SIZE", "1K")
+	t.Setenv("BLOCKSIZE", "1MB")
+	ui := CreateStdoutUI(bytes.NewBuffer(nil), false, false, false, false, false, false, false, "", 0, false, 0)
+	assert.Equal(t, "2", ui.formatSize(1025))
+}
+
+func TestBlockSizeEnvironmentFormats(t *testing.T) {
+	tests := []struct {
+		name      string
+		blockSize string
+		size      int64
+		expected  string
+	}{
+		{name: "decimal suffix", blockSize: "kB", size: 1025, expected: "2kB"},
+		{name: "numeric suffix", blockSize: "2kB", size: 1025, expected: "1"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("BLOCK_SIZE", test.blockSize)
+			t.Setenv("BLOCKSIZE", "")
+			ui := CreateStdoutUI(bytes.NewBuffer(nil), false, false, false, false, false, false, false, "", 0, false, 0)
+			assert.Equal(t, test.expected, ui.formatSize(test.size))
+		})
+	}
+}
+
+func TestBlockSizeEnvironmentHumanReadableModes(t *testing.T) {
+	t.Run("binary", func(t *testing.T) {
+		t.Setenv("BLOCK_SIZE", "human-readable")
+		ui := CreateStdoutUI(bytes.NewBuffer(nil), false, false, false, false, false, false, false, "", 0, false, 0)
+		assert.Equal(t, "1.0 KiB", ui.formatSize(1025))
+	})
+	t.Run("si", func(t *testing.T) {
+		t.Setenv("BLOCK_SIZE", "si")
+		ui := CreateStdoutUI(bytes.NewBuffer(nil), false, false, false, false, false, false, false, "", 0, false, 0)
+		assert.Equal(t, "1.0 kB", ui.formatSize(1025))
+	})
+}
+
+func TestBlockSizeEnvironmentIsOverriddenByFlags(t *testing.T) {
+	t.Setenv("BLOCK_SIZE", "1K")
+	ui := CreateStdoutUI(bytes.NewBuffer(nil), false, false, false, false, false, false, true, "", 0, false, 0)
+	assert.Equal(t, "1025", ui.formatSize(1025))
+}
+
+func TestBlockSizeEnvironmentSIFlagOverridesEnvironment(t *testing.T) {
+	t.Setenv("BLOCK_SIZE", "1K")
+	ui := CreateStdoutUI(bytes.NewBuffer(nil), false, false, false, false, false, true, false, "", 0, false, 0)
+	assert.Equal(t, "1.0 kB", ui.formatSize(1025))
 }

--- a/tui/format.go
+++ b/tui/format.go
@@ -221,6 +221,9 @@ func (ui *UI) formatSize(size int64, reverseColor, transparentBg bool) string {
 		}
 	}
 
+	if formatted, ok := ui.FormatBlockSize(size); ok {
+		return formatted + color
+	}
 	if ui.UseSIPrefix {
 		return formatWithDecPrefix(size, color)
 	}

--- a/tui/format_test.go
+++ b/tui/format_test.go
@@ -2,12 +2,19 @@ package tui
 
 import (
 	"bytes"
+	"os"
 	"testing"
 
 	"github.com/dundee/gdu/v5/internal/testapp"
 	"github.com/dundee/gdu/v5/pkg/analyze"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestMain(m *testing.M) {
+	os.Unsetenv("BLOCK_SIZE")
+	os.Unsetenv("BLOCKSIZE")
+	os.Exit(m.Run())
+}
 
 func TestFormatSize(t *testing.T) {
 	simScreen := testapp.CreateSimScreen()
@@ -24,6 +31,15 @@ func TestFormatSize(t *testing.T) {
 	assert.Equal(t, "1.0[white:black:-] PiB", ui.formatSize(1<<50, false, false))
 	assert.Equal(t, "1.0[white:black:-] EiB", ui.formatSize(1<<60, false, false))
 	assert.Equal(t, "-1.0[white:black:-] KiB", ui.formatSize(-1<<10, false, false))
+}
+
+func TestFormatSizeWithBlockSizeEnvironment(t *testing.T) {
+	t.Setenv("BLOCK_SIZE", "1K")
+	simScreen := testapp.CreateSimScreen()
+	defer simScreen.Fini()
+
+	ui := CreateUI(testapp.CreateMockedApp(true), simScreen, &bytes.Buffer{}, false, false, false, false)
+	assert.Equal(t, "2[white:black:-]", ui.formatSize(1025, false, false))
 }
 
 func TestFormatSizeDec(t *testing.T) {

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -166,6 +166,9 @@ func CreateUI(
 		deleteQueue:             make(chan deleteQueueItem, 1000),
 		deleteWorkersCount:      3 * runtime.GOMAXPROCS(0),
 	}
+	if !useSIPrefix {
+		ui.SetBlockSizeFromEnvironment()
+	}
 	for _, o := range opts {
 		o(ui)
 	}


### PR DESCRIPTION
## Summary

- honor `BLOCK_SIZE`, falling back to `BLOCKSIZE`, across stdout, TUI, and export-progress terminal formatting
- support fixed GNU-style byte block sizes, `human-readable`, and `si`; round positive block counts up
- preserve precedence for explicit size-format flags and keep exported JSON values in raw bytes
- make formatter tests deterministic under externally supplied block-size variables

## Verification

- `go test -v -covermode=count ./...`
- `env BLOCK_SIZE=1K go test ./...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.2 run ./internal/common/... ./stdout/... ./tui/... ./report/... ./cmd/gdu/app/... ./cmd/gdu/...`
- CLI smoke tests with `BLOCK_SIZE=1K` and `BLOCKSIZE=kB`

Closes #120