### PR TITLE
feat: customize JSON export attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ When `--top` or `--depth` flags are used, the full directory tree is built in me
 
 Export mode (flag `-o`) outputs all usage data as JSON, which can be later opened using the `-f` flag. In interactive mode, press `Ctrl+C` during a scan to stop scheduling new work and keep the results found so far.
 
+By default the export includes every attribute, and directories always carry their `asize`, `dsize`, and `items` summary stats so they can be preserved on import. Use `--output-attrs=asize,dsize` to emit only selected optional attributes; `name` is always included. Available attributes are `asize`, `dsize`, `items`, `mtime`, and `notreg`.
+
 Gdu honors `BLOCK_SIZE` and `BLOCKSIZE` in terminal output. `BLOCK_SIZE` takes precedence; both accept GNU coreutils block-size values such as `1K`, `kB`, `human-readable`, and `si`. Explicit size-format flags override these environment variables. Exported JSON always retains raw byte values.
 
 Hard links are counted only once.

--- a/cmd/gdu/app/app.go
+++ b/cmd/gdu/app/app.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -57,6 +58,7 @@ type Flags struct {
 	LogFile            string    `yaml:"log-file"`
 	InputFile          string    `yaml:"input-file"`
 	OutputFile         string    `yaml:"output-file"`
+	OutputAttrs        string    `yaml:"output-attrs"`
 	IgnoreFromFile     string    `yaml:"ignore-from-file"`
 	IgnoreDirs         []string  `yaml:"ignore-dirs"`
 	IgnoreDirPatterns  []string  `yaml:"ignore-dir-patterns"`
@@ -231,13 +233,21 @@ func (a *App) Run() error {
 		return fmt.Errorf("--interactive and --non-interactive cannot be used at once")
 	}
 
+	outputAttributes, err := gfs.ParseJSONAttributes(a.Flags.OutputAttrs)
+	if err != nil {
+		return err
+	}
+	if a.Flags.OutputAttrs != "" && a.Flags.OutputFile == "" {
+		return errors.New("--output-attrs requires --output-file")
+	}
+
 	path := a.getPath()
-	path, err := filepath.Abs(path)
+	path, err = filepath.Abs(path)
 	if err != nil {
 		return err
 	}
 
-	ui, err = a.createUI()
+	ui, err = a.createUI(outputAttributes)
 	if err != nil {
 		return err
 	}
@@ -370,7 +380,7 @@ func (a *App) setTimeFilters(ui UI) error {
 	return nil
 }
 
-func (a *App) createUI() (UI, error) {
+func (a *App) createUI(outputAttributes gfs.JSONAttributes) (UI, error) {
 	var ui UI
 	var err error
 
@@ -405,6 +415,7 @@ func (a *App) createUI() (UI, error) {
 			a.Flags.Top,
 			a.Flags.Depth,
 			a.Flags.Summarize,
+			outputAttributes,
 		)
 	case a.Flags.ShouldRunInNonInteractiveMode(a.Istty):
 		fixedUnit := ""

--- a/cmd/gdu/app/app.go
+++ b/cmd/gdu/app/app.go
@@ -233,7 +233,7 @@ func (a *App) Run() error {
 		return fmt.Errorf("--interactive and --non-interactive cannot be used at once")
 	}
 
-	outputAttributes, err := gfs.ParseJSONAttributes(a.Flags.OutputAttrs)
+	outputAttributes, err := parseJSONAttributes(a.Flags.OutputAttrs)
 	if err != nil {
 		return err
 	}

--- a/cmd/gdu/app/app_test.go
+++ b/cmd/gdu/app/app_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"bytes"
+	"encoding/json"
 	"io"
 	"os"
 	"regexp"
@@ -435,6 +436,75 @@ func TestAnalyzePathWithExport(t *testing.T) {
 
 	assert.NotEmpty(t, out)
 	assert.Nil(t, err)
+}
+
+func TestAnalyzePathWithCustomizedExport(t *testing.T) {
+	fin := testdir.CreateTestDir()
+	defer fin()
+	defer os.Remove("output.json")
+
+	out, err := runApp(
+		&Flags{
+			LogFile:     "/dev/null",
+			OutputFile:  "output.json",
+			OutputAttrs: "asize,dsize",
+		},
+		[]string{"test_dir"},
+		false,
+		testdev.DevicesInfoGetterMock{},
+	)
+
+	assert.Empty(t, out)
+	assert.NoError(t, err)
+
+	content, err := os.ReadFile("output.json")
+	assert.NoError(t, err)
+
+	var report []any
+	assert.NoError(t, json.Unmarshal(content, &report))
+	assertOutputAttributes(t, report[3])
+}
+
+func assertOutputAttributes(t *testing.T, value any) {
+	t.Helper()
+
+	switch value := value.(type) {
+	case []any:
+		for _, child := range value {
+			assertOutputAttributes(t, child)
+		}
+	case map[string]any:
+		assert.Contains(t, value, "name")
+		for attribute := range value {
+			assert.Contains(t, []string{"name", "asize", "dsize"}, attribute)
+		}
+	default:
+		t.Fatalf("unexpected JSON value %T", value)
+	}
+}
+
+func TestOutputAttributesRequireExport(t *testing.T) {
+	out, err := runApp(
+		&Flags{LogFile: "/dev/null", OutputAttrs: "asize"},
+		nil,
+		false,
+		testdev.DevicesInfoGetterMock{},
+	)
+
+	assert.Empty(t, out)
+	assert.EqualError(t, err, "--output-attrs requires --output-file")
+}
+
+func TestOutputAttributesRejectUnknownAttribute(t *testing.T) {
+	out, err := runApp(
+		&Flags{LogFile: "/dev/null", OutputFile: "output.json", OutputAttrs: "size"},
+		nil,
+		false,
+		testdev.DevicesInfoGetterMock{},
+	)
+
+	assert.Empty(t, out)
+	assert.EqualError(t, err, `unknown JSON output attribute "size"`)
 }
 
 func TestAnalyzePathWithExportAndTop(t *testing.T) {

--- a/cmd/gdu/app/output_attrs.go
+++ b/cmd/gdu/app/output_attrs.go
@@ -1,0 +1,30 @@
+package app
+
+import (
+	"fmt"
+	"strings"
+
+	gfs "github.com/dundee/gdu/v5/pkg/fs"
+)
+
+// parseJSONAttributes parses the comma-separated --output-attrs value into the
+// set of optional attributes to include in the JSON export. An empty value
+// yields a nil set, which preserves the complete legacy export.
+func parseJSONAttributes(value string) (gfs.JSONAttributes, error) {
+	if value == "" {
+		return nil, nil
+	}
+
+	attributes := make(gfs.JSONAttributes)
+	for _, attribute := range strings.Split(value, ",") {
+		attribute = strings.TrimSpace(attribute)
+		switch attribute {
+		case "name", "asize", "dsize", "items", "mtime", "notreg":
+			attributes[attribute] = struct{}{}
+		default:
+			return nil, fmt.Errorf("unknown JSON output attribute %q", attribute)
+		}
+	}
+
+	return attributes, nil
+}

--- a/cmd/gdu/app/output_attrs_test.go
+++ b/cmd/gdu/app/output_attrs_test.go
@@ -1,0 +1,42 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseJSONAttributes(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		included []string
+		excluded []string
+		valid    bool
+	}{
+		{name: "default", valid: true, included: []string{"asize", "dsize", "items", "mtime", "notreg"}},
+		{name: "selected", value: "asize, dsize", valid: true, included: []string{"asize", "dsize"}, excluded: []string{"items", "mtime", "notreg"}},
+		{name: "name", value: "name", valid: true, excluded: []string{"asize", "dsize", "items", "mtime", "notreg"}},
+		{name: "items", value: "items", valid: true, included: []string{"items"}, excluded: []string{"asize", "dsize", "mtime", "notreg"}},
+		{name: "unknown", value: "size", valid: false},
+		{name: "empty selection", value: "asize,", valid: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			attributes, err := parseJSONAttributes(test.value)
+			if !test.valid {
+				assert.ErrorContains(t, err, "unknown JSON output attribute")
+				return
+			}
+
+			assert.NoError(t, err)
+			for _, attribute := range test.included {
+				assert.True(t, attributes.Includes(attribute))
+			}
+			for _, attribute := range test.excluded {
+				assert.False(t, attributes.Includes(attribute))
+			}
+		})
+	}
+}

--- a/cmd/gdu/main.go
+++ b/cmd/gdu/main.go
@@ -49,6 +49,7 @@ func init() {
 	flags.StringVar(&af.CfgFile, "config-file", "", "Read config from file (default is $HOME/.gdu.yaml)")
 	flags.StringVarP(&af.LogFile, "log-file", "l", "/dev/null", "Path to a logfile")
 	flags.StringVarP(&af.OutputFile, "output-file", "o", "", "Export all info into file as JSON")
+	flags.StringVar(&af.OutputAttrs, "output-attrs", "", "Export only selected JSON attributes (name,asize,dsize,items,mtime,notreg)")
 	flags.StringVarP(&af.InputFile, "input-file", "f", "", "Import analysis from JSON file")
 	flags.IntVarP(&af.MaxCores, "max-cores", "m", runtime.NumCPU(), fmt.Sprintf("Set max cores that Gdu will use. %d cores available", runtime.NumCPU()))
 	flags.BoolVar(&af.SequentialScanning, "sequential", false, "Use sequential scanning (intended for rotating HDDs)")

--- a/pkg/analyze/encode.go
+++ b/pkg/analyze/encode.go
@@ -4,10 +4,12 @@ import (
 	"encoding/json"
 	"io"
 	"strconv"
+
+	"github.com/dundee/gdu/v5/pkg/fs"
 )
 
 // EncodeJSON writes JSON representation of dir
-func (f *Dir) EncodeJSON(writer io.Writer, topLevel bool) error {
+func (f *Dir) EncodeJSON(writer io.Writer, topLevel bool, attributes fs.JSONAttributes) error {
 	buff := make([]byte, 0, 20)
 
 	buff = append(buff, []byte(`[{"name":`)...)
@@ -22,13 +24,22 @@ func (f *Dir) EncodeJSON(writer io.Writer, topLevel bool) error {
 		}
 	}
 
-	buff = append(buff, []byte(`,"asize":`)...)
-	buff = append(buff, []byte(strconv.FormatInt(f.GetSize(), 10))...)
-	buff = append(buff, []byte(`,"dsize":`)...)
-	buff = append(buff, []byte(strconv.FormatInt(f.GetUsage(), 10))...)
-	buff = append(buff, []byte(`,"items":`)...)
-	buff = append(buff, []byte(strconv.FormatInt(f.GetItemCount(), 10))...)
-	if !f.GetMtime().IsZero() {
+	// Directory summary stats (asize, dsize, items) are written by default so
+	// they can be preserved on import. When --output-attrs is supplied, each is
+	// emitted only if explicitly selected.
+	if attributes.Includes("asize") {
+		buff = append(buff, []byte(`,"asize":`)...)
+		buff = append(buff, []byte(strconv.FormatInt(f.GetSize(), 10))...)
+	}
+	if attributes.Includes("dsize") {
+		buff = append(buff, []byte(`,"dsize":`)...)
+		buff = append(buff, []byte(strconv.FormatInt(f.GetUsage(), 10))...)
+	}
+	if attributes.Includes("items") {
+		buff = append(buff, []byte(`,"items":`)...)
+		buff = append(buff, []byte(strconv.FormatInt(f.GetItemCount(), 10))...)
+	}
+	if attributes.Includes("mtime") && !f.GetMtime().IsZero() {
 		buff = append(buff, []byte(`,"mtime":`)...)
 		buff = append(buff, []byte(strconv.FormatInt(f.GetMtime().Unix(), 10))...)
 	}
@@ -49,7 +60,7 @@ func (f *Dir) EncodeJSON(writer io.Writer, topLevel bool) error {
 				return err
 			}
 		}
-		err := item.EncodeJSON(writer, false)
+		err := item.EncodeJSON(writer, false, attributes)
 		if err != nil {
 			return err
 		}
@@ -62,30 +73,30 @@ func (f *Dir) EncodeJSON(writer io.Writer, topLevel bool) error {
 }
 
 // EncodeJSON writes JSON representation of file
-func (f *File) EncodeJSON(writer io.Writer, topLevel bool) error {
+func (f *File) EncodeJSON(writer io.Writer, _ bool, attributes fs.JSONAttributes) error {
 	buff := make([]byte, 0, 20)
 
 	buff = append(buff, []byte(`{"name":`)...)
 	if err := addString(&buff, f.GetName()); err != nil {
 		return err
 	}
-	if f.GetSize() > 0 {
+	if attributes.Includes("asize") && f.GetSize() > 0 {
 		buff = append(buff, []byte(`,"asize":`)...)
 		buff = append(buff, []byte(strconv.FormatInt(f.GetSize(), 10))...)
 	}
-	if f.GetUsage() > 0 {
+	if attributes.Includes("dsize") && f.GetUsage() > 0 {
 		buff = append(buff, []byte(`,"dsize":`)...)
 		buff = append(buff, []byte(strconv.FormatInt(f.GetUsage(), 10))...)
 	}
-	if !f.GetMtime().IsZero() {
+	if attributes.Includes("mtime") && !f.GetMtime().IsZero() {
 		buff = append(buff, []byte(`,"mtime":`)...)
 		buff = append(buff, []byte(strconv.FormatInt(f.GetMtime().Unix(), 10))...)
 	}
 
-	if f.Flag == '@' {
+	if attributes.Includes("notreg") && f.Flag == '@' {
 		buff = append(buff, []byte(`,"notreg":true`)...)
 	}
-	if f.Flag == 'H' {
+	if attributes == nil && f.Flag == 'H' {
 		buff = append(buff, []byte(`,"ino":`+strconv.FormatUint(f.Mli, 10)+`,"hlnkc":true`)...)
 	}
 

--- a/pkg/analyze/encode_test.go
+++ b/pkg/analyze/encode_test.go
@@ -58,7 +58,7 @@ func TestEncode(t *testing.T) {
 	subdir.Files = fs.Files{file, file2, file3}
 
 	var buff bytes.Buffer
-	err := dir.EncodeJSON(&buff, true)
+	err := dir.EncodeJSON(&buff, true, nil)
 
 	assert.Nil(t, err)
 	assert.Contains(t, buff.String(), `"name":"nested"`)
@@ -73,8 +73,36 @@ func TestEncodeEmptyDir(t *testing.T) {
 	dir := &Dir{File: &File{Name: "empty"}}
 
 	var buff bytes.Buffer
-	err := dir.EncodeJSON(&buff, false)
+	err := dir.EncodeJSON(&buff, false, nil)
 
 	assert.NoError(t, err)
 	assert.Equal(t, "[{\"name\":\"empty\",\"asize\":0,\"dsize\":0,\"items\":0}\n]", buff.String())
+}
+
+func TestEncodeSelectedAttributes(t *testing.T) {
+	dir := &Dir{
+		File: &File{
+			Name:  "test_dir",
+			Size:  10,
+			Usage: 18,
+			Mtime: time.Date(2021, 8, 19, 0, 40, 0, 0, time.UTC),
+		},
+		BasePath: ".",
+	}
+	dir.AddFile(&File{
+		Name:  "file",
+		Size:  3,
+		Usage: 4,
+		Mtime: time.Date(2021, 8, 19, 0, 40, 0, 0, time.UTC),
+		Flag:  '@',
+	})
+
+	var buff bytes.Buffer
+	err := dir.EncodeJSON(&buff, true, fs.JSONAttributes{"asize": {}, "dsize": {}})
+
+	assert.NoError(t, err)
+	assert.Contains(t, buff.String(), `"name":"test_dir","asize":10,"dsize":18`)
+	assert.Contains(t, buff.String(), `"name":"file","asize":3,"dsize":4`)
+	assert.NotContains(t, buff.String(), `"mtime"`)
+	assert.NotContains(t, buff.String(), `"notreg"`)
 }

--- a/pkg/analyze/sqlite.go
+++ b/pkg/analyze/sqlite.go
@@ -632,14 +632,14 @@ func (i *SqliteItem) GetMultiLinkedInode() uint64 {
 }
 
 // EncodeJSON encodes the item to JSON
-func (i *SqliteItem) EncodeJSON(writer io.Writer, topLevel bool) error {
+func (i *SqliteItem) EncodeJSON(writer io.Writer, topLevel bool, attributes fs.JSONAttributes) error {
 	if i.isDir {
-		return i.encodeDirJSON(writer, topLevel)
+		return i.encodeDirJSON(writer, topLevel, attributes)
 	}
-	return i.encodeFileJSON(writer)
+	return i.encodeFileJSON(writer, attributes)
 }
 
-func (i *SqliteItem) encodeDirJSON(writer io.Writer, topLevel bool) error {
+func (i *SqliteItem) encodeDirJSON(writer io.Writer, topLevel bool, attributes fs.JSONAttributes) error {
 	buff := make([]byte, 0, 128)
 	buff = append(buff, []byte(`[{"name":`)...)
 
@@ -651,13 +651,22 @@ func (i *SqliteItem) encodeDirJSON(writer io.Writer, topLevel bool) error {
 		return err
 	}
 
-	buff = append(buff, []byte(`,"asize":`)...)
-	buff = append(buff, []byte(strconv.FormatInt(i.GetSize(), 10))...)
-	buff = append(buff, []byte(`,"dsize":`)...)
-	buff = append(buff, []byte(strconv.FormatInt(i.GetUsage(), 10))...)
-	buff = append(buff, []byte(`,"items":`)...)
-	buff = append(buff, []byte(strconv.FormatInt(i.GetItemCount(), 10))...)
-	if !i.GetMtime().IsZero() {
+	// Directory summary stats (asize, dsize, items) are written by default so
+	// they can be preserved on import. When --output-attrs is supplied, each is
+	// emitted only if explicitly selected.
+	if attributes.Includes("asize") {
+		buff = append(buff, []byte(`,"asize":`)...)
+		buff = append(buff, []byte(strconv.FormatInt(i.GetSize(), 10))...)
+	}
+	if attributes.Includes("dsize") {
+		buff = append(buff, []byte(`,"dsize":`)...)
+		buff = append(buff, []byte(strconv.FormatInt(i.GetUsage(), 10))...)
+	}
+	if attributes.Includes("items") {
+		buff = append(buff, []byte(`,"items":`)...)
+		buff = append(buff, []byte(strconv.FormatInt(i.GetItemCount(), 10))...)
+	}
+	if attributes.Includes("mtime") && !i.GetMtime().IsZero() {
 		buff = append(buff, []byte(`,"mtime":`)...)
 		buff = append(buff, []byte(strconv.FormatInt(i.GetMtime().Unix(), 10))...)
 	}
@@ -685,7 +694,7 @@ func (i *SqliteItem) encodeDirJSON(writer io.Writer, topLevel bool) error {
 			}
 		}
 		child.parent = i
-		if err := child.EncodeJSON(writer, false); err != nil {
+		if err := child.EncodeJSON(writer, false, attributes); err != nil {
 			return err
 		}
 	}
@@ -696,29 +705,29 @@ func (i *SqliteItem) encodeDirJSON(writer io.Writer, topLevel bool) error {
 	return nil
 }
 
-func (i *SqliteItem) encodeFileJSON(writer io.Writer) error {
+func (i *SqliteItem) encodeFileJSON(writer io.Writer, attributes fs.JSONAttributes) error {
 	buff := make([]byte, 0, 128)
 	buff = append(buff, []byte(`{"name":`)...)
 	if err := addSqliteString(&buff, i.GetName()); err != nil {
 		return err
 	}
-	if i.GetSize() > 0 {
+	if attributes.Includes("asize") && i.GetSize() > 0 {
 		buff = append(buff, []byte(`,"asize":`)...)
 		buff = append(buff, []byte(strconv.FormatInt(i.GetSize(), 10))...)
 	}
-	if i.GetUsage() > 0 {
+	if attributes.Includes("dsize") && i.GetUsage() > 0 {
 		buff = append(buff, []byte(`,"dsize":`)...)
 		buff = append(buff, []byte(strconv.FormatInt(i.GetUsage(), 10))...)
 	}
-	if !i.GetMtime().IsZero() {
+	if attributes.Includes("mtime") && !i.GetMtime().IsZero() {
 		buff = append(buff, []byte(`,"mtime":`)...)
 		buff = append(buff, []byte(strconv.FormatInt(i.GetMtime().Unix(), 10))...)
 	}
 
-	if i.flag == '@' {
+	if attributes.Includes("notreg") && i.flag == '@' {
 		buff = append(buff, []byte(`,"notreg":true`)...)
 	}
-	if i.flag == 'H' {
+	if attributes == nil && i.flag == 'H' {
 		buff = append(buff, []byte(`,"ino":`+strconv.FormatUint(i.mli, 10)+`,"hlnkc":true`)...)
 	}
 

--- a/pkg/analyze/sqlite_test.go
+++ b/pkg/analyze/sqlite_test.go
@@ -655,7 +655,7 @@ func TestSqliteItemEncodeJSON(t *testing.T) {
 	root, _ := storage.GetItemByID(rootID)
 
 	var buf bytes.Buffer
-	err = root.EncodeJSON(&buf, false)
+	err = root.EncodeJSON(&buf, false, nil)
 	assert.NoError(t, err)
 
 	expected := `[{"name":"root","asize":100,"dsize":200,"items":2,"mtime":1600000000},
@@ -673,9 +673,54 @@ func TestSqliteItemEncodeEmptyDirJSON(t *testing.T) {
 	root, _ := storage.GetItemByID(rootID)
 
 	var buf bytes.Buffer
-	err = root.EncodeJSON(&buf, false)
+	err = root.EncodeJSON(&buf, false, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, "[{\"name\":\"empty\",\"asize\":0,\"dsize\":0,\"items\":0}\n]", buf.String())
+}
+
+func TestSqliteItemEncodeJSONWithSelectedAttributes(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	storage, err := NewSqliteStorage(dbPath)
+	assert.NoError(t, err)
+	defer storage.Close()
+
+	mtime := time.Unix(1600000000, 0)
+	rootID, _ := storage.InsertItem(nil, "root", true, 100, 200, mtime, 2, 0, ' ')
+	storage.InsertItem(&rootID, "file.txt", false, 10, 20, mtime, 1, 0, ' ')
+
+	root, _ := storage.GetItemByID(rootID)
+	var buf bytes.Buffer
+	err = root.EncodeJSON(&buf, false, fs.JSONAttributes{"asize": {}, "dsize": {}})
+
+	assert.NoError(t, err)
+	assert.Equal(t, `[{"name":"root","asize":100,"dsize":200},
+{"name":"file.txt","asize":10,"dsize":20}]`, buf.String())
+}
+
+func TestSqliteItemEncodeJSONWithSpecialAttributes(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	storage, err := NewSqliteStorage(dbPath)
+	assert.NoError(t, err)
+	defer storage.Close()
+
+	mtime := time.Unix(1600000000, 0)
+	rootID, _ := storage.InsertItem(nil, "root", true, 0, 0, mtime, 3, 0, ' ')
+	storage.InsertItem(&rootID, "other", false, 0, 0, mtime, 1, 0, '@')
+	storage.InsertItem(&rootID, "link", false, 0, 0, mtime, 1, 123, 'H')
+
+	root, _ := storage.GetItemByID(rootID)
+	var buf bytes.Buffer
+	err = root.EncodeJSON(&buf, false, nil)
+	assert.NoError(t, err)
+	assert.Contains(t, buf.String(), `"notreg":true`)
+	assert.Contains(t, buf.String(), `"ino":123,"hlnkc":true`)
+
+	buf.Reset()
+	err = root.EncodeJSON(&buf, false, fs.JSONAttributes{"notreg": {}})
+	assert.NoError(t, err)
+	assert.Contains(t, buf.String(), `"notreg":true`)
+	assert.NotContains(t, buf.String(), `"ino"`)
+	assert.NotContains(t, buf.String(), `"mtime"`)
 }
 
 func TestCreateSqliteAnalyzer(t *testing.T) {

--- a/pkg/analyze/stored.go
+++ b/pkg/analyze/stored.go
@@ -421,19 +421,19 @@ type ParentDir struct {
 func (p *ParentDir) GetPath() string {
 	return p.Path
 }
-func (p *ParentDir) GetName() string                                  { panic("must not be called") }
-func (p *ParentDir) GetFlag() rune                                    { panic("must not be called") }
-func (p *ParentDir) IsDir() bool                                      { panic("must not be called") }
-func (p *ParentDir) GetSize() int64                                   { panic("must not be called") }
-func (p *ParentDir) GetType() string                                  { panic("must not be called") }
-func (p *ParentDir) GetUsage() int64                                  { panic("must not be called") }
-func (p *ParentDir) GetMtime() time.Time                              { panic("must not be called") }
-func (p *ParentDir) GetItemCount() int64                              { panic("must not be called") }
-func (p *ParentDir) GetParent() fs.Item                               { panic("must not be called") }
-func (p *ParentDir) SetParent(fs.Item)                                { panic("must not be called") }
-func (p *ParentDir) GetMultiLinkedInode() uint64                      { panic("must not be called") }
-func (p *ParentDir) EncodeJSON(writer io.Writer, topLevel bool) error { panic("must not be called") }
-func (p *ParentDir) UpdateStats(linkedItems fs.HardLinkedItems)       { panic("must not be called") }
+func (p *ParentDir) GetName() string                                     { panic("must not be called") }
+func (p *ParentDir) GetFlag() rune                                       { panic("must not be called") }
+func (p *ParentDir) IsDir() bool                                         { panic("must not be called") }
+func (p *ParentDir) GetSize() int64                                      { panic("must not be called") }
+func (p *ParentDir) GetType() string                                     { panic("must not be called") }
+func (p *ParentDir) GetUsage() int64                                     { panic("must not be called") }
+func (p *ParentDir) GetMtime() time.Time                                 { panic("must not be called") }
+func (p *ParentDir) GetItemCount() int64                                 { panic("must not be called") }
+func (p *ParentDir) GetParent() fs.Item                                  { panic("must not be called") }
+func (p *ParentDir) SetParent(fs.Item)                                   { panic("must not be called") }
+func (p *ParentDir) GetMultiLinkedInode() uint64                         { panic("must not be called") }
+func (p *ParentDir) EncodeJSON(io.Writer, bool, fs.JSONAttributes) error { panic("must not be called") }
+func (p *ParentDir) UpdateStats(linkedItems fs.HardLinkedItems)          { panic("must not be called") }
 func (p *ParentDir) UpdateStatsWithFileFiltering(linkedItems fs.HardLinkedItems) {
 	panic("must not be called")
 }

--- a/pkg/analyze/stored_test.go
+++ b/pkg/analyze/stored_test.go
@@ -235,7 +235,7 @@ func TestParentDirEncodeJSONPanics(t *testing.T) {
 		}
 	}()
 	dir := &ParentDir{}
-	err := dir.EncodeJSON(nil, false)
+	err := dir.EncodeJSON(nil, false, nil)
 	assert.NoError(t, err)
 }
 

--- a/pkg/analyze/tardir.go
+++ b/pkg/analyze/tardir.go
@@ -38,8 +38,8 @@ func (tf *TarFile) GetType() string {
 }
 
 // EncodeJSON encodes tar file to JSON
-func (tf *TarFile) EncodeJSON(writer io.Writer, topLevel bool) error {
-	return tf.File.EncodeJSON(writer, topLevel)
+func (tf *TarFile) EncodeJSON(writer io.Writer, topLevel bool, attributes fs.JSONAttributes) error {
+	return tf.File.EncodeJSON(writer, topLevel, attributes)
 }
 
 // GetType returns type of tar directory
@@ -53,8 +53,8 @@ func (td *TarDir) IsDir() bool {
 }
 
 // EncodeJSON encodes tar directory to JSON
-func (td *TarDir) EncodeJSON(writer io.Writer, topLevel bool) error {
-	return td.Dir.EncodeJSON(writer, topLevel)
+func (td *TarDir) EncodeJSON(writer io.Writer, topLevel bool, attributes fs.JSONAttributes) error {
+	return td.Dir.EncodeJSON(writer, topLevel, attributes)
 }
 
 // GetPath returns the virtual path for tar directory

--- a/pkg/analyze/tardir_test.go
+++ b/pkg/analyze/tardir_test.go
@@ -383,7 +383,7 @@ func TestTarFileEncodeJSON(t *testing.T) {
 		inTarPath: "x.txt",
 	}
 	var buf bytes.Buffer
-	assert.NoError(t, tf.EncodeJSON(&buf, false))
+	assert.NoError(t, tf.EncodeJSON(&buf, false, nil))
 	assert.NotEmpty(t, buf.String())
 }
 
@@ -403,7 +403,7 @@ func TestTarDirEncodeJSON(t *testing.T) {
 		tarPath: "/a.tar",
 	}
 	var buf bytes.Buffer
-	assert.NoError(t, td.EncodeJSON(&buf, true))
+	assert.NoError(t, td.EncodeJSON(&buf, true, nil))
 	assert.NotEmpty(t, buf.String())
 }
 

--- a/pkg/analyze/top_dir.go
+++ b/pkg/analyze/top_dir.go
@@ -72,14 +72,14 @@ func (d *SimpleDir) GetPath() string {
 	return d.BasePath + pathSep + d.Name
 }
 
-func (d *SimpleDir) GetFlag() rune                                    { panic("not implemented") }
-func (d *SimpleDir) GetType() string                                  { panic("not implemented") }
-func (d *SimpleDir) GetMtime() time.Time                              { panic("not implemented") }
-func (d *SimpleDir) GetItemCount() int64                              { panic("not implemented") }
-func (d *SimpleDir) GetParent() fs.Item                               { panic("not implemented") }
-func (d *SimpleDir) SetParent(parent fs.Item)                         { panic("not implemented") }
-func (d *SimpleDir) GetMultiLinkedInode() uint64                      { panic("not implemented") }
-func (d *SimpleDir) EncodeJSON(writer io.Writer, topLevel bool) error { panic("not implemented") }
+func (d *SimpleDir) GetFlag() rune                                       { panic("not implemented") }
+func (d *SimpleDir) GetType() string                                     { panic("not implemented") }
+func (d *SimpleDir) GetMtime() time.Time                                 { panic("not implemented") }
+func (d *SimpleDir) GetItemCount() int64                                 { panic("not implemented") }
+func (d *SimpleDir) GetParent() fs.Item                                  { panic("not implemented") }
+func (d *SimpleDir) SetParent(parent fs.Item)                            { panic("not implemented") }
+func (d *SimpleDir) GetMultiLinkedInode() uint64                         { panic("not implemented") }
+func (d *SimpleDir) EncodeJSON(io.Writer, bool, fs.JSONAttributes) error { panic("not implemented") }
 func (d *SimpleDir) GetItemStats(linkedItems fs.HardLinkedItems, filteringFiles bool) (itemCount, size, usage int64) {
 	panic("not implemented")
 }

--- a/pkg/analyze/top_dir_test.go
+++ b/pkg/analyze/top_dir_test.go
@@ -165,7 +165,7 @@ func TestSimpleDirPanics(t *testing.T) {
 	assert.Panics(t, func() { d.GetParent() })
 	assert.Panics(t, func() { d.SetParent(nil) })
 	assert.Panics(t, func() { d.GetMultiLinkedInode() })
-	assert.Panics(t, func() { d.EncodeJSON(nil, false) })
+	assert.Panics(t, func() { d.EncodeJSON(nil, false, nil) })
 	assert.Panics(t, func() { d.GetItemStats(nil, false) })
 	assert.Panics(t, func() { d.AddFile(nil) })
 	assert.Panics(t, func() {

--- a/pkg/analyze/zipdir.go
+++ b/pkg/analyze/zipdir.go
@@ -35,9 +35,9 @@ func (zf *ZipFile) GetType() string {
 }
 
 // EncodeJSON encodes zip file to JSON
-func (zf *ZipFile) EncodeJSON(writer io.Writer, topLevel bool) error {
+func (zf *ZipFile) EncodeJSON(writer io.Writer, topLevel bool, attributes fs.JSONAttributes) error {
 	// Use the embedded File's EncodeJSON method
-	return zf.File.EncodeJSON(writer, topLevel)
+	return zf.File.EncodeJSON(writer, topLevel, attributes)
 }
 
 // GetType returns type of zip directory
@@ -51,9 +51,9 @@ func (zd *ZipDir) IsDir() bool {
 }
 
 // EncodeJSON encodes zip directory to JSON
-func (zd *ZipDir) EncodeJSON(writer io.Writer, topLevel bool) error {
+func (zd *ZipDir) EncodeJSON(writer io.Writer, topLevel bool, attributes fs.JSONAttributes) error {
 	// Use the embedded Dir's EncodeJSON method
-	return zd.Dir.EncodeJSON(writer, topLevel)
+	return zd.Dir.EncodeJSON(writer, topLevel, attributes)
 }
 
 // GetPath returns the virtual path for zip directory

--- a/pkg/analyze/zipdir_coverage_test.go
+++ b/pkg/analyze/zipdir_coverage_test.go
@@ -31,7 +31,7 @@ func TestZipFileEncodeJSON(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	err := zipFile.EncodeJSON(&buf, false)
+	err := zipFile.EncodeJSON(&buf, false, nil)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, buf.String())
 }
@@ -47,7 +47,7 @@ func TestZipDirEncodeJSON(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	err := zipDir.EncodeJSON(&buf, false)
+	err := zipDir.EncodeJSON(&buf, false, nil)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, buf.String())
 }

--- a/pkg/fs/file.go
+++ b/pkg/fs/file.go
@@ -1,10 +1,8 @@
 package fs
 
 import (
-	"fmt"
 	"io"
 	"iter"
-	"strings"
 	"time"
 
 	"github.com/maruel/natural"
@@ -28,39 +26,6 @@ const (
 	SortAsc SortOrder = iota
 	SortDesc
 )
-
-// JSONAttributes selects optional attributes written to an analysis export.
-// A nil set preserves the complete legacy export.
-type JSONAttributes map[string]struct{}
-
-// ParseJSONAttributes parses the comma-separated --output-attrs value.
-func ParseJSONAttributes(value string) (JSONAttributes, error) {
-	if value == "" {
-		return nil, nil
-	}
-
-	attributes := make(JSONAttributes)
-	for _, attribute := range strings.Split(value, ",") {
-		attribute = strings.TrimSpace(attribute)
-		switch attribute {
-		case "name", "asize", "dsize", "items", "mtime", "notreg":
-			attributes[attribute] = struct{}{}
-		default:
-			return nil, fmt.Errorf("unknown JSON output attribute %q", attribute)
-		}
-	}
-
-	return attributes, nil
-}
-
-// Includes reports whether an optional JSON attribute should be written.
-func (attributes JSONAttributes) Includes(attribute string) bool {
-	if attributes == nil {
-		return true
-	}
-	_, ok := attributes[attribute]
-	return ok
-}
 
 // Item is a FS item (file or dir)
 type Item interface {

--- a/pkg/fs/file.go
+++ b/pkg/fs/file.go
@@ -1,8 +1,10 @@
 package fs
 
 import (
+	"fmt"
 	"io"
 	"iter"
+	"strings"
 	"time"
 
 	"github.com/maruel/natural"
@@ -27,6 +29,39 @@ const (
 	SortDesc
 )
 
+// JSONAttributes selects optional attributes written to an analysis export.
+// A nil set preserves the complete legacy export.
+type JSONAttributes map[string]struct{}
+
+// ParseJSONAttributes parses the comma-separated --output-attrs value.
+func ParseJSONAttributes(value string) (JSONAttributes, error) {
+	if value == "" {
+		return nil, nil
+	}
+
+	attributes := make(JSONAttributes)
+	for _, attribute := range strings.Split(value, ",") {
+		attribute = strings.TrimSpace(attribute)
+		switch attribute {
+		case "name", "asize", "dsize", "items", "mtime", "notreg":
+			attributes[attribute] = struct{}{}
+		default:
+			return nil, fmt.Errorf("unknown JSON output attribute %q", attribute)
+		}
+	}
+
+	return attributes, nil
+}
+
+// Includes reports whether an optional JSON attribute should be written.
+func (attributes JSONAttributes) Includes(attribute string) bool {
+	if attributes == nil {
+		return true
+	}
+	_, ok := attributes[attribute]
+	return ok
+}
+
 // Item is a FS item (file or dir)
 type Item interface {
 	GetPath() string
@@ -41,7 +76,7 @@ type Item interface {
 	GetParent() Item
 	SetParent(Item)
 	GetMultiLinkedInode() uint64
-	EncodeJSON(writer io.Writer, topLevel bool) error
+	EncodeJSON(writer io.Writer, topLevel bool, attributes JSONAttributes) error
 	GetItemStats(linkedItems HardLinkedItems, filteringFiles bool) (itemCount int64, size, usage int64)
 	UpdateStats(linkedItems HardLinkedItems)
 	UpdateStatsWithFileFiltering(linkedItems HardLinkedItems)

--- a/pkg/fs/json_attributes.go
+++ b/pkg/fs/json_attributes.go
@@ -1,0 +1,14 @@
+package fs
+
+// JSONAttributes selects optional attributes written to an analysis export.
+// A nil set preserves the complete legacy export.
+type JSONAttributes map[string]struct{}
+
+// Includes reports whether an optional JSON attribute should be written.
+func (attributes JSONAttributes) Includes(attribute string) bool {
+	if attributes == nil {
+		return true
+	}
+	_, ok := attributes[attribute]
+	return ok
+}

--- a/pkg/fs/json_attributes_test.go
+++ b/pkg/fs/json_attributes_test.go
@@ -6,37 +6,22 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestParseJSONAttributes(t *testing.T) {
-	tests := []struct {
-		name     string
-		value    string
-		included []string
-		excluded []string
-		valid    bool
-	}{
-		{name: "default", valid: true, included: []string{"asize", "dsize", "items", "mtime", "notreg"}},
-		{name: "selected", value: "asize, dsize", valid: true, included: []string{"asize", "dsize"}, excluded: []string{"items", "mtime", "notreg"}},
-		{name: "name", value: "name", valid: true, excluded: []string{"asize", "dsize", "items", "mtime", "notreg"}},
-		{name: "items", value: "items", valid: true, included: []string{"items"}, excluded: []string{"asize", "dsize", "mtime", "notreg"}},
-		{name: "unknown", value: "size", valid: false},
-		{name: "empty selection", value: "asize,", valid: false},
-	}
+func TestJSONAttributesIncludes(t *testing.T) {
+	t.Run("nil set includes every attribute", func(t *testing.T) {
+		var attributes JSONAttributes
+		assert.True(t, attributes.Includes("asize"))
+		assert.True(t, attributes.Includes("anything"))
+	})
 
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			attributes, err := ParseJSONAttributes(test.value)
-			if !test.valid {
-				assert.ErrorContains(t, err, "unknown JSON output attribute")
-				return
-			}
+	t.Run("empty set includes nothing", func(t *testing.T) {
+		attributes := JSONAttributes{}
+		assert.False(t, attributes.Includes("asize"))
+	})
 
-			assert.NoError(t, err)
-			for _, attribute := range test.included {
-				assert.True(t, attributes.Includes(attribute))
-			}
-			for _, attribute := range test.excluded {
-				assert.False(t, attributes.Includes(attribute))
-			}
-		})
-	}
+	t.Run("selected set includes only its members", func(t *testing.T) {
+		attributes := JSONAttributes{"asize": {}, "dsize": {}}
+		assert.True(t, attributes.Includes("asize"))
+		assert.True(t, attributes.Includes("dsize"))
+		assert.False(t, attributes.Includes("items"))
+	})
 }

--- a/pkg/fs/json_attributes_test.go
+++ b/pkg/fs/json_attributes_test.go
@@ -1,0 +1,42 @@
+package fs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseJSONAttributes(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		included []string
+		excluded []string
+		valid    bool
+	}{
+		{name: "default", valid: true, included: []string{"asize", "dsize", "items", "mtime", "notreg"}},
+		{name: "selected", value: "asize, dsize", valid: true, included: []string{"asize", "dsize"}, excluded: []string{"items", "mtime", "notreg"}},
+		{name: "name", value: "name", valid: true, excluded: []string{"asize", "dsize", "items", "mtime", "notreg"}},
+		{name: "items", value: "items", valid: true, included: []string{"items"}, excluded: []string{"asize", "dsize", "mtime", "notreg"}},
+		{name: "unknown", value: "size", valid: false},
+		{name: "empty selection", value: "asize,", valid: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			attributes, err := ParseJSONAttributes(test.value)
+			if !test.valid {
+				assert.ErrorContains(t, err, "unknown JSON output attribute")
+				return
+			}
+
+			assert.NoError(t, err)
+			for _, attribute := range test.included {
+				assert.True(t, attributes.Includes(attribute))
+			}
+			for _, attribute := range test.excluded {
+				assert.False(t, attributes.Includes(attribute))
+			}
+		})
+	}
+}

--- a/report/export.go
+++ b/report/export.go
@@ -22,14 +22,15 @@ import (
 // UI struct
 type UI struct {
 	*common.UI
-	output       io.Writer
-	exportOutput io.Writer
-	red          *color.Color
-	orange       *color.Color
-	writtenChan  chan struct{}
-	top          int
-	depth        int
-	summarize    bool
+	output           io.Writer
+	exportOutput     io.Writer
+	red              *color.Color
+	orange           *color.Color
+	writtenChan      chan struct{}
+	outputAttributes fs.JSONAttributes
+	top              int
+	depth            int
+	summarize        bool
 }
 
 // CreateExportUI creates UI for stdout
@@ -42,6 +43,7 @@ func CreateExportUI(
 	top int,
 	depth int,
 	summarize bool,
+	outputAttributes fs.JSONAttributes,
 ) *UI {
 	ui := &UI{
 		UI: &common.UI{
@@ -49,12 +51,13 @@ func CreateExportUI(
 			Analyzer:     analyze.CreateAnalyzer(),
 			UseSIPrefix:  useSIPrefix,
 		},
-		output:       output,
-		exportOutput: exportOutput,
-		writtenChan:  make(chan struct{}),
-		top:          top,
-		depth:        depth,
-		summarize:    summarize,
+		output:           output,
+		exportOutput:     exportOutput,
+		writtenChan:      make(chan struct{}),
+		outputAttributes: outputAttributes,
+		top:              top,
+		depth:            depth,
+		summarize:        summarize,
 	}
 	if !useSIPrefix {
 		ui.SetBlockSizeFromEnvironment()
@@ -238,7 +241,7 @@ func (ui *UI) exportDir(dir fs.Item, waitWritten *sync.WaitGroup) error {
 		dir = ui.limitDirByDepth(dir, 0)
 	}
 
-	if err := dir.EncodeJSON(&buff, true); err != nil {
+	if err := dir.EncodeJSON(&buff, true, ui.outputAttributes); err != nil {
 		return err
 	}
 	if _, err = buff.Write([]byte("]\n")); err != nil {

--- a/report/export_linux_test.go
+++ b/report/export_linux_test.go
@@ -27,7 +27,7 @@ func TestReadFromStorage(t *testing.T) {
 	output := bytes.NewBuffer(make([]byte, 10))
 	reportOutput := bytes.NewBuffer(make([]byte, 10))
 
-	ui := CreateExportUI(output, reportOutput, false, true, false, 0, 0, false)
+	ui := CreateExportUI(output, reportOutput, false, true, false, 0, 0, false, nil)
 	ui.SetIgnoreDirPaths([]string{"/xxx"})
 	ui.SetAnalyzer(analyze.CreateStoredAnalyzer(storagePath))
 	err := ui.AnalyzePath("test_dir", nil)
@@ -47,7 +47,7 @@ func TestReadFromStorageWithErr(t *testing.T) {
 	output := bytes.NewBuffer(make([]byte, 10))
 	reportOutput := bytes.NewBuffer(make([]byte, 10))
 
-	ui := CreateExportUI(output, reportOutput, false, false, false, 0, 0, false)
+	ui := CreateExportUI(output, reportOutput, false, false, false, 0, 0, false, nil)
 	ui.SetIgnoreDirPaths([]string{"/xxx"})
 	err := ui.ReadFromStorage(storagePath, "test_dir")
 

--- a/report/export_test.go
+++ b/report/export_test.go
@@ -2,7 +2,10 @@ package report
 
 import (
 	"bytes"
+	"errors"
+	"io"
 	"os"
+	"sync"
 	"testing"
 
 	log "github.com/sirupsen/logrus"
@@ -24,6 +27,15 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
+type errorExportItem struct {
+	*analyze.Dir
+	err error
+}
+
+func (item errorExportItem) EncodeJSON(io.Writer, bool, fs.JSONAttributes) error {
+	return item.err
+}
+
 func TestAnalyzePath(t *testing.T) {
 	fin := testdir.CreateTestDir()
 	defer fin()
@@ -31,7 +43,7 @@ func TestAnalyzePath(t *testing.T) {
 	output := bytes.NewBuffer(make([]byte, 10))
 	reportOutput := bytes.NewBuffer(make([]byte, 10))
 
-	ui := CreateExportUI(output, reportOutput, false, false, false, 0, 0, false)
+	ui := CreateExportUI(output, reportOutput, false, false, false, 0, 0, false, nil)
 	ui.SetIgnoreDirPaths([]string{"/xxx"})
 	err := ui.AnalyzePath("test_dir", nil)
 	assert.Nil(t, err)
@@ -41,6 +53,15 @@ func TestAnalyzePath(t *testing.T) {
 	assert.Contains(t, reportOutput.String(), `"name":"nested"`)
 }
 
+func TestExportDirReturnsEncodeError(t *testing.T) {
+	sentinel := errors.New("encode failed")
+	ui := CreateExportUI(&bytes.Buffer{}, &bytes.Buffer{}, false, false, false, 0, 0, false, nil)
+
+	err := ui.exportDir(errorExportItem{err: sentinel}, &sync.WaitGroup{})
+
+	assert.ErrorIs(t, err, sentinel)
+}
+
 func TestAnalyzePathWithTop(t *testing.T) {
 	fin := testdir.CreateTestDir()
 	defer fin()
@@ -48,7 +69,7 @@ func TestAnalyzePathWithTop(t *testing.T) {
 	output := bytes.NewBuffer(make([]byte, 10))
 	reportOutput := bytes.NewBuffer(make([]byte, 10))
 
-	ui := CreateExportUI(output, reportOutput, false, false, false, 2, 0, false)
+	ui := CreateExportUI(output, reportOutput, false, false, false, 2, 0, false, nil)
 	ui.SetIgnoreDirPaths([]string{"/xxx"})
 	err := ui.AnalyzePath("test_dir", nil)
 	assert.Nil(t, err)
@@ -68,7 +89,7 @@ func TestAnalyzePathWithTopAndTypeFilter(t *testing.T) {
 	output := bytes.NewBuffer(make([]byte, 10))
 	reportOutput := bytes.NewBuffer(make([]byte, 10))
 
-	ui := CreateExportUI(output, reportOutput, false, false, false, 10, 0, false)
+	ui := CreateExportUI(output, reportOutput, false, false, false, 10, 0, false, nil)
 	ui.SetIgnoreDirPaths([]string{"/xxx"})
 	ui.SetIncludeTypes([]string{"none"})
 	err := ui.AnalyzePath("test_dir", nil)
@@ -87,7 +108,7 @@ func TestAnalyzePathWithDepth(t *testing.T) {
 	var output bytes.Buffer
 	var reportOutput bytes.Buffer
 
-	ui := CreateExportUI(&output, &reportOutput, false, false, false, 0, 2, false)
+	ui := CreateExportUI(&output, &reportOutput, false, false, false, 0, 2, false, nil)
 	ui.SetIgnoreDirPaths([]string{"/xxx"})
 	err := ui.AnalyzePath("test_dir", nil)
 	assert.Nil(t, err)
@@ -106,7 +127,7 @@ func TestAnalyzePathWithDepthOne(t *testing.T) {
 	var output bytes.Buffer
 	var reportOutput bytes.Buffer
 
-	ui := CreateExportUI(&output, &reportOutput, false, false, false, 0, 1, false)
+	ui := CreateExportUI(&output, &reportOutput, false, false, false, 0, 1, false, nil)
 	ui.SetIgnoreDirPaths([]string{"/xxx"})
 	err := ui.AnalyzePath("test_dir", nil)
 	assert.Nil(t, err)
@@ -139,7 +160,7 @@ func TestAnalyzePathWithSummarize(t *testing.T) {
 	var output bytes.Buffer
 	var reportOutput bytes.Buffer
 
-	ui := CreateExportUI(&output, &reportOutput, false, false, false, 0, 0, true)
+	ui := CreateExportUI(&output, &reportOutput, false, false, false, 0, 0, true, nil)
 	ui.SetIgnoreDirPaths([]string{"/xxx"})
 	err := ui.AnalyzePath("test_dir", nil)
 	assert.Nil(t, err)
@@ -158,7 +179,7 @@ func TestAnalyzePathWithTopRoundTrip(t *testing.T) {
 	var output bytes.Buffer
 	var reportOutput bytes.Buffer
 
-	ui := CreateExportUI(&output, &reportOutput, false, false, false, 2, 0, false)
+	ui := CreateExportUI(&output, &reportOutput, false, false, false, 2, 0, false, nil)
 	ui.SetIgnoreDirPaths([]string{"/xxx"})
 	err := ui.AnalyzePath("test_dir", nil)
 	assert.Nil(t, err)
@@ -187,7 +208,7 @@ func TestAnalyzePathWithTopLargerThanFileCount(t *testing.T) {
 	var output bytes.Buffer
 	var reportOutput bytes.Buffer
 
-	ui := CreateExportUI(&output, &reportOutput, false, false, false, 100, 0, false)
+	ui := CreateExportUI(&output, &reportOutput, false, false, false, 100, 0, false, nil)
 	ui.SetIgnoreDirPaths([]string{"/xxx"})
 	err := ui.AnalyzePath("test_dir", nil)
 	assert.Nil(t, err)
@@ -205,7 +226,7 @@ func TestAnalyzePathWithDepthLargerThanTreeDepth(t *testing.T) {
 	var output bytes.Buffer
 	var reportOutput bytes.Buffer
 
-	ui := CreateExportUI(&output, &reportOutput, false, false, false, 0, 100, false)
+	ui := CreateExportUI(&output, &reportOutput, false, false, false, 0, 100, false, nil)
 	ui.SetIgnoreDirPaths([]string{"/xxx"})
 	err := ui.AnalyzePath("test_dir", nil)
 	assert.Nil(t, err)
@@ -224,7 +245,7 @@ func TestAnalyzePathWithSummarizeAndTop(t *testing.T) {
 	var output bytes.Buffer
 	var reportOutput bytes.Buffer
 
-	ui := CreateExportUI(&output, &reportOutput, false, false, false, 2, 0, true)
+	ui := CreateExportUI(&output, &reportOutput, false, false, false, 2, 0, true, nil)
 	ui.SetIgnoreDirPaths([]string{"/xxx"})
 	err := ui.AnalyzePath("test_dir", nil)
 	assert.Nil(t, err)
@@ -243,7 +264,7 @@ func TestAnalyzePathWithSummarizeAndDepth(t *testing.T) {
 	var output bytes.Buffer
 	var reportOutput bytes.Buffer
 
-	ui := CreateExportUI(&output, &reportOutput, false, false, false, 0, 1, true)
+	ui := CreateExportUI(&output, &reportOutput, false, false, false, 0, 1, true, nil)
 	ui.SetIgnoreDirPaths([]string{"/xxx"})
 	err := ui.AnalyzePath("test_dir", nil)
 	assert.Nil(t, err)
@@ -259,7 +280,7 @@ func TestLimitDirByDepthWithNonDir(t *testing.T) {
 	var output bytes.Buffer
 	var reportOutput bytes.Buffer
 
-	ui := CreateExportUI(&output, &reportOutput, false, false, false, 0, 1, false)
+	ui := CreateExportUI(&output, &reportOutput, false, false, false, 0, 1, false, nil)
 	file := &analyze.File{Name: "file"}
 	result := ui.limitDirByDepth(file, 0)
 
@@ -273,7 +294,7 @@ func TestAnalyzePathWithDepthZeroIsIgnored(t *testing.T) {
 	var output bytes.Buffer
 	var reportOutput bytes.Buffer
 
-	ui := CreateExportUI(&output, &reportOutput, false, false, false, 0, 0, false)
+	ui := CreateExportUI(&output, &reportOutput, false, false, false, 0, 0, false, nil)
 	ui.SetIgnoreDirPaths([]string{"/xxx"})
 	err := ui.AnalyzePath("test_dir", nil)
 	assert.Nil(t, err)
@@ -292,7 +313,7 @@ func TestAnalyzePathWithProgress(t *testing.T) {
 	var output bytes.Buffer
 	var reportOutput bytes.Buffer
 
-	ui := CreateExportUI(&output, &reportOutput, true, true, true, 0, 0, false)
+	ui := CreateExportUI(&output, &reportOutput, true, true, true, 0, 0, false, nil)
 	ui.SetIgnoreDirPaths([]string{"/xxx"})
 	err := ui.AnalyzePath("test_dir", nil)
 	assert.Nil(t, err)
@@ -306,7 +327,7 @@ func TestShowDevices(t *testing.T) {
 	var output bytes.Buffer
 	var reportOutput bytes.Buffer
 
-	ui := CreateExportUI(&output, &reportOutput, false, true, false, 0, 0, false)
+	ui := CreateExportUI(&output, &reportOutput, false, true, false, 0, 0, false, nil)
 	err := ui.ListDevices(device.Getter)
 
 	assert.Contains(t, err.Error(), "not supported")
@@ -316,7 +337,7 @@ func TestReadAnalysisWhileExporting(t *testing.T) {
 	var output bytes.Buffer
 	var reportOutput bytes.Buffer
 
-	ui := CreateExportUI(&output, &reportOutput, false, true, false, 0, 0, false)
+	ui := CreateExportUI(&output, &reportOutput, false, true, false, 0, 0, false, nil)
 	err := ui.ReadAnalysis(&output)
 
 	assert.Contains(t, err.Error(), "not possible while exporting")
@@ -334,7 +355,7 @@ func TestExportToFile(t *testing.T) {
 
 	var output bytes.Buffer
 
-	ui := CreateExportUI(&output, reportOutput, false, true, false, 0, 0, false)
+	ui := CreateExportUI(&output, reportOutput, false, true, false, 0, 0, false, nil)
 	ui.SetIgnoreDirPaths([]string{"/xxx"})
 	err = ui.AnalyzePath("test_dir", nil)
 	assert.Nil(t, err)
@@ -364,7 +385,7 @@ func TestExportToFileWithTop(t *testing.T) {
 
 	var output bytes.Buffer
 
-	ui := CreateExportUI(&output, reportOutput, false, true, false, 2, 0, false)
+	ui := CreateExportUI(&output, reportOutput, false, true, false, 2, 0, false, nil)
 	ui.SetIgnoreDirPaths([]string{"/xxx"})
 	err = ui.AnalyzePath("test_dir", nil)
 	assert.Nil(t, err)
@@ -391,7 +412,7 @@ func TestExportToFileWithDepth(t *testing.T) {
 
 	var output bytes.Buffer
 
-	ui := CreateExportUI(&output, reportOutput, false, true, false, 0, 2, false)
+	ui := CreateExportUI(&output, reportOutput, false, true, false, 0, 2, false, nil)
 	ui.SetIgnoreDirPaths([]string{"/xxx"})
 	err = ui.AnalyzePath("test_dir", nil)
 	assert.Nil(t, err)
@@ -421,7 +442,7 @@ func TestFormatSize(t *testing.T) {
 	var output bytes.Buffer
 	var reportOutput bytes.Buffer
 
-	ui := CreateExportUI(&output, &reportOutput, false, true, false, 0, 0, false)
+	ui := CreateExportUI(&output, &reportOutput, false, true, false, 0, 0, false, nil)
 
 	assert.Contains(t, ui.formatSize(1), "B")
 	assert.Contains(t, ui.formatSize(1<<10+1), "KiB")
@@ -438,7 +459,7 @@ func TestFormatSizeWithBlockSizeEnvironment(t *testing.T) {
 	var output bytes.Buffer
 	var reportOutput bytes.Buffer
 
-	ui := CreateExportUI(&output, &reportOutput, false, true, false, 0, 0, false)
+	ui := CreateExportUI(&output, &reportOutput, false, true, false, 0, 0, false, nil)
 	assert.Equal(t, "2", ui.formatSize(1025))
 }
 
@@ -446,7 +467,7 @@ func TestFormatSizeDec(t *testing.T) {
 	var output bytes.Buffer
 	var reportOutput bytes.Buffer
 
-	ui := CreateExportUI(&output, &reportOutput, false, true, true, 0, 0, false)
+	ui := CreateExportUI(&output, &reportOutput, false, true, true, 0, 0, false, nil)
 
 	assert.Contains(t, ui.formatSize(1), "B")
 	assert.Contains(t, ui.formatSize(1<<10+1), "kB")

--- a/tui/actions.go
+++ b/tui/actions.go
@@ -424,8 +424,9 @@ func (ui *UI) exportAnalysis() {
 			ui.showErrFromGo("Error creating file", err)
 			return
 		}
+		defer file.Close()
 
-		if err = ui.topDir.EncodeJSON(&buff, true); err != nil {
+		if err = ui.topDir.EncodeJSON(&buff, true, nil); err != nil {
 			ui.showErrFromGo("Error encoding JSON", err)
 			return
 		}

--- a/tui/export_test.go
+++ b/tui/export_test.go
@@ -2,7 +2,10 @@ package tui
 
 import (
 	"bytes"
+	"errors"
+	"io"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/dundee/gdu/v5/internal/testanalyze"
@@ -13,6 +16,15 @@ import (
 	"github.com/rivo/tview"
 	"github.com/stretchr/testify/assert"
 )
+
+type errorExportItem struct {
+	*analyze.Dir
+	err error
+}
+
+func (item errorExportItem) EncodeJSON(io.Writer, bool, fs.JSONAttributes) error {
+	return item.err
+}
 
 func TestConfirmExport(t *testing.T) {
 	simScreen := testapp.CreateSimScreen()
@@ -70,6 +82,24 @@ func TestExportAnalysis(t *testing.T) {
 	for _, f := range ui.app.(*testapp.MockedApp).GetUpdateDraws() {
 		f()
 	}
+}
+
+func TestExportAnalysisHandlesEncodeError(t *testing.T) {
+	simScreen := testapp.CreateSimScreen()
+	defer simScreen.Fini()
+	app := testapp.CreateMockedApp(true)
+	ui := CreateUI(app, simScreen, &bytes.Buffer{}, false, true, false, false)
+	ui.done = make(chan struct{})
+	ui.exportName = filepath.Join(t.TempDir(), "export.json")
+	ui.topDir = errorExportItem{err: errors.New("encode failed")}
+
+	ui.exportAnalysis()
+	<-ui.done
+
+	for _, draw := range app.(*testapp.MockedApp).GetUpdateDraws() {
+		draw()
+	}
+	assert.True(t, ui.pages.HasPage("error"))
 }
 
 func TestExportAnalysisEsc(t *testing.T) {


### PR DESCRIPTION
## Summary

- add `--output-attrs` to select JSON export attributes while retaining `name` on every record
- support `asize`, `dsize`, `mtime`, and `notreg`; validate unknown selections and require `--output-file`
- thread the selection through in-memory, SQLite, and archive encoders; preserve complete legacy exports, including interactive export, by default
- document the option and cover parsing, encoder behavior, SQLite output, and CLI export output

## Verification

- `go test -v -covermode=count ./...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.2 run ./...`
- CLI smoke test: `gdu --non-interactive --no-progress --output-file report.json --output-attrs=asize,dsize <directory>`; parsed JSON contained only `name`, `asize`, and `dsize` record keys

Closes #93