### PR TITLE
feat: stop scanning and keep partial results

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ In non-interactive mode (and without `--top` and `--depth` flags), gdu uses a me
 This means memory usage stays constant regardless of how large the scanned directory tree is.
 When `--top` or `--depth` flags are used, the full directory tree is built in memory as in interactive mode.
 
-Export mode (flag `-o`) outputs all usage data as JSON, which can be later opened using the `-f` flag.
+Export mode (flag `-o`) outputs all usage data as JSON, which can be later opened using the `-f` flag. In interactive mode, press `Ctrl+C` during a scan to stop scheduling new work and keep the results found so far.
 
 Hard links are counted only once.
 

--- a/internal/common/analyze.go
+++ b/internal/common/analyze.go
@@ -29,6 +29,7 @@ type Analyzer interface {
 	SetTimeFilter(timeFilter TimeFilter)
 	SetArchiveBrowsing(bool)
 	SetFileTypeFilter(filter ShouldFileBeIgnored)
+	Cancel()
 	GetDone() SignalGroup
 	GetProgress() CurrentProgress
 	ResetProgress()

--- a/internal/common/ui_test.go
+++ b/internal/common/ui_test.go
@@ -88,6 +88,8 @@ func (a *MockedAnalyzer) GetDone() SignalGroup {
 // ResetProgress does nothing
 func (a *MockedAnalyzer) ResetProgress() {}
 
+func (a *MockedAnalyzer) Cancel() {}
+
 // SetFollowSymlinks does nothing
 func (a *MockedAnalyzer) SetFollowSymlinks(v bool) {
 	a.FollowSymlinks = v

--- a/internal/testanalyze/analyze.go
+++ b/internal/testanalyze/analyze.go
@@ -2,6 +2,7 @@ package testanalyze
 
 import (
 	"errors"
+	"sync/atomic"
 	"time"
 
 	"github.com/dundee/gdu/v5/internal/common"
@@ -11,7 +12,9 @@ import (
 )
 
 // MockedAnalyzer returns dir with files with different size exponents
-type MockedAnalyzer struct{}
+type MockedAnalyzer struct {
+	cancelled atomic.Bool
+}
 
 // AnalyzeDir returns dir with files with different size exponents
 func (a *MockedAnalyzer) AnalyzeDir(
@@ -78,8 +81,20 @@ func (a *MockedAnalyzer) GetDone() common.SignalGroup {
 	return c
 }
 
-// ResetProgress does nothing
-func (a *MockedAnalyzer) ResetProgress() {}
+// ResetProgress clears cancellation state for a subsequent analysis.
+func (a *MockedAnalyzer) ResetProgress() {
+	a.cancelled.Store(false)
+}
+
+// Cancel records a cancellation request.
+func (a *MockedAnalyzer) Cancel() {
+	a.cancelled.Store(true)
+}
+
+// IsCancelled reports whether cancellation was requested.
+func (a *MockedAnalyzer) IsCancelled() bool {
+	return a.cancelled.Load()
+}
 
 // SetFollowSymlinks does nothing
 func (a *MockedAnalyzer) SetFollowSymlinks(v bool) {}

--- a/internal/testanalyze/analyze_test.go
+++ b/internal/testanalyze/analyze_test.go
@@ -94,11 +94,13 @@ func TestGetDone(t *testing.T) {
 	}
 }
 
-func TestResetProgress(t *testing.T) {
+func TestResetProgressClearsCancellation(t *testing.T) {
 	a := &MockedAnalyzer{}
-	assert.NotPanics(t, func() {
-		a.ResetProgress()
-	})
+	a.Cancel()
+	assert.True(t, a.IsCancelled())
+
+	a.ResetProgress()
+	assert.False(t, a.IsCancelled())
 }
 
 func TestSetFollowSymlinks(t *testing.T) {

--- a/pkg/analyze/analyzer.go
+++ b/pkg/analyze/analyzer.go
@@ -17,6 +17,7 @@ type BaseAnalyzer struct {
 	progressCurrentItemName atomic.Value
 	currentDir              atomic.Value
 	doneChan                common.SignalGroup
+	cancelled               atomic.Bool
 	wait                    *WaitGroup
 	ignoreDir               common.ShouldDirBeIgnored
 	ignoreFileType          common.ShouldFileBeIgnored
@@ -37,6 +38,7 @@ func (a *BaseAnalyzer) Init() {
 	a.progressTotalUsage.Store(0)
 	a.progressCurrentItemName.Store("")
 	a.currentDir.Store((*Dir)(nil))
+	a.cancelled.Store(false)
 	a.progressTicker = time.NewTicker(50 * time.Millisecond)
 }
 
@@ -46,16 +48,15 @@ func (a *BaseAnalyzer) setCurrentDir(dir *Dir) {
 	a.currentDir.Store(dir)
 }
 
-// GetCurrentDir returns the root directory being built by the running analysis,
-// or nil if no analysis has started yet. The returned tree is still being
-// mutated by the analyzer, so callers must only read it through the locked
-// accessors (e.g. GetFilesLocked / UpdateStats).
+// GetCurrentDir returns an independent snapshot of the directory tree built so
+// far, or nil if no analysis has started yet. Callers may aggregate or navigate
+// the snapshot without mutating the live scan state.
 func (a *BaseAnalyzer) GetCurrentDir() fs.Item {
 	dir, _ := a.currentDir.Load().(*Dir)
 	if dir == nil {
 		return nil
 	}
-	return dir
+	return snapshotDir(dir, nil)
 }
 
 // SetFollowSymlinks sets whether symlink to files should be followed
@@ -88,8 +89,27 @@ func (a *BaseAnalyzer) GetDone() common.SignalGroup {
 	return a.doneChan
 }
 
-// ResetProgress resets the analyzer state
+// Cancel stops scheduling new scan work. In-flight filesystem operations are
+// allowed to finish so the caller can safely use the partial directory tree.
+func (a *BaseAnalyzer) Cancel() {
+	a.cancelled.Store(true)
+}
+
+// IsCancelled reports whether the current scan has been cancelled.
+func (a *BaseAnalyzer) IsCancelled() bool {
+	return a.cancelled.Load()
+}
+
+func (a *BaseAnalyzer) shouldSkipDir(name, path string) bool {
+	return a.ignoreDir(name, path) || a.IsCancelled()
+}
+
+// ResetProgress prepares the analyzer for a new scan. Call it only after the
+// previous scan has completed and before exposing the new scan to cancellation.
 func (a *BaseAnalyzer) ResetProgress() {
+	if a.progressTicker != nil {
+		a.progressTicker.Stop()
+	}
 	a.Init()
 }
 

--- a/pkg/analyze/cancel_race_test.go
+++ b/pkg/analyze/cancel_race_test.go
@@ -1,0 +1,120 @@
+package analyze
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/dundee/gdu/v5/internal/common"
+	"github.com/dundee/gdu/v5/pkg/fs"
+	"github.com/stretchr/testify/require"
+)
+
+type cancelRaceAnalyzer interface {
+	common.Analyzer
+	IsCancelled() bool
+}
+
+type cancelRaceAnalyzerFactory struct {
+	name string
+	new  func(*testing.T) cancelRaceAnalyzer
+}
+
+func TestCancelPreemptiveAnalyzers(t *testing.T) {
+	root := createCancelRaceTree(t)
+
+	for _, factory := range cancelRaceAnalyzerFactories() {
+		t.Run(factory.name, func(t *testing.T) {
+			analyzer := factory.new(t)
+			analyzer.Cancel()
+
+			dir := analyzer.AnalyzeDir(root, func(string, string) bool { return false }, nil)
+
+			require.NotNil(t, dir)
+			require.True(t, analyzer.IsCancelled())
+			var children int
+			for range dir.GetFiles(fs.SortByName, fs.SortAsc) {
+				children++
+			}
+			require.Zero(t, children, "preemptive cancellation must not schedule child scans")
+		})
+	}
+}
+
+func TestCancelWhileAnalyzingAnalyzers(t *testing.T) {
+	root := createCancelRaceTree(t)
+	blockedPath := filepath.Join(root, "1")
+
+	for _, factory := range cancelRaceAnalyzerFactories() {
+		t.Run(factory.name, func(t *testing.T) {
+			analyzer := factory.new(t)
+			started := make(chan struct{})
+			release := make(chan struct{})
+
+			ignore := func(_ string, path string) bool {
+				if path == blockedPath {
+					close(started)
+					<-release
+				}
+				return false
+			}
+
+			result := make(chan fs.Item, 1)
+			go func() {
+				result <- analyzer.AnalyzeDir(root, ignore, nil)
+			}()
+
+			select {
+			case <-started:
+			case <-time.After(10 * time.Second):
+				t.Fatal("analyzer did not reach the blocked root entry")
+			}
+			analyzer.Cancel()
+			close(release)
+
+			select {
+			case dir := <-result:
+				require.NotNil(t, dir)
+				require.True(t, analyzer.IsCancelled())
+				require.NotContains(t, itemNames(dir), "1")
+			case <-time.After(10 * time.Second):
+				t.Fatal("analyzer did not finish after cancellation")
+			}
+		})
+	}
+}
+
+func cancelRaceAnalyzerFactories() []cancelRaceAnalyzerFactory {
+	return []cancelRaceAnalyzerFactory{
+		{name: "parallel", new: func(*testing.T) cancelRaceAnalyzer { return CreateAnalyzer() }},
+		{name: "stable", new: func(*testing.T) cancelRaceAnalyzer { return CreateStableOrderAnalyzer() }},
+		{name: "sequential", new: func(*testing.T) cancelRaceAnalyzer { return CreateSeqAnalyzer() }},
+		{name: "stored", new: func(t *testing.T) cancelRaceAnalyzer {
+			return CreateStoredAnalyzer(filepath.Join(t.TempDir(), "results.badger"))
+		}},
+		{name: "sqlite", new: func(t *testing.T) cancelRaceAnalyzer {
+			analyzer, err := CreateSqliteAnalyzer(filepath.Join(t.TempDir(), "results.sqlite"))
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, analyzer.storage.Close()) })
+			return analyzer
+		}},
+		{name: "top-dir", new: func(*testing.T) cancelRaceAnalyzer { return CreateTopDirAnalyzer() }},
+	}
+}
+
+func createCancelRaceTree(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	for i := range 8 {
+		top := filepath.Join(root, strconv.Itoa(i))
+		require.NoError(t, os.Mkdir(top, 0o700))
+		for j := range 8 {
+			nested := filepath.Join(top, strconv.Itoa(j))
+			require.NoError(t, os.Mkdir(nested, 0o700))
+			require.NoError(t, os.WriteFile(filepath.Join(nested, "file"), []byte("data"), 0o600))
+		}
+	}
+	return root
+}

--- a/pkg/analyze/cancel_test.go
+++ b/pkg/analyze/cancel_test.go
@@ -1,0 +1,164 @@
+package analyze
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dundee/gdu/v5/internal/common"
+	"github.com/dundee/gdu/v5/pkg/fs"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAnalyzersCancelKeepsPartialResults(t *testing.T) {
+	root := createCancellationTree(t)
+
+	tests := []struct {
+		name     string
+		analyzer common.Analyzer
+	}{
+		{name: "parallel", analyzer: CreateAnalyzer()},
+		{name: "stable parallel", analyzer: CreateStableOrderAnalyzer()},
+		{name: "sequential", analyzer: CreateSeqAnalyzer()},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dir := scanUntilCancelled(t, test.analyzer, root)
+
+			assert.True(t, test.analyzer.(interface{ IsCancelled() bool }).IsCancelled())
+			assert.Contains(t, itemNames(dir), "a-file")
+			assert.NotContains(t, itemNames(dir), "b-dir")
+		})
+	}
+}
+
+func TestParallelAnalyzersCancelQueuedDirectories(t *testing.T) {
+	root := createCancellationTree(t)
+	tests := []struct {
+		name    string
+		factory func() common.Analyzer
+	}{
+		{name: "parallel", factory: func() common.Analyzer { return CreateAnalyzer() }},
+		{name: "stable parallel", factory: func() common.Analyzer { return CreateStableOrderAnalyzer() }},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			initialSlots := len(concurrencyLimit)
+			for len(concurrencyLimit) < cap(concurrencyLimit) {
+				concurrencyLimit <- struct{}{}
+			}
+			defer func() {
+				for len(concurrencyLimit) > initialSlots {
+					<-concurrencyLimit
+				}
+			}()
+
+			analyzer := test.factory()
+			result := make(chan fs.Item, 1)
+			go func() {
+				result <- analyzer.AnalyzeDir(root, func(_, _ string) bool { return false }, nil)
+			}()
+
+			assert.Eventually(t, func() bool {
+				return analyzer.GetProgress().CurrentItemName == root
+			}, time.Second, time.Millisecond)
+			analyzer.Cancel()
+			<-concurrencyLimit
+
+			select {
+			case dir := <-result:
+				assert.NotContains(t, itemNames(dir), "b-dir")
+			case <-time.After(time.Second):
+				t.Fatal("analyzer did not discard queued directory after cancellation")
+			}
+		})
+	}
+}
+
+func TestStorageBackedAnalyzersCancelKeepsPartialResults(t *testing.T) {
+	root := createCancellationTree(t)
+
+	stored := CreateStoredAnalyzer(filepath.Join(t.TempDir(), "results.badger"))
+	dir := scanUntilCancelled(t, stored, root)
+	assert.True(t, stored.IsCancelled())
+	assert.Contains(t, itemNames(dir), "a-file")
+	assert.NotContains(t, itemNames(dir), "b-dir")
+
+	sqliteAnalyzer, err := CreateSqliteAnalyzer(filepath.Join(t.TempDir(), "results.sqlite"))
+	assert.NoError(t, err)
+	defer sqliteAnalyzer.storage.Close()
+	dir = scanUntilCancelled(t, sqliteAnalyzer, root)
+	assert.True(t, sqliteAnalyzer.IsCancelled())
+	assert.Contains(t, itemNames(dir), "a-file")
+	assert.NotContains(t, itemNames(dir), "b-dir")
+}
+
+func TestAnalyzeDirHonorsPreemptiveCancellation(t *testing.T) {
+	analyzer := CreateSeqAnalyzer()
+	analyzer.Cancel()
+
+	dir := analyzer.AnalyzeDir(createCancellationTree(t), func(_, _ string) bool { return false }, nil)
+
+	assert.True(t, analyzer.IsCancelled())
+	assert.NotContains(t, itemNames(dir), "a-file")
+	assert.NotContains(t, itemNames(dir), "b-dir")
+}
+
+func TestResetProgressClearsPreviousCancellation(t *testing.T) {
+	analyzer := CreateSeqAnalyzer()
+	analyzer.Cancel()
+	analyzer.ResetProgress()
+
+	dir := analyzer.AnalyzeDir(createCancellationTree(t), func(_, _ string) bool { return false }, nil)
+
+	assert.False(t, analyzer.IsCancelled())
+	assert.Contains(t, itemNames(dir), "a-file")
+	assert.Contains(t, itemNames(dir), "b-dir")
+}
+
+func TestTopDirAnalyzerCancellationStopsActiveSubdirectory(t *testing.T) {
+	root := t.TempDir()
+	assert.NoError(t, os.WriteFile(filepath.Join(root, "unscanned"), []byte("data"), 0o600))
+
+	analyzer := CreateTopDirAnalyzer()
+	t.Cleanup(analyzer.progressTicker.Stop)
+	analyzer.Cancel()
+	result := &TopDir{}
+
+	analyzer.processSubDir(root, result)
+
+	size, usage, itemCount := result.GetUsage()
+	assert.Zero(t, size)
+	assert.Zero(t, usage)
+	assert.Zero(t, itemCount)
+}
+
+func createCancellationTree(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	assert.NoError(t, os.WriteFile(filepath.Join(root, "a-file"), []byte("complete"), 0o600))
+	assert.NoError(t, os.Mkdir(filepath.Join(root, "b-dir"), 0o700))
+	assert.NoError(t, os.WriteFile(filepath.Join(root, "b-dir", "nested"), []byte("pending"), 0o600))
+	return root
+}
+
+func scanUntilCancelled(t *testing.T, analyzer common.Analyzer, root string) fs.Item {
+	t.Helper()
+	return analyzer.AnalyzeDir(root, func(name, _ string) bool {
+		if name == "b-dir" {
+			analyzer.Cancel()
+		}
+		return false
+	}, nil)
+}
+
+func itemNames(dir fs.Item) []string {
+	var names []string
+	for item := range dir.GetFiles(fs.SortByName, fs.SortAsc) {
+		names = append(names, item.GetName())
+	}
+	return names
+}

--- a/pkg/analyze/file.go
+++ b/pkg/analyze/file.go
@@ -11,6 +11,11 @@ import (
 	"github.com/dundee/gdu/v5/pkg/fs"
 )
 
+// fileFlagMu protects the mutable Flag field on published File values. File
+// keeps its fields public for compatibility, so hard-link accounting can
+// update Flag after a file has been exposed to preview readers.
+var fileFlagMu sync.RWMutex
+
 // File struct
 type File struct {
 	Mtime  time.Time
@@ -49,6 +54,8 @@ func (f *File) GetPath() string {
 
 // GetFlag returns flag of the file
 func (f *File) GetFlag() rune {
+	fileFlagMu.RLock()
+	defer fileFlagMu.RUnlock()
 	return f.Flag
 }
 
@@ -69,6 +76,8 @@ func (f *File) GetMtime() time.Time {
 
 // GetType returns name type of item
 func (f *File) GetType() string {
+	fileFlagMu.RLock()
+	defer fileFlagMu.RUnlock()
 	if f.Flag == '@' {
 		return "Other"
 	}
@@ -89,7 +98,9 @@ func (f *File) alreadyCounted(linkedItems fs.HardLinkedItems) bool {
 	mli := f.Mli
 	counted := false
 	if mli > 0 {
+		fileFlagMu.Lock()
 		f.Flag = 'H'
+		fileFlagMu.Unlock()
 		if _, ok := linkedItems[mli]; ok {
 			counted = true
 		}
@@ -160,11 +171,103 @@ type Dir struct {
 	m         sync.RWMutex
 }
 
+func snapshotDir(source *Dir, parent fs.Item) *Dir {
+	source.m.RLock()
+	snapshot := &Dir{
+		File: &File{
+			Mtime:  source.Mtime,
+			Parent: parent,
+			Name:   source.Name,
+			Size:   source.Size,
+			Usage:  source.Usage,
+			Mli:    source.Mli,
+			Flag:   source.Flag,
+		},
+		BasePath:  source.BasePath,
+		Files:     make(fs.Files, 0, len(source.Files)),
+		ItemCount: source.ItemCount,
+	}
+	children := append(fs.Files(nil), source.Files...)
+	source.m.RUnlock()
+
+	for _, child := range children {
+		snapshot.Files = append(snapshot.Files, snapshotItem(child, snapshot))
+	}
+	return snapshot
+}
+
+func snapshotItem(source, parent fs.Item) fs.Item {
+	switch item := source.(type) {
+	case *ZipDir:
+		snapshot := &ZipDir{Dir: snapshotDir(item.Dir, parent), zipPath: item.zipPath}
+		reparentSnapshotChildren(snapshot.Dir, snapshot)
+		return snapshot
+	case *TarDir:
+		snapshot := &TarDir{Dir: snapshotDir(item.Dir, parent), tarPath: item.tarPath}
+		reparentSnapshotChildren(snapshot.Dir, snapshot)
+		return snapshot
+	case *ZipFile:
+		return &ZipFile{
+			File:      snapshotFile(item.File, parent),
+			zipPath:   item.zipPath,
+			inZipPath: item.inZipPath,
+		}
+	case *TarFile:
+		return &TarFile{
+			File:      snapshotFile(item.File, parent),
+			tarPath:   item.tarPath,
+			inTarPath: item.inTarPath,
+		}
+	case *Dir:
+		return snapshotDir(item, parent)
+	case *File:
+		return snapshotFile(item, parent)
+	}
+
+	if source.IsDir() {
+		snapshot := &Dir{
+			File:      snapshotFile(source, parent),
+			Files:     make(fs.Files, 0),
+			ItemCount: source.GetItemCount(),
+		}
+		for child := range source.GetFilesLocked(fs.SortByName, fs.SortAsc) {
+			snapshot.Files = append(snapshot.Files, snapshotItem(child, snapshot))
+		}
+		return snapshot
+	}
+	return snapshotFile(source, parent)
+}
+
+func reparentSnapshotChildren(dir *Dir, parent fs.Item) {
+	for _, child := range dir.Files {
+		child.SetParent(parent)
+	}
+}
+
+func snapshotFile(source, parent fs.Item) *File {
+	return &File{
+		Mtime:  source.GetMtime(),
+		Parent: parent,
+		Name:   source.GetName(),
+		Size:   source.GetSize(),
+		Usage:  source.GetUsage(),
+		Mli:    source.GetMultiLinkedInode(),
+		Flag:   source.GetFlag(),
+	}
+}
+
 // AddFile add item to files
 func (f *Dir) AddFile(item fs.Item) {
 	f.m.Lock()
 	defer f.m.Unlock()
 	f.Files = append(f.Files, item)
+}
+
+// SetFlag updates the directory flag while preserving snapshot consistency.
+func (f *Dir) SetFlag(flag rune) {
+	f.m.Lock()
+	f.Flag = flag
+	f.m.Unlock()
 }
 
 // GetFiles returns all files in directory as a sorted iterator
@@ -208,6 +311,34 @@ func (f *Dir) GetType() string {
 	return "Directory"
 }
 
+// GetFlag returns the current directory flag.
+func (f *Dir) GetFlag() rune {
+	f.m.RLock()
+	defer f.m.RUnlock()
+	return f.Flag
+}
+
+// GetSize returns the current apparent size.
+func (f *Dir) GetSize() int64 {
+	f.m.RLock()
+	defer f.m.RUnlock()
+	return f.Size
+}
+
+// GetUsage returns the current disk usage.
+func (f *Dir) GetUsage() int64 {
+	f.m.RLock()
+	defer f.m.RUnlock()
+	return f.Usage
+}
+
+// GetMtime returns the current modification time.
+func (f *Dir) GetMtime() time.Time {
+	f.m.RLock()
+	defer f.m.RUnlock()
+	return f.Mtime
+}
+
 // GetItemCount returns number of files in dir
 func (f *Dir) GetItemCount() int64 {
 	f.m.RLock()
@@ -234,7 +365,7 @@ func (f *Dir) GetPath() string {
 // GetItemStats returns item count, apparent usage and real usage of this dir
 func (f *Dir) GetItemStats(linkedItems fs.HardLinkedItems, filteringFiles bool) (itemCount, size, usage int64) {
 	f.updateStats(linkedItems, filteringFiles)
-	return f.ItemCount, f.GetSize(), f.GetUsage()
+	return f.GetItemCount(), f.GetSize(), f.GetUsage()
 }
 
 func (f *Dir) UpdateStats(linkedItems fs.HardLinkedItems) {
@@ -253,6 +384,8 @@ func (f *Dir) updateStats(linkedItems fs.HardLinkedItems, filteringFiles bool) {
 	f.m.RLock()
 	files := make(fs.Files, len(f.Files))
 	copy(files, f.Files)
+	mtime := f.Mtime
+	flag := f.Flag
 	f.m.RUnlock()
 
 	totalSize := int64(0)
@@ -265,8 +398,9 @@ func (f *Dir) updateStats(linkedItems fs.HardLinkedItems, filteringFiles bool) {
 		totalUsage += usage
 		itemCount += count
 
-		if entry.GetMtime().After(f.Mtime) {
-			f.Mtime = entry.GetMtime()
+		entryMtime := entry.GetMtime()
+		if entryMtime.After(mtime) {
+			mtime = entryMtime
 		}
 
 		if !entry.IsDir() {
@@ -275,11 +409,16 @@ func (f *Dir) updateStats(linkedItems fs.HardLinkedItems, filteringFiles bool) {
 
 		switch entry.GetFlag() {
 		case '!', '.':
-			if f.Flag != '!' {
-				f.Flag = '.'
+			if flag != '!' {
+				flag = '.'
 			}
 		}
 	}
+
+	f.m.Lock()
+	defer f.m.Unlock()
+	f.Mtime = mtime
+	f.Flag = flag
 
 	// no files, or just empty dirs
 	if len(files) == 0 || (!hasFiles && filteringFiles && itemCount == int64(len(files)+1)) {

--- a/pkg/analyze/parallel.go
+++ b/pkg/analyze/parallel.go
@@ -46,6 +46,26 @@ func (a *ParallelAnalyzer) AnalyzeDir(
 	return dir
 }
 
+func (a *ParallelAnalyzer) processQueuedDir(path string, parent *Dir, result chan<- *Dir) {
+	concurrencyLimit <- struct{}{}
+	if a.IsCancelled() {
+		<-concurrencyLimit
+		result <- nil
+		return
+	}
+
+	subdir := a.processDir(path)
+	subdir.Parent = parent
+	<-concurrencyLimit
+	result <- subdir
+}
+
+func addSubDir(parent, child *Dir) {
+	if child != nil {
+		parent.AddFile(child)
+	}
+}
+
 func (a *ParallelAnalyzer) processDir(path string) *Dir {
 	var (
 		file       fs.Item
@@ -74,22 +94,18 @@ func (a *ParallelAnalyzer) processDir(path string) *Dir {
 	setDirPlatformSpecificAttrs(dir, path)
 
 	for _, f := range files {
+		if a.IsCancelled() {
+			break
+		}
 		name := f.Name()
 		entryPath := filepath.Join(path, name)
 		if f.IsDir() {
-			if a.ignoreDir(name, entryPath) {
+			if a.shouldSkipDir(name, entryPath) {
 				continue
 			}
 			dirCount++
 
-			go func(entryPath string) {
-				concurrencyLimit <- struct{}{}
-				subdir := a.processDir(entryPath)
-				subdir.Parent = dir
-
-				subDirChan <- subdir
-				<-concurrencyLimit
-			}(entryPath)
+			go a.processQueuedDir(entryPath, dir, subDirChan)
 		} else {
 			// Apply file type filter if set
 			if a.ignoreFileType != nil && a.ignoreFileType(name) {
@@ -99,7 +115,7 @@ func (a *ParallelAnalyzer) processDir(path string) *Dir {
 			info, err = f.Info()
 			if err != nil {
 				log.Print(err.Error())
-				dir.Flag = '!'
+				dir.SetFlag('!')
 				continue
 			}
 
@@ -107,7 +123,7 @@ func (a *ParallelAnalyzer) processDir(path string) *Dir {
 				infoF, err := followSymlink(entryPath, a.gitAnnexedSize)
 				if err != nil {
 					log.Print(err.Error())
-					dir.Flag = '!'
+					dir.SetFlag('!')
 					continue
 				}
 				if infoF != nil {
@@ -177,9 +193,9 @@ func (a *ParallelAnalyzer) processDir(path string) *Dir {
 	go func() {
 		var sub *Dir
 
-		for i := 0; i < dirCount; i++ {
+		for range dirCount {
 			sub = <-subDirChan
-			dir.AddFile(sub)
+			addSubDir(dir, sub)
 		}
 
 		a.wait.Done()

--- a/pkg/analyze/parallel_coverage_test.go
+++ b/pkg/analyze/parallel_coverage_test.go
@@ -2,11 +2,14 @@ package analyze
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/dundee/gdu/v5/internal/common"
 	"github.com/dundee/gdu/v5/internal/testdir"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParallelAnalyzerSetFollowSymlinks(t *testing.T) {
@@ -131,4 +134,56 @@ func TestParallelAnalyzerAnalyzeDirWithIgnoreDir(t *testing.T) {
 	assert.Equal(t, "test_dir", dir.Name)
 	// Should have fewer items since nested directory was ignored
 	assert.Less(t, dir.ItemCount, int64(5))
+}
+
+func TestAnalyzersMarkFilesystemErrors(t *testing.T) {
+	factories := []struct {
+		name string
+		new  func() common.Analyzer
+	}{
+		{name: "parallel", new: func() common.Analyzer { return CreateAnalyzer() }},
+		{name: "stable parallel", new: func() common.Analyzer { return CreateStableOrderAnalyzer() }},
+		{name: "sequential", new: func() common.Analyzer { return CreateSeqAnalyzer() }},
+	}
+
+	for _, factory := range factories {
+		t.Run(factory.name, func(t *testing.T) {
+			t.Run("disappeared file", func(t *testing.T) {
+				root := t.TempDir()
+				filePath := filepath.Join(root, "removed-during-scan")
+				require.NoError(t, os.WriteFile(filePath, []byte("data"), 0o600))
+
+				var removeErr error
+				dir := factory.new().AnalyzeDir(
+					root,
+					func(_, _ string) bool { return false },
+					func(string) bool {
+						removeErr = os.Remove(filePath)
+						return false
+					},
+				)
+
+				require.NoError(t, removeErr)
+				assert.Equal(t, '!', dir.GetFlag())
+			})
+
+			t.Run("broken symlink", func(t *testing.T) {
+				root := t.TempDir()
+				err := os.Symlink(filepath.Join(root, "missing-target"), filepath.Join(root, "broken-link"))
+				if err != nil {
+					t.Skipf("creating symlink: %v", err)
+				}
+
+				analyzer := factory.new()
+				analyzer.SetFollowSymlinks(true)
+				dir := analyzer.AnalyzeDir(
+					root,
+					func(_, _ string) bool { return false },
+					func(string) bool { return false },
+				)
+
+				assert.Equal(t, '!', dir.GetFlag())
+			})
+		})
+	}
 }

--- a/pkg/analyze/parallel_stable.go
+++ b/pkg/analyze/parallel_stable.go
@@ -76,11 +76,14 @@ func (a *ParallelStableOrderAnalyzer) processDir(path string) *Dir {
 	itemChan := make(chan indexedItem, len(files))
 
 	for _, f := range files {
+		if a.IsCancelled() {
+			break
+		}
 		name := f.Name()
 		entryPath := filepath.Join(path, name)
 
 		if f.IsDir() {
-			if a.ignoreDir(name, entryPath) {
+			if a.shouldSkipDir(name, entryPath) {
 				continue
 			}
 			currentIndex := itemCount
@@ -89,11 +92,16 @@ func (a *ParallelStableOrderAnalyzer) processDir(path string) *Dir {
 
 			go func(entryPath string, idx int) {
 				concurrencyLimit <- struct{}{}
+				if a.IsCancelled() {
+					<-concurrencyLimit
+					itemChan <- indexedItem{idx, nil}
+					return
+				}
 				subdir := a.processDir(entryPath)
 				subdir.Parent = dir
 
-				itemChan <- indexedItem{idx, subdir}
 				<-concurrencyLimit
+				itemChan <- indexedItem{idx, subdir}
 			}(entryPath, currentIndex)
 		} else {
 			// Apply file type filter if set
@@ -104,7 +112,7 @@ func (a *ParallelStableOrderAnalyzer) processDir(path string) *Dir {
 			info, err = f.Info()
 			if err != nil {
 				log.Print(err.Error())
-				dir.Flag = '!'
+				dir.SetFlag('!')
 				continue
 			}
 
@@ -112,7 +120,7 @@ func (a *ParallelStableOrderAnalyzer) processDir(path string) *Dir {
 				infoF, err := followSymlink(entryPath, a.gitAnnexedSize)
 				if err != nil {
 					log.Print(err.Error())
-					dir.Flag = '!'
+					dir.SetFlag('!')
 					continue
 				}
 				if infoF != nil {
@@ -151,8 +159,10 @@ func (a *ParallelStableOrderAnalyzer) processDir(path string) *Dir {
 		}
 
 		// Add all items in their original order
-		for i := 0; i < itemCount; i++ {
-			dir.AddFile(items[i].item)
+		for i := range itemCount {
+			if items[i].item != nil {
+				dir.AddFile(items[i].item)
+			}
 		}
 
 		a.wait.Done()

--- a/pkg/analyze/parallel_top_dir.go
+++ b/pkg/analyze/parallel_top_dir.go
@@ -67,10 +67,13 @@ func (a *TopDirAnalyzer) AnalyzeDir(
 	var topDirs []*TopDir
 
 	for _, f := range files {
+		if a.IsCancelled() {
+			break
+		}
 		name := f.Name()
 		entryPath := filepath.Join(path, name)
 		if f.IsDir() {
-			if a.ignoreDir(name, entryPath) {
+			if a.shouldSkipDir(name, entryPath) {
 				continue
 			}
 			topDir := &TopDir{
@@ -172,10 +175,13 @@ func (a *TopDirAnalyzer) processSubDir(path string, topDir *TopDir) {
 	}
 
 	for _, f := range files {
+		if a.IsCancelled() {
+			break
+		}
 		name := f.Name()
 		entryPath := path + pathSep + name
 		if f.IsDir() {
-			if a.ignoreDir(name, entryPath) {
+			if a.shouldSkipDir(name, entryPath) {
 				continue
 			}
 

--- a/pkg/analyze/partial_tree_race_test.go
+++ b/pkg/analyze/partial_tree_race_test.go
@@ -1,0 +1,114 @@
+package analyze
+
+import (
+	"fmt"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/dundee/gdu/v5/pkg/fs"
+)
+
+// TestPartialTreeLockedAccessors exercises the preview contract against the
+// same mutations a scan performs while constructing and updating directories.
+// The fixed round barriers make the stress repeatable without timing sleeps.
+func TestPartialTreeLockedAccessors(t *testing.T) {
+	const rounds = 256
+	const mutationsPerRound = 8
+
+	root := &Dir{
+		File:  &File{Name: "root"},
+		Files: make(fs.Files, 0, rounds),
+	}
+	analyzer := CreateAnalyzer()
+	analyzer.setCurrentDir(root)
+
+	for round := range rounds {
+		start := make(chan struct{})
+		var workers sync.WaitGroup
+		workers.Add(2)
+
+		go func(round int) {
+			defer workers.Done()
+			<-start
+
+			child := &Dir{
+				File: &File{
+					Name:   fmt.Sprintf("dir-%03d", round),
+					Mtime:  time.Unix(int64(round), 0),
+					Parent: root,
+				},
+				Files: make(fs.Files, 0, mutationsPerRound),
+			}
+			root.AddFile(child)
+			for mutation := range mutationsPerRound {
+				child.AddFile(&File{
+					Name:   fmt.Sprintf("file-%03d-%02d", round, mutation),
+					Size:   int64(mutation + 1),
+					Usage:  int64(mutation + 1),
+					Mli:    uint64(round + 1),
+					Mtime:  time.Unix(int64(round), int64(mutation)),
+					Parent: child,
+				})
+				child.SetFlag('!')
+				child.UpdateStats(make(fs.HardLinkedItems))
+				root.UpdateStats(make(fs.HardLinkedItems))
+				runtime.Gosched()
+			}
+		}(round)
+
+		// This models a preview-triggered stats update overlapping the analyzer
+		// worker's own update traversal on the same partially built tree.
+		go func() {
+			defer workers.Done()
+			<-start
+			for range mutationsPerRound {
+				root.UpdateStats(make(fs.HardLinkedItems))
+				runtime.Gosched()
+			}
+		}()
+
+		close(start)
+		current, ok := analyzer.GetCurrentDir().(*Dir)
+		if !ok {
+			t.Fatal("current directory unavailable during partial scan")
+		}
+		readLockedTree(current)
+		workers.Wait()
+	}
+
+	root.UpdateStats(make(fs.HardLinkedItems))
+	if got, want := root.GetItemCount(), int64(1+rounds*(mutationsPerRound+1)); got != want {
+		t.Fatalf("partial tree stats = %d, want %d", got, want)
+	}
+}
+
+// readLockedTree mirrors preview traversal: every mutable directory is read
+// through GetFilesLocked and its synchronized scalar accessors.
+func readLockedTree(root *Dir) {
+	_ = root.GetName()
+	_ = root.GetFlag()
+	_ = root.GetSize()
+	_ = root.GetUsage()
+	_ = root.GetMtime()
+	_ = root.GetItemCount()
+	for item := range root.GetFilesLocked(fs.SortBySize, fs.SortDesc) {
+		_ = item.GetName()
+		_ = item.GetFlag()
+		_ = item.GetSize()
+		_ = item.GetUsage()
+		_ = item.GetMtime()
+		_ = item.GetItemCount()
+		if child, ok := item.(*Dir); ok {
+			for nested := range child.GetFilesLocked(fs.SortByName, fs.SortAsc) {
+				_ = nested.GetName()
+				_ = nested.GetFlag()
+				_ = nested.GetSize()
+				_ = nested.GetUsage()
+				_ = nested.GetMtime()
+				_ = nested.GetItemCount()
+			}
+		}
+	}
+}

--- a/pkg/analyze/preview_race_test.go
+++ b/pkg/analyze/preview_race_test.go
@@ -77,7 +77,87 @@ func TestPreviewWhileScanning(t *testing.T) {
 	// 40 dirs * (20 files + nested dir with 20 files) + nested dirs + root
 	assert.Greater(t, dir.GetItemCount(), int64(40*40))
 
-	// the analyzer must expose the same root it returned
+	// the analyzer exposes a point-in-time snapshot of the returned root
 	var _ common.Analyzer = analyzer
 	assert.Equal(t, dir.GetPath(), analyzer.GetCurrentDir().GetPath())
+}
+
+func TestCurrentDirSnapshotCannotOverwriteLiveStats(t *testing.T) {
+	live := &Dir{
+		File:      &File{Name: "root", Size: 100, Usage: 100},
+		Files:     make(fs.Files, 0, 1),
+		ItemCount: 1,
+	}
+	analyzer := CreateAnalyzer()
+	analyzer.setCurrentDir(live)
+
+	snapshot := analyzer.GetCurrentDir()
+	live.AddFile(&File{Name: "complete", Size: 7, Usage: 5, Parent: live})
+	live.UpdateStats(make(fs.HardLinkedItems))
+	snapshot.UpdateStats(make(fs.HardLinkedItems))
+
+	assert.Equal(t, int64(7), live.GetSize())
+	assert.Equal(t, int64(5), live.GetUsage())
+	assert.Equal(t, int64(2), live.GetItemCount())
+	assert.Empty(t, itemNames(snapshot))
+}
+
+func TestCurrentDirSnapshotPreservesArchiveItems(t *testing.T) {
+	live := &Dir{
+		File:     &File{Name: "root"},
+		BasePath: "/tmp",
+		Files:    make(fs.Files, 0, 2),
+	}
+	zipDir := &ZipDir{
+		Dir: &Dir{
+			File:  &File{Name: "archive.zip", Parent: live},
+			Files: make(fs.Files, 0, 1),
+		},
+		zipPath: "/tmp/archive.zip",
+	}
+	zipDir.Files = append(zipDir.Files, &ZipFile{
+		File:      &File{Name: "inside.zip", Parent: zipDir},
+		zipPath:   "/tmp/archive.zip",
+		inZipPath: "inside.zip",
+	})
+	tarDir := &TarDir{
+		Dir: &Dir{
+			File:  &File{Name: "archive.tar", Parent: live},
+			Files: make(fs.Files, 0, 1),
+		},
+		tarPath: "/tmp/archive.tar",
+	}
+	tarDir.Files = append(tarDir.Files, &TarFile{
+		File:      &File{Name: "inside.tar", Parent: tarDir},
+		tarPath:   "/tmp/archive.tar",
+		inTarPath: "inside.tar",
+	})
+	live.Files = append(live.Files, zipDir, tarDir)
+
+	analyzer := CreateAnalyzer()
+	analyzer.setCurrentDir(live)
+	snapshot := analyzer.GetCurrentDir()
+
+	items := make(map[string]fs.Item)
+	for item := range snapshot.GetFiles(fs.SortByName, fs.SortAsc) {
+		items[item.GetName()] = item
+	}
+	zipSnapshot, ok := items["archive.zip"].(*ZipDir)
+	assert.True(t, ok)
+	assert.Equal(t, zipDir.GetType(), zipSnapshot.GetType())
+	assert.Equal(t, zipDir.GetPath(), zipSnapshot.GetPath())
+	for item := range zipSnapshot.GetFiles(fs.SortByName, fs.SortAsc) {
+		_, isZipFile := item.(*ZipFile)
+		assert.True(t, isZipFile)
+		assert.Equal(t, zipDir.Files[0].GetPath(), item.GetPath())
+	}
+	tarSnapshot, ok := items["archive.tar"].(*TarDir)
+	assert.True(t, ok)
+	assert.Equal(t, tarDir.GetType(), tarSnapshot.GetType())
+	assert.Equal(t, tarDir.GetPath(), tarSnapshot.GetPath())
+	for item := range tarSnapshot.GetFiles(fs.SortByName, fs.SortAsc) {
+		_, isTarFile := item.(*TarFile)
+		assert.True(t, isTarFile)
+		assert.Equal(t, tarDir.Files[0].GetPath(), item.GetPath())
+	}
 }

--- a/pkg/analyze/sequential.go
+++ b/pkg/analyze/sequential.go
@@ -65,10 +65,13 @@ func (a *SequentialAnalyzer) processDir(path string) *Dir {
 	setDirPlatformSpecificAttrs(dir, path)
 
 	for _, f := range files {
+		if a.IsCancelled() {
+			break
+		}
 		name := f.Name()
 		entryPath := filepath.Join(path, name)
 		if f.IsDir() {
-			if a.ignoreDir(name, entryPath) {
+			if a.shouldSkipDir(name, entryPath) {
 				continue
 			}
 			dirCount++
@@ -85,7 +88,7 @@ func (a *SequentialAnalyzer) processDir(path string) *Dir {
 			info, err = f.Info()
 			if err != nil {
 				log.Print(err.Error())
-				dir.Flag = '!'
+				dir.SetFlag('!')
 				continue
 			}
 
@@ -93,7 +96,7 @@ func (a *SequentialAnalyzer) processDir(path string) *Dir {
 				infoF, err := followSymlink(entryPath, a.gitAnnexedSize)
 				if err != nil {
 					log.Print(err.Error())
-					dir.Flag = '!'
+					dir.SetFlag('!')
 					continue
 				}
 				if infoF != nil {

--- a/pkg/analyze/sqlite.go
+++ b/pkg/analyze/sqlite.go
@@ -1062,6 +1062,10 @@ func (a *SqliteAnalyzer) processDir(path string, parentID *int64) *SqliteItem {
 	}
 	defer releaseSlot()
 
+	if parentID != nil && a.IsCancelled() {
+		return nil
+	}
+
 	files, err := os.ReadDir(path)
 	if err != nil {
 		log.Print(err.Error())
@@ -1096,11 +1100,14 @@ func (a *SqliteAnalyzer) processDir(path string, parentID *int64) *SqliteItem {
 	// Spawn subdirectory scans in parallel; each goroutine fully completes its
 	// subtree (including DB row finalization) before sending the result back.
 	for _, f := range files {
+		if a.IsCancelled() {
+			break
+		}
 		name := f.Name()
 		entryPath := filepath.Join(path, name)
 
 		if f.IsDir() {
-			if a.ignoreDir(name, entryPath) {
+			if a.shouldSkipDir(name, entryPath) {
 				continue
 			}
 			dirCount++
@@ -1220,6 +1227,9 @@ func (a *SqliteAnalyzer) persistArchive(archiveDir *Dir, parentID int64) {
 		return
 	}
 	for _, f := range archiveDir.Files {
+		if a.IsCancelled() {
+			return
+		}
 		if f.IsDir() {
 			var subDir *Dir
 			switch v := f.(type) {

--- a/pkg/analyze/sqlite_test.go
+++ b/pkg/analyze/sqlite_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/dundee/gdu/v5/internal/testdir"
 	"github.com/dundee/gdu/v5/pkg/fs"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewSqliteStorage(t *testing.T) {
@@ -449,6 +450,65 @@ func TestSqliteItemGetFilesLocked(t *testing.T) {
 	files := slices.Collect(root.GetFilesLocked(fs.SortByName, fs.SortAsc))
 	assert.Len(t, files, 1)
 	assert.Equal(t, "file.txt", files[0].GetName())
+}
+
+func TestSnapshotSqliteItemTree(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	storage, err := NewSqliteStorage(dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, storage.Close()) })
+
+	rootID, err := storage.InsertItem(nil, "root", true, 100, 200, time.Now(), 2, 0, ' ')
+	require.NoError(t, err)
+	_, err = storage.InsertItem(&rootID, "file.txt", false, 10, 20, time.Now(), 1, 0, ' ')
+	require.NoError(t, err)
+	root, err := storage.GetItemByID(rootID)
+	require.NoError(t, err)
+
+	snapshot, ok := snapshotItem(root, nil).(*Dir)
+	require.True(t, ok)
+	require.Len(t, snapshot.Files, 1)
+	assert.Equal(t, "root", snapshot.GetName())
+	assert.Equal(t, "file.txt", snapshot.Files[0].GetName())
+	assert.Same(t, snapshot, snapshot.Files[0].GetParent())
+}
+
+func TestSqliteAnalyzerCancellationStopsArchivePersistence(t *testing.T) {
+	analyzer, err := CreateSqliteAnalyzer(filepath.Join(t.TempDir(), "test.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, analyzer.storage.Close()) })
+
+	parentID, err := analyzer.storage.InsertItem(nil, "archive.zip", true, 0, 0, time.Now(), 1, 0, ' ')
+	require.NoError(t, err)
+	archive := &Dir{
+		File:  &File{Name: "archive.zip"},
+		Files: fs.Files{&File{Name: "must-not-be-persisted"}},
+	}
+
+	analyzer.Cancel()
+	analyzer.persistArchive(archive, parentID)
+
+	children, err := analyzer.storage.GetChildren(parentID)
+	require.NoError(t, err)
+	assert.Empty(t, children)
+}
+
+func TestSqliteAnalyzerPreemptiveCancellationSkipsChildDirectory(t *testing.T) {
+	analyzer, err := CreateSqliteAnalyzer(filepath.Join(t.TempDir(), "test.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, analyzer.storage.Close()) })
+
+	parentID, err := analyzer.storage.InsertItem(nil, "root", true, 0, 0, time.Now(), 1, 0, ' ')
+	require.NoError(t, err)
+	childPath := filepath.Join(t.TempDir(), "unscanned")
+	require.NoError(t, os.Mkdir(childPath, 0o700))
+
+	analyzer.Cancel()
+	assert.Nil(t, analyzer.processDir(childPath, &parentID))
+
+	children, err := analyzer.storage.GetChildren(parentID)
+	require.NoError(t, err)
+	assert.Empty(t, children)
 }
 
 func TestSqliteItemRLock(t *testing.T) {

--- a/pkg/analyze/stored.go
+++ b/pkg/analyze/stored.go
@@ -91,10 +91,13 @@ func (a *StoredAnalyzer) processDir(path string) *StoredDir {
 	setDirPlatformSpecificAttrs(dir.Dir, path)
 
 	for _, f := range files {
+		if a.IsCancelled() {
+			break
+		}
 		name := f.Name()
 		entryPath := filepath.Join(path, name)
 		if f.IsDir() {
-			if a.ignoreDir(name, entryPath) {
+			if a.shouldSkipDir(name, entryPath) {
 				continue
 			}
 			dirCount++

--- a/tui/actions.go
+++ b/tui/actions.go
@@ -79,15 +79,18 @@ func (ui *UI) AnalyzePath(path string, parentDir fs.Item) error {
 	ui.pages.AddPage("progress", flex, true, true)
 	ui.progressFlex = flex
 
+	ui.Analyzer.ResetProgress()
+
 	analyzer := ui.Analyzer
 	doneChan := analyzer.GetDone()
 	go ui.updateProgress(analyzer, doneChan)
 
 	ui.scanStart = time.Now()
 	ui.scanning = true
+	ui.scanCancelled = false
 	go func() {
 		defer debug.FreeOSMemory()
-		currentDir := ui.Analyzer.AnalyzeDir(path, ui.CreateIgnoreFunc(), ui.CreateFileTypeFilter())
+		currentDir := analyzer.AnalyzeDir(path, ui.CreateIgnoreFunc(), ui.CreateFileTypeFilter())
 
 		if parentDir != nil {
 			currentDir.SetParent(parentDir)
@@ -107,6 +110,7 @@ func (ui *UI) AnalyzePath(path string, parentDir fs.Item) error {
 
 		ui.app.QueueUpdateDraw(func() {
 			ui.scanning = false
+			ui.scanCancelled = false
 			// remember the longest scan so we can guard against accidental quits
 			if d := time.Since(ui.scanStart); d > ui.scanDuration {
 				ui.scanDuration = d

--- a/tui/actions_test.go
+++ b/tui/actions_test.go
@@ -5,8 +5,10 @@ import (
 	"errors"
 	"os"
 	"slices"
+	"sync"
 	"testing"
 
+	"github.com/dundee/gdu/v5/internal/common"
 	"github.com/dundee/gdu/v5/internal/testanalyze"
 	"github.com/dundee/gdu/v5/internal/testapp"
 	"github.com/dundee/gdu/v5/internal/testdir"
@@ -114,6 +116,63 @@ func TestAnalyzePathBW(t *testing.T) {
 
 	assert.Equal(t, 4, ui.table.GetRowCount())
 	assert.Contains(t, ui.table.GetCell(0, 0).Text, "ddd")
+}
+
+func TestCtrlCDuringScanShowsPartialResults(t *testing.T) {
+	simScreen := testapp.CreateSimScreen()
+	defer simScreen.Fini()
+
+	app := testapp.CreateMockedApp(false)
+	ui := CreateUI(app, simScreen, &bytes.Buffer{}, true, true, false, false)
+	analyzer := &blockingAnalyzer{
+		started:   make(chan struct{}),
+		cancelled: make(chan struct{}),
+		done:      make(common.SignalGroup),
+	}
+	ui.Analyzer = analyzer
+	ui.done = make(chan struct{})
+
+	assert.NoError(t, ui.AnalyzePath("test_dir", nil))
+
+	key := ui.keyPressed(tcell.NewEventKey(tcell.KeyCtrlC, 0, 0))
+	assert.Nil(t, key)
+	assert.True(t, ui.scanCancelled)
+	<-ui.done
+	for _, draw := range app.(*testapp.MockedApp).GetUpdateDraws() {
+		draw()
+	}
+
+	assert.False(t, ui.scanCancelled)
+	assert.False(t, ui.pages.HasPage("progress"))
+	assert.Equal(t, "test_dir", ui.currentDir.GetName())
+	assert.Equal(t, 4, ui.table.GetRowCount())
+}
+
+type blockingAnalyzer struct {
+	testanalyze.MockedAnalyzer
+	started   chan struct{}
+	cancelled chan struct{}
+	done      common.SignalGroup
+	once      sync.Once
+}
+
+func (a *blockingAnalyzer) AnalyzeDir(
+	path string, ignore common.ShouldDirBeIgnored, fileTypeFilter common.ShouldFileBeIgnored,
+) fs.Item {
+	close(a.started)
+	<-a.cancelled
+	defer a.done.Broadcast()
+	return a.MockedAnalyzer.AnalyzeDir(path, ignore, fileTypeFilter)
+}
+
+func (a *blockingAnalyzer) Cancel() {
+	a.once.Do(func() {
+		close(a.cancelled)
+	})
+}
+
+func (a *blockingAnalyzer) GetDone() common.SignalGroup {
+	return a.done
 }
 
 func TestAnalyzePathWithParentDir(t *testing.T) {

--- a/tui/cancel_race_test.go
+++ b/tui/cancel_race_test.go
@@ -1,0 +1,301 @@
+package tui
+
+import (
+	"bytes"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/dundee/gdu/v5/internal/common"
+	"github.com/dundee/gdu/v5/internal/testanalyze"
+	"github.com/dundee/gdu/v5/internal/testapp"
+	"github.com/dundee/gdu/v5/pkg/fs"
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+	"github.com/stretchr/testify/require"
+)
+
+type cancelRaceApp struct {
+	*testapp.MockedApp
+	updates chan func()
+	mu      sync.Mutex
+	stops   int
+}
+
+func newCancelRaceApp() *cancelRaceApp {
+	return &cancelRaceApp{
+		MockedApp: &testapp.MockedApp{},
+		updates:   make(chan func(), 8),
+	}
+}
+
+func (app *cancelRaceApp) QueueUpdateDraw(update func()) *tview.Application {
+	app.updates <- update
+	return nil
+}
+
+func (app *cancelRaceApp) Stop() {
+	app.mu.Lock()
+	app.stops++
+	app.mu.Unlock()
+}
+
+func (app *cancelRaceApp) stopCount() int {
+	app.mu.Lock()
+	defer app.mu.Unlock()
+	return app.stops
+}
+
+func (app *cancelRaceApp) nextUpdate(t *testing.T) func() {
+	t.Helper()
+	select {
+	case update := <-app.updates:
+		return update
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for queued UI update")
+		return nil
+	}
+}
+
+type failOnceSignalScreen struct {
+	tcell.Screen
+	attempted chan struct{}
+	fail      bool
+}
+
+func (screen *failOnceSignalScreen) PostEvent(event tcell.Event) error {
+	if screen.fail {
+		screen.fail = false
+		close(screen.attempted)
+		return tcell.ErrEventQFull
+	}
+	return screen.Screen.PostEvent(event)
+}
+
+type signalLifecycleApp struct {
+	*testapp.MockedApp
+	signalAttempted <-chan struct{}
+}
+
+func (app *signalLifecycleApp) Run() error {
+	<-app.signalAttempted
+	return nil
+}
+
+type cancelRaceAnalyzer struct {
+	*testanalyze.MockedAnalyzer
+	started   chan struct{}
+	release   chan struct{}
+	cancelled chan struct{}
+	done      common.SignalGroup
+	cancelMu  sync.Mutex
+	cancels   int
+	once      sync.Once
+}
+
+func newCancelRaceAnalyzer() *cancelRaceAnalyzer {
+	progressDone := make(common.SignalGroup)
+	progressDone.Broadcast()
+	return &cancelRaceAnalyzer{
+		MockedAnalyzer: &testanalyze.MockedAnalyzer{},
+		started:        make(chan struct{}),
+		release:        make(chan struct{}),
+		cancelled:      make(chan struct{}),
+		done:           progressDone,
+	}
+}
+
+func (a *cancelRaceAnalyzer) AnalyzeDir(
+	path string, ignore common.ShouldDirBeIgnored, fileTypeFilter common.ShouldFileBeIgnored,
+) fs.Item {
+	close(a.started)
+	select {
+	case <-a.cancelled:
+	case <-a.release:
+	}
+	return a.MockedAnalyzer.AnalyzeDir(path, ignore, fileTypeFilter)
+}
+
+func (a *cancelRaceAnalyzer) Cancel() {
+	a.cancelMu.Lock()
+	a.cancels++
+	a.cancelMu.Unlock()
+	a.once.Do(func() { close(a.cancelled) })
+}
+
+func (a *cancelRaceAnalyzer) cancelCount() int {
+	a.cancelMu.Lock()
+	defer a.cancelMu.Unlock()
+	return a.cancels
+}
+
+func (a *cancelRaceAnalyzer) GetDone() common.SignalGroup {
+	return a.done
+}
+
+func newCancelRaceUI(app *cancelRaceApp, analyzer *cancelRaceAnalyzer) *UI {
+	screen := testapp.CreateSimScreen()
+	ui := CreateUI(app, screen, &bytes.Buffer{}, true, true, false, false)
+	ui.Analyzer = analyzer
+	ui.done = make(chan struct{})
+	return ui
+}
+
+func drainScanUpdates(t *testing.T, app *cancelRaceApp, ui *UI) {
+	t.Helper()
+	// One update finalizes progress and one applies the completed scan. The
+	// progress channel is already closed, so the first update is deterministic.
+	first := app.nextUpdate(t)
+	second := app.nextUpdate(t)
+	first()
+	second()
+	require.False(t, ui.scanning)
+	require.False(t, ui.pages.HasPage("progress"))
+}
+
+func TestAnalyzePathImmediateCtrlCIsNotLost(t *testing.T) {
+	app := newCancelRaceApp()
+	analyzer := newCancelRaceAnalyzer()
+	ui := newCancelRaceUI(app, analyzer)
+
+	require.NoError(t, ui.AnalyzePath("test_dir", nil))
+	// Ctrl-C is intentionally delivered immediately, before AnalyzeDir is
+	// guaranteed to have started. Cancel must still be observed by the double.
+	require.Nil(t, ui.keyPressed(tcell.NewEventKey(tcell.KeyCtrlC, 0, 0)))
+	_ = ui.keyPressed(tcell.NewEventKey(tcell.KeyCtrlC, 0, 0))
+
+	select {
+	case <-analyzer.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("AnalyzeDir did not start")
+	}
+	select {
+	case <-ui.done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("scan did not complete after cancellation")
+	}
+	drainScanUpdates(t, app, ui)
+
+	require.Equal(t, 1, analyzer.cancelCount())
+	require.Equal(t, 0, app.stopCount())
+	require.Equal(t, "test_dir", ui.currentDir.GetName())
+}
+
+func TestCtrlCBeforeQueuedCompletionKeepsResults(t *testing.T) {
+	app := newCancelRaceApp()
+	analyzer := newCancelRaceAnalyzer()
+	ui := newCancelRaceUI(app, analyzer)
+
+	require.NoError(t, ui.AnalyzePath("test_dir", nil))
+	close(analyzer.release)
+	select {
+	case <-ui.done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("scan did not complete")
+	}
+
+	// The completion draw is queued, but has not run yet. Cancellation must
+	// not discard the result or make the completion callback unsafe.
+	require.Nil(t, ui.keyPressed(tcell.NewEventKey(tcell.KeyCtrlC, 0, 0)))
+	drainScanUpdates(t, app, ui)
+
+	require.Equal(t, 1, analyzer.cancelCount())
+	require.Equal(t, "test_dir", ui.currentDir.GetName())
+	require.Equal(t, 4, ui.table.GetRowCount())
+}
+
+func TestRepeatedSignalCtrlCIsIdempotent(t *testing.T) {
+	app := newCancelRaceApp()
+	analyzer := newCancelRaceAnalyzer()
+	ui := newCancelRaceUI(app, analyzer)
+
+	require.NoError(t, ui.AnalyzePath("test_dir", nil))
+	ui.keyPressed(signalEvent(os.Interrupt))
+	ui.keyPressed(signalEvent(os.Interrupt))
+	require.Equal(t, 1, analyzer.cancelCount())
+	require.Equal(t, 0, app.stopCount())
+
+	close(analyzer.release)
+	select {
+	case <-ui.done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("scan did not complete")
+	}
+	drainScanUpdates(t, app, ui)
+
+	// Once the completion callback has marked the scan finished, SIGINT takes
+	// the normal quit path.
+	ui.keyPressed(signalEvent(os.Interrupt))
+	require.Equal(t, 1, app.stopCount())
+}
+
+func TestSignalLoopQueuesScanCancellation(t *testing.T) {
+	app := newCancelRaceApp()
+	analyzer := &testanalyze.MockedAnalyzer{}
+	screen := testapp.CreateSimScreen()
+	require.NoError(t, screen.Init())
+	defer screen.Fini()
+	ui := CreateUI(app, screen, &bytes.Buffer{}, true, true, false, false)
+	ui.Analyzer = analyzer
+	ui.progress = tview.NewTextView()
+	ui.scanning = true
+
+	signals := make(chan os.Signal, 1)
+	signals <- os.Interrupt
+	close(signals)
+	ui.handleSignals(signals, make(chan struct{}))
+
+	event, ok := screen.PollEvent().(*tcell.EventKey)
+	require.True(t, ok)
+	ui.keyPressed(event)
+
+	require.True(t, analyzer.IsCancelled())
+	require.True(t, ui.scanCancelled)
+	require.Equal(t, 0, app.stopCount())
+}
+
+func TestSignalLoopRetriesFullEventQueue(t *testing.T) {
+	app := newCancelRaceApp()
+	analyzer := &testanalyze.MockedAnalyzer{}
+	simScreen := testapp.CreateSimScreen()
+	require.NoError(t, simScreen.Init())
+	defer simScreen.Fini()
+	screen := &failOnceSignalScreen{
+		Screen:    simScreen,
+		attempted: make(chan struct{}),
+		fail:      true,
+	}
+	ui := CreateUI(app, screen, &bytes.Buffer{}, true, true, false, false)
+	ui.Analyzer = analyzer
+	ui.progress = tview.NewTextView()
+	ui.scanning = true
+
+	signals := make(chan os.Signal, 1)
+	signals <- os.Interrupt
+	close(signals)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		ui.handleSignals(signals, make(chan struct{}))
+	}()
+
+	select {
+	case <-screen.attempted:
+	case <-time.After(time.Second):
+		t.Fatal("signal event delivery was not attempted")
+	}
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("signal event was not retried")
+	}
+
+	event, ok := simScreen.PollEvent().(*tcell.EventKey)
+	require.True(t, ok)
+	ui.keyPressed(event)
+
+	require.True(t, analyzer.IsCancelled())
+	require.True(t, ui.scanCancelled)
+	require.Equal(t, 0, app.stopCount())
+}

--- a/tui/keys.go
+++ b/tui/keys.go
@@ -15,6 +15,11 @@ var analyzeParentPath = func(ui *UI, path string, parentDir fs.Item) error {
 }
 
 func (ui *UI) keyPressed(key *tcell.EventKey) *tcell.EventKey {
+	if key.Key() == tcell.KeyExit {
+		ui.handleSignalEvent(key)
+		return nil
+	}
+
 	if ui.handleCtrlZ(key) == nil {
 		return nil
 	}
@@ -41,6 +46,10 @@ func (ui *UI) keyPressed(key *tcell.EventKey) *tcell.EventKey {
 
 	if ui.pages.HasPage("confirm") {
 		return ui.handleConfirmation(key)
+	}
+
+	if key.Key() == tcell.KeyCtrlC && ui.cancelScan() {
+		return nil
 	}
 
 	if ui.previewing {

--- a/tui/keys_test.go
+++ b/tui/keys_test.go
@@ -477,6 +477,40 @@ func TestTabDuringScanEntersPreview(t *testing.T) {
 	assert.False(t, ui.pages.HasPage("progress"))
 }
 
+func TestCtrlCDuringScanCancelsAnalyzer(t *testing.T) {
+	fin := testdir.CreateTestDir()
+	defer fin()
+
+	ui := analyzedUI(t, &bytes.Buffer{})
+	ui.progress = tview.NewTextView()
+	ui.scanning = true
+	ui.pages.AddPage("progress", ui.progress, true, true)
+
+	key := ui.keyPressed(tcell.NewEventKey(tcell.KeyCtrlC, 0, 0))
+
+	assert.Nil(t, key)
+	assert.True(t, ui.scanCancelled)
+	assert.True(t, ui.Analyzer.(*analyze.ParallelAnalyzer).IsCancelled())
+	assert.Equal(t, " Stopping scan... ", ui.progress.GetTitle())
+}
+
+func TestCtrlCDuringScanPreviewCancelsAnalyzer(t *testing.T) {
+	fin := testdir.CreateTestDir()
+	defer fin()
+
+	ui := analyzedUI(t, &bytes.Buffer{})
+	ui.progress = tview.NewTextView()
+	ui.scanning = true
+	ui.pages.AddPage("progress", ui.progress, true, true)
+	ui.enterPreview()
+
+	key := ui.keyPressed(tcell.NewEventKey(tcell.KeyCtrlC, 0, 0))
+
+	assert.Nil(t, key)
+	assert.True(t, ui.scanCancelled)
+	assert.True(t, ui.Analyzer.(*analyze.ParallelAnalyzer).IsCancelled())
+}
+
 func TestPreviewIgnoresDestructiveKeys(t *testing.T) {
 	fin := testdir.CreateTestDir()
 	defer fin()

--- a/tui/progress.go
+++ b/tui/progress.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/dundee/gdu/v5/internal/common"
-	"github.com/dundee/gdu/v5/pkg/path"
 )
 
 func (ui *UI) updateProgress(analyzer common.Analyzer, doneChan common.SignalGroup) {
@@ -39,7 +38,7 @@ func (ui *UI) updateProgress(analyzer common.Analyzer, doneChan common.SignalGro
 
 		progress := analyzer.GetProgress()
 
-		func(itemCount int64, totalUsage int64, currentItem string) {
+		func(itemCount int64, totalUsage int64) {
 			delta := time.Since(start).Round(time.Second)
 
 			if deviceSize > 0 && showBar {
@@ -60,11 +59,10 @@ func (ui *UI) updateProgress(analyzer common.Analyzer, doneChan common.SignalGro
 					"[white:black:-], elapsed time: " +
 					color +
 					delta.String() +
-					"[white:black:-]\nCurrent item: [white:black:b]" +
-					path.ShortenPath(currentItem, ui.currentItemNameMaxLen) +
-					"[white:black:-]\n\nPress Tab to preview results found so far")
+					"[white:black:-]\n\nPress Tab to preview results found so far\n" +
+					"Press Ctrl+C to stop scanning and keep results")
 			})
-		}(progress.ItemCount, progress.TotalUsage, progress.CurrentItemName)
+		}(progress.ItemCount, progress.TotalUsage)
 	}
 }
 

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -100,6 +100,7 @@ type UI struct {
 	currentDeviceSize       int64
 	confirmQuit             bool
 	scanning                bool
+	scanCancelled           bool
 	scanStart               time.Time
 	scanDuration            time.Duration
 	previewing              bool
@@ -327,28 +328,97 @@ func (ui *UI) SetDeleteInParallel() {
 
 // StartUILoop starts tview application
 func (ui *UI) StartUILoop() error {
+	signals := make(chan os.Signal, 1)
+	signal.Notify(
+		signals,
+		syscall.SIGHUP,
+		syscall.SIGINT,
+		syscall.SIGQUIT,
+		syscall.SIGILL,
+		syscall.SIGTRAP,
+		syscall.SIGABRT,
+		syscall.SIGPIPE,
+		syscall.SIGTERM,
+	)
+	defer signal.Stop(signals)
+
+	return ui.runUILoop(signals)
+}
+
+func (ui *UI) runUILoop(signals <-chan os.Signal) error {
+	stopSignals := make(chan struct{})
+	signalsDone := make(chan struct{})
 	go func() {
-		c := make(chan os.Signal, 1)
-		signal.Notify(
-			c,
-			syscall.SIGHUP,
-			syscall.SIGINT,
-			syscall.SIGQUIT,
-			syscall.SIGILL,
-			syscall.SIGTRAP,
-			syscall.SIGABRT,
-			syscall.SIGPIPE,
-			syscall.SIGTERM,
-		)
-		s := <-c
-		log.Printf("Got signal: %s", s)
-		ui.app.QueueUpdateDraw(func() {
-			ui.printMarkedPaths()
-			ui.app.Stop()
-		})
+		defer close(signalsDone)
+		ui.handleSignals(signals, stopSignals)
 	}()
 
-	return ui.app.Run()
+	err := ui.app.Run()
+	close(stopSignals)
+	<-signalsDone
+	return err
+}
+
+func (ui *UI) handleSignals(signals <-chan os.Signal, stop <-chan struct{}) {
+	for {
+		select {
+		case <-stop:
+			return
+		case current, ok := <-signals:
+			if !ok {
+				return
+			}
+			log.Printf("Got signal: %s", current)
+			ui.postSignalEvent(signalEvent(current), stop)
+		}
+	}
+}
+
+func (ui *UI) postSignalEvent(event *tcell.EventKey, stop <-chan struct{}) {
+	if err := ui.screen.PostEvent(event); err == nil {
+		return
+	}
+
+	retry := time.NewTicker(time.Millisecond)
+	defer retry.Stop()
+	for {
+		select {
+		case <-stop:
+			return
+		case <-retry.C:
+			if err := ui.screen.PostEvent(event); err == nil {
+				return
+			}
+		}
+	}
+}
+
+func signalEvent(current os.Signal) *tcell.EventKey {
+	modifiers := tcell.ModNone
+	if current == syscall.SIGINT {
+		modifiers = tcell.ModCtrl
+	}
+	return tcell.NewEventKey(tcell.KeyExit, 0, modifiers)
+}
+
+func (ui *UI) handleSignalEvent(event *tcell.EventKey) {
+	if event.Modifiers() == tcell.ModCtrl && (ui.cancelScan() || ui.scanning) {
+		return
+	}
+	ui.printMarkedPaths()
+	ui.app.Stop()
+}
+
+func (ui *UI) cancelScan() bool {
+	if !ui.scanning || ui.scanCancelled {
+		return false
+	}
+
+	ui.Analyzer.Cancel()
+	ui.scanCancelled = true
+	ui.progress.SetTitle(" Stopping scan... ")
+	ui.progress.SetText("Stopping scan and keeping results...")
+	return true
 }
 
 // SetConfirmQuit sets whether gdu asks for confirmation before quitting
@@ -417,7 +487,6 @@ func (ui *UI) resetSorting() {
 }
 
 func (ui *UI) rescanDir() {
-	ui.Analyzer.ResetProgress()
 	ui.linkedItems = make(fs.HardLinkedItems)
 	err := ui.AnalyzePath(ui.currentDirPath, ui.currentDir.GetParent())
 	if err != nil {

--- a/tui/tui_test.go
+++ b/tui/tui_test.go
@@ -10,6 +10,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
+	"github.com/dundee/gdu/v5/internal/common"
 	"github.com/dundee/gdu/v5/internal/testanalyze"
 	"github.com/dundee/gdu/v5/internal/testapp"
 	"github.com/dundee/gdu/v5/internal/testdev"
@@ -78,6 +79,35 @@ func TestUpdateProgress(t *testing.T) {
 	done := ui.Analyzer.GetDone()
 	done.Broadcast()
 	ui.updateProgress(ui.Analyzer, done)
+}
+
+func TestUpdateProgressShowsCancellationHint(t *testing.T) {
+	simScreen := testapp.CreateSimScreen()
+	defer simScreen.Fini()
+
+	app := testapp.CreateMockedApp(false).(*testapp.MockedApp)
+	ui := CreateUI(app, simScreen, &bytes.Buffer{}, false, false, false, false)
+	ui.progress = ui.header
+	done := make(common.SignalGroup)
+	finished := make(chan struct{})
+	go func() {
+		defer close(finished)
+		ui.updateProgress(ui.Analyzer, done)
+	}()
+
+	if !assert.Eventually(t, func() bool {
+		return len(app.GetUpdateDraws()) > 0
+	}, time.Second, 10*time.Millisecond) {
+		done.Broadcast()
+		<-finished
+		return
+	}
+	done.Broadcast()
+	<-finished
+
+	draws := app.GetUpdateDraws()
+	draws[0]()
+	assert.Contains(t, ui.progress.GetText(false), "Press Ctrl+C to stop scanning and keep results")
 }
 
 func TestSetShowDiskProgressBar(t *testing.T) {
@@ -172,6 +202,36 @@ func TestAppRun(t *testing.T) {
 	err := ui.StartUILoop()
 
 	assert.Nil(t, err)
+}
+
+func TestUILoopReturnsWithPendingSignal(t *testing.T) {
+	simScreen := testapp.CreateSimScreen()
+	assert.NoError(t, simScreen.Init())
+	defer simScreen.Fini()
+	screen := &failOnceSignalScreen{
+		Screen:    simScreen,
+		attempted: make(chan struct{}),
+		fail:      true,
+	}
+	app := &signalLifecycleApp{
+		MockedApp:       testapp.CreateMockedApp(false).(*testapp.MockedApp),
+		signalAttempted: screen.attempted,
+	}
+	ui := CreateUI(app, screen, &bytes.Buffer{}, false, true, false, false)
+	signals := make(chan os.Signal, 1)
+	signals <- os.Interrupt
+
+	result := make(chan error, 1)
+	go func() {
+		result <- ui.runUILoop(signals)
+	}()
+
+	select {
+	case err := <-result:
+		assert.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("UI loop did not stop its signal listener")
+	}
 }
 
 func TestAppRunWithErr(t *testing.T) {


### PR DESCRIPTION
## Summary
- make Ctrl+C during an interactive scan stop scheduling new work instead of quitting
- keep the partial directory tree and transition directly to navigable results
- preserve point-in-time preview safety while analyzers are still mutating the live tree
- apply cooperative cancellation consistently to parallel, stable, sequential, stored, SQLite, and top-directory analyzers
- document the Ctrl+C behavior

## Behavior
- first Ctrl+C during a scan requests cancellation and shows a stopping state
- in-flight filesystem operations finish safely; no new recursive work is scheduled
- the resulting partial tree remains available for navigation
- later Ctrl+C follows the normal quit path
- cancellation state resets before a subsequent scan

## Verification
- `go vet ./...`
- `go test ./...`
- `go test -race ./pkg/analyze ./tui`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.2 run ./...`
- interactive smoke: scan `/`, send SIGINT while active, observe `Stopping scan and keeping results...`, then reach a populated results screen

Closes #150