### PR TITLE
fix: sanitize control characters in paths printed on quit

### DIFF
--- a/tui/keys.go
+++ b/tui/keys.go
@@ -209,7 +209,7 @@ func (ui *UI) doQuit(printCurrentDirPath bool) {
 	ui.app.Stop()
 	ui.printMarkedPaths()
 	if printCurrentDirPath {
-		fmt.Fprintf(ui.output, "%s\n", ui.currentDirPath)
+		fmt.Fprintf(ui.output, "%s\n", sanitizePathForDisplay(ui.currentDirPath))
 	}
 }
 

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -6,9 +6,11 @@ import (
 	"os"
 	"os/signal"
 	"runtime"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
+	"unicode"
 
 	log "github.com/sirupsen/logrus"
 
@@ -639,9 +641,23 @@ func (ui *UI) isDeleteAllowedWithFilter() bool {
 	return false
 }
 
+// sanitizePathForDisplay replaces control characters (which can include
+// terminal escape sequences) with the Unicode replacement character. A
+// scanned directory entry's name has no character restrictions, and these
+// paths are printed to the real terminal after the tview screen has
+// stopped, bypassing tview's own protective rendering entirely.
+func sanitizePathForDisplay(s string) string {
+	return strings.Map(func(r rune) rune {
+		if unicode.IsControl(r) {
+			return '�'
+		}
+		return r
+	}, s)
+}
+
 // printMarkedPaths prints the paths of the marked items to the output
 func (ui *UI) printMarkedPaths() {
 	for _, path := range ui.markedPaths {
-		fmt.Fprintf(ui.output, "%s\n", path)
+		fmt.Fprintf(ui.output, "%s\n", sanitizePathForDisplay(path))
 	}
 }


### PR DESCRIPTION
Fixes #615.

gdu's TUI is built on tview, which already strips control characters from the paths it renders on screen. But two features print a path directly to the terminal after the TUI has already stopped, bypassing that protection: quitting with `Q` prints the current directory's path, and quitting after marking files prints each marked path. A scanned directory or file's name has no character restrictions, so a crafted name can inject terminal escape sequences into either printed line.

Adds `sanitizePathForDisplay` (`tui/tui.go`), replacing control characters with the Unicode replacement character, applied at both `doQuit`'s currentDirPath print (`tui/keys.go`) and `printMarkedPaths` (`tui/tui.go`).

Verified against a directory containing a subdirectory named with a raw OSC title-set escape sequence, navigating into it and quitting with `Q`, output redirected to a file and inspected as a hex dump. Confirmed no regression with a normal directory path. `tui` package tests pass.

One honest caveat: I fixed `printMarkedPaths` using the identical pattern as the confirmed `Q`-path sink (same unsanitized `fmt.Fprintf` shape, same sanitizer), but I wasn't able to independently reproduce that specific call site live within the time I had. Marking an entry worked (confirmed via the checkmark in the UI itself), but the raw output capture never showed the expected printed line on quit despite a few timing adjustments on my end. The fix should still be correct by inspection, just flagging that I'm not claiming it as independently reproduced the way the `Q` path is.