### PR TITLE
fix(timefilter): drop the stray separator in the until= filter footer

### DIFF
--- a/pkg/timefilter/timefilter.go
+++ b/pkg/timefilter/timefilter.go
@@ -117,9 +117,9 @@ func (tf *TimeFilter) FormatForDisplay(loc *time.Location) string {
 
 	for _, until := range tf.until {
 		if until.instant != nil {
-			parts = append(parts, "until=", until.instant.In(loc).Format(time.RFC3339))
+			parts = append(parts, "until="+until.instant.In(loc).Format(time.RFC3339))
 		} else if until.dateOnly != nil {
-			parts = append(parts, "until=", until.dateOnly.Format("2006-01-02")+" (date-only)")
+			parts = append(parts, "until="+until.dateOnly.Format("2006-01-02")+" (date-only)")
 		}
 	}
 

--- a/pkg/timefilter/timefilter_test.go
+++ b/pkg/timefilter/timefilter_test.go
@@ -654,6 +654,26 @@ func TestFormatForDisplayUntilDateOnly(t *testing.T) {
 	}
 }
 
+func TestFormatForDisplayUntilInstant(t *testing.T) {
+	loc, err := time.LoadLocation("America/Vancouver")
+	if err != nil {
+		t.Fatalf("Failed to load timezone: %v", err)
+	}
+
+	now := time.Date(2025, 8, 11, 12, 0, 0, 0, loc)
+
+	filter, err := NewTimeFilter("", "2026-08-01T10:00:00Z", "", "", now, loc)
+	if err != nil {
+		t.Fatalf("Failed to create time filter: %v", err)
+	}
+
+	result := filter.FormatForDisplay(time.UTC)
+	expected := " Filtered by: time=mtime; until=2026-08-01T10:00:00Z"
+	if result != expected {
+		t.Errorf("Expected %q, got %q", expected, result)
+	}
+}
+
 func TestIncludeByTimeBound(t *testing.T) {
 	loc, err := time.LoadLocation("America/Vancouver")
 	if err != nil {

--- a/pkg/timefilter/timefilter_test.go
+++ b/pkg/timefilter/timefilter_test.go
@@ -1,6 +1,7 @@
 package timefilter
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
@@ -627,6 +628,29 @@ func TestTimeFilterIncludeByTimeFilter(t *testing.T) {
 				t.Errorf("Expected include=%v, got include=%v", tt.expectInclude, result)
 			}
 		})
+	}
+}
+
+func TestFormatForDisplayUntilDateOnly(t *testing.T) {
+	loc, err := time.LoadLocation("America/Vancouver")
+	if err != nil {
+		t.Fatalf("Failed to load timezone: %v", err)
+	}
+
+	now := time.Date(2025, 8, 11, 12, 0, 0, 0, loc)
+
+	filter, err := NewTimeFilter("", "2026-08-01", "", "", now, loc)
+	if err != nil {
+		t.Fatalf("Failed to create time filter: %v", err)
+	}
+
+	result := filter.FormatForDisplay(loc)
+	expected := " Filtered by: time=mtime; until=2026-08-01 (date-only)"
+	if result != expected {
+		t.Errorf("Expected %q, got %q", expected, result)
+	}
+	if strings.Contains(result, "; ;") || strings.Contains(result, "until=;") {
+		t.Errorf("Result contains stray separator: %q", result)
 	}
 }
 


### PR DESCRIPTION
## What's broken

With `--until` or `--min-age` set, the TUI footer renders a stray separator before the value:

```
 Filtered by: time=mtime; until=; 2026-08-01 (date-only)
```

## Repro

```
gdu --until 2026-08-01 /some/dir
```

The footer shows `until=;` followed by the date on the other side of the separator.

## The fix

`FormatForDisplay` builds the `since=` parts by concatenating the label and value into one slice element, but the `until=` branches append them as two separate elements. The slice is later joined with `"; "`, so every `until` filter gains a separator in the middle. Both `until` branches now concatenate, matching `since`.

Combined filters render correctly too:

```
 Filtered by: time=mtime; since=2026-01-01 (date-only); until=2026-08-01 (date-only)
```

## Verification

Added `TestFormatForDisplayUntilDateOnly` in `pkg/timefilter/timefilter_test.go`. It fails against the old code with `until=; 2026-08-01 (date-only)` and passes with the fix. `go test ./...` is green.
