### PR TITLE
fix: don't materialize dataless files when scanning on macOS

### DIFF
--- a/cmd/gdu/app/app.go
+++ b/cmd/gdu/app/app.go
@@ -643,6 +643,13 @@ func (a *App) runAction(ui UI, path string) error {
 			return fmt.Errorf("reading analysis: %w", err)
 		}
 	default:
+		// Do not materialize dataless files on macOS. Without this, scanning
+		// an iCloud Drive / Google Drive / OneDrive tree is orders of
+		// magnitude slower. This is a no-op on other platforms.
+		if err := gfs.PreventDatalessMaterialization(); err != nil {
+			log.Printf("Could not prevent dataless materialization: %s", err)
+		}
+
 		if build.RootPathPrefix != "" {
 			path = build.RootPathPrefix + path
 		}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.0
 
 require (
 	github.com/dgraph-io/badger/v4 v4.9.1
+	github.com/ebitengine/purego v0.10.2
 	github.com/fatih/color v1.19.0
 	github.com/gdamore/tcell/v2 v2.13.10
 	github.com/h2non/filetype v1.1.3

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/dgryski/go-farm v0.0.0-20240924180020-3414d57e47da h1:aIftn67I1fkbMa5
 github.com/dgryski/go-farm v0.0.0-20240924180020-3414d57e47da/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
+github.com/ebitengine/purego v0.10.2 h1:W809HbnvzAxgdm+aOvlSekrM16wGCdT/e76+9tS7gzE=
+github.com/ebitengine/purego v0.10.2/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/fatih/color v1.19.0 h1:Zp3PiM21/9Ld6FzSKyL5c/BULoe/ONr9KlbYVOfG8+w=
 github.com/fatih/color v1.19.0/go.mod h1:zNk67I0ZUT1bEGsSGyCZYZNrHuTkJJB+r6Q9VuMi0LE=
 github.com/gdamore/encoding v1.0.1 h1:YzKZckdBL6jVt2Gc+5p82qhrGiqMdG/eNs6Wy0u3Uhw=

--- a/pkg/fs/dataless_darwin.go
+++ b/pkg/fs/dataless_darwin.go
@@ -1,0 +1,77 @@
+//go:build darwin
+
+package fs
+
+import (
+	"fmt"
+
+	"github.com/ebitengine/purego"
+)
+
+// Constants from the macOS SDK, sys/resource.h. Documented in setiopolicy_np(3).
+const (
+	iopolTypeVFSMaterializeDatalessFiles = 3 // IOPOL_TYPE_VFS_MATERIALIZE_DATALESS_FILES
+	iopolScopeProcess                    = 0 // IOPOL_SCOPE_PROCESS
+	iopolMaterializeDatalessFilesOff     = 1 // IOPOL_MATERIALIZE_DATALESS_FILES_OFF
+)
+
+const libSystem = "/usr/lib/libSystem.B.dylib"
+
+// PreventDatalessMaterialization stops the kernel from materializing dataless
+// files while this process walks the filesystem.
+//
+// On volumes backed by a File Provider extension (iCloud Drive, Google Drive,
+// OneDrive, Dropbox) files can be "dataless": the metadata is local but the
+// contents are not. Traversing such a directory makes the kernel ask the
+// provider to materialize it. That is a synchronous round trip to the provider
+// daemon and often a real download, so scanning is orders of magnitude slower
+// and pulls down data the user never asked for.
+//
+// /usr/bin/du opts out for the same reason, by setting the
+// vfs.nspace.prevent_materialization sysctl (rdar://44903941):
+// https://github.com/apple-oss-distributions/file_cmds/blob/659a8a301e2acf0343f8b8673a154a2ca4d07084/du/du.c#L323
+//
+// We use setiopolicy_np instead. It sets the same per-process kernel state, and
+// it is the API Apple documents for this in TN3150:
+// https://developer.apple.com/documentation/technotes/tn3150-getting-ready-for-data-less-files
+//
+// The scope is IOPOL_SCOPE_PROCESS rather than IOPOL_SCOPE_THREAD because
+// goroutines migrate between OS threads. Thread scope would require
+// LockOSThread on every scanning worker. The call needs no privileges and is
+// inert on volumes with no dataless files, so it is safe to make it always.
+//
+// It goes through libSystem rather than a raw syscall because libSystem is the
+// only ABI Apple guarantees (QA1118). x/sys/unix has no binding for
+// setiopolicy_np, and gdu builds with CGO_ENABLED=0, so purego provides the
+// dlopen/dlsym bridge.
+//
+// Note that with materialization off, reading the contents of a dataless file
+// fails with EDEADLK. Scanning only reads metadata, so it is unaffected. The
+// file viewer (v) and archive browsing do read contents, and show an error
+// dialog for a dataless file. That is intentional: a disk usage tool should not
+// download a file to display it.
+func PreventDatalessMaterialization() error {
+	lib, err := purego.Dlopen(libSystem, purego.RTLD_NOW|purego.RTLD_GLOBAL)
+	if err != nil {
+		return fmt.Errorf("dlopen %s: %w", libSystem, err)
+	}
+
+	// Use Dlsym and RegisterFunc, not RegisterLibFunc, as the latter panics if
+	// the symbol is missing.
+	sym, err := purego.Dlsym(lib, "setiopolicy_np")
+	if err != nil {
+		return fmt.Errorf("dlsym setiopolicy_np: %w", err)
+	}
+
+	var setiopolicyNp func(iotype, scope, policy int32) int32
+	purego.RegisterFunc(&setiopolicyNp, sym)
+
+	if rc := setiopolicyNp(
+		iopolTypeVFSMaterializeDatalessFiles,
+		iopolScopeProcess,
+		iopolMaterializeDatalessFilesOff,
+	); rc != 0 {
+		return fmt.Errorf("setiopolicy_np returned %d", rc)
+	}
+	return nil
+}

--- a/pkg/fs/dataless_darwin_test.go
+++ b/pkg/fs/dataless_darwin_test.go
@@ -1,0 +1,34 @@
+//go:build darwin
+
+package fs
+
+import (
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+// TestPreventDatalessMaterialization checks that the call reaches the kernel, by
+// reading back the state it is supposed to change.
+//
+// setiopolicy_np with IOPOL_TYPE_VFS_MATERIALIZE_DATALESS_FILES and the
+// vfs.nspace.prevent_materialization sysctl are the same per-process state.
+// x/sys/unix exposes sysctl readers but no writer, which is enough here: we can
+// verify the result even though we cannot produce it.
+//
+// The state is per-process and has no effect outside the test binary.
+func TestPreventDatalessMaterialization(t *testing.T) {
+	const preventMaterializationSysctl = "vfs.nspace.prevent_materialization"
+
+	if err := PreventDatalessMaterialization(); err != nil {
+		t.Fatalf("PreventDatalessMaterialization: %s", err)
+	}
+
+	after, err := unix.SysctlUint32(preventMaterializationSysctl)
+	if err != nil {
+		t.Skipf("cannot read %s: %s", preventMaterializationSysctl, err)
+	}
+	if after != 1 {
+		t.Errorf("%s = %d, want 1", preventMaterializationSysctl, after)
+	}
+}

--- a/pkg/fs/dataless_other.go
+++ b/pkg/fs/dataless_other.go
@@ -1,0 +1,8 @@
+//go:build !darwin
+
+package fs
+
+// PreventDatalessMaterialization is a no-op on platforms other than macOS.
+func PreventDatalessMaterialization() error {
+	return nil
+}


### PR DESCRIPTION
On macOS, /usr/bin/du is orders of magnitude faster than gdu in the presence of dataless files. This PR fixes the issue by using the same approach as macOS's /usr/bin/du.

## Problem

On volumes backed by a File Provider extension (iCloud Drive, Google Drive, OneDrive, Dropbox), traversing a dataless directory makes the kernel ask the provider to materialize it. That triggers a synchronous round trip to the provider daemon and often a real download, which also pulls down data the user never asked for.

## Solution

/usr/bin/du solves this by setting the
vfs.nspace.prevent_materialization sysctl:
https://github.com/apple-oss-distributions/file_cmds/blob/659a8a301e2acf0343f8b8673a154a2ca4d07084/du/du.c#L323

But Apple does not guarantee binary compatibility at the syscall interface, only in the dynamically linked system libraries: https://developer.apple.com/library/archive/qa/qa1118/_index.html

Instead, we use setiopolicy_np, the API Apple documents for this in TN3150. It sets the same per-process kernel state as the sysctl: https://developer.apple.com/documentation/technotes/tn3150-getting-ready-for-data-less-files

The policy needs no privileges and is inert on volumes with no dataless files, so it is set unconditionally. Failure is logged, not fatal. On other platforms the call is a no-op.

The call goes through libSystem via purego rather than a raw syscall, because x/sys/unix has no binding for setiopolicy_np and gdu builds with CGO_ENABLED=0, so cgo is not an option. purego has no dependencies of its own, is not linked into non-darwin builds, and adds about 138 KB.