### PR TITLE
fix(cmd): stop truncating a --config-file path at the first space

### DIFF
--- a/cmd/gdu/main.go
+++ b/cmd/gdu/main.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
 	"runtime"
 	"strings"
 
@@ -174,13 +173,15 @@ func setDefaults() {
 }
 
 func setConfigFilePath() {
-	command := strings.Join(os.Args, " ")
-	if strings.Contains(command, "--config-file") {
-		re := regexp.MustCompile("--config-file[= ]([^ ]+)")
-		parts := re.FindStringSubmatch(command)
-
-		if len(parts) > 1 {
-			af.CfgFile = parts[1]
+	// Read the arguments one by one instead of joining them, so that paths
+	// containing spaces are not truncated.
+	for i, arg := range os.Args {
+		if value, found := strings.CutPrefix(arg, "--config-file="); found {
+			af.CfgFile = value
+			return
+		}
+		if arg == "--config-file" && i+1 < len(os.Args) {
+			af.CfgFile = os.Args[i+1]
 			return
 		}
 	}

--- a/cmd/gdu/main_test.go
+++ b/cmd/gdu/main_test.go
@@ -52,6 +52,38 @@ func TestInteractiveFlagCanBeSet(t *testing.T) {
 	}
 }
 
+func TestSetConfigFilePathWithSpaces(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "dir with spaces")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("could not create temp dir: %v", err)
+	}
+	path := filepath.Join(dir, "my config.yaml")
+
+	origArgs := os.Args
+	origErr := configErr
+	origAf := af
+	t.Cleanup(func() {
+		os.Args = origArgs
+		configErr = origErr
+		af = origAf
+	})
+
+	for _, args := range [][]string{
+		{"gdu", "--config-file=" + path},
+		{"gdu", "--config-file", path},
+	} {
+		af = &app.Flags{}
+		configErr = nil
+		os.Args = args
+
+		setConfigFilePath()
+
+		if af.CfgFile != path {
+			t.Errorf("expected config file path %q for args %v, got %q", path, args, af.CfgFile)
+		}
+	}
+}
+
 func TestInitConfigMalformedSystemConfig(t *testing.T) {
 	// Write invalid YAML to a temp file and point systemConfigPath at it.
 	tmp := filepath.Join(t.TempDir(), "gdu.yaml")


### PR DESCRIPTION
## What's broken

A `--config-file` path containing a space is truncated at the first space, so the config is silently ignored.

```
$ printf 'summarize: true\n' > "/tmp/gdu v/gdu.yaml"
$ gdu --config-file="/tmp/gdu v/gdu.yaml" -n -p /tmp/gscan
    4.0 KiB a.bin
        0 B /sub
```

`summarize: true` had no effect. With `--log-file -` the reason shows up:

```
Error reading config file: yaml: control characters are not allowed
```

`CfgFile` had become `/tmp/gdu`, which on that machine is the gdu binary itself, so YAML was being asked to parse an ELF file. Depending on what sits at the truncated path you get a parse error, a wrong config, or nothing at all.

After:

```
$ gdu --config-file="/tmp/gdu v/gdu.yaml" -n -p /tmp/gscan
    4.0 KiB gscan
```

## The fix

`setConfigFilePath` joined `os.Args` with spaces and then matched `--config-file[= ]([^ ]+)`, so `[^ ]+` stops at the first space in the path. The join is what loses the argument boundaries that the shell already established.

It now walks `os.Args` element by element, which handles both `--config-file=PATH` and `--config-file PATH`. The `regexp` import becomes unused and is dropped.

This runs before cobra parses flags, which is why the manual scan exists in the first place, so it stays a manual scan.

## Verification

`TestSetConfigFilePathWithSpaces` covers both spellings against a path with spaces in the directory name and the file name. With the change reverted it fails on both, reporting the truncated path. It saves and restores `os.Args`, `af` and `configErr`, and `cmd/gdu` has no parallel tests. `go test ./...` passes.
