### PR TITLE
fix(device): skip malformed mount lines instead of panicking

### DIFF
--- a/pkg/device/dev_linux.go
+++ b/pkg/device/dev_linux.go
@@ -56,6 +56,11 @@ func readMountsFile(file io.Reader) (mounts Devices, err error) {
 		line := scanner.Text()
 		parts := strings.Fields(line)
 
+		// skip malformed lines, a valid entry has at least device, mount point and fstype
+		if len(parts) < 3 {
+			continue
+		}
+
 		device := &Device{
 			Name:       parts[0],
 			MountPoint: unescapeString(parts[1]),

--- a/pkg/device/dev_linux_test.go
+++ b/pkg/device/dev_linux_test.go
@@ -58,6 +58,19 @@ host2:/dir2/ /mnt/dir2 nfs rw,relatime,vers=3,rsize=524288,wsize=524288,namlen=2
 	assert.Nil(t, err)
 }
 
+func TestMalformedMountsLinesAreSkipped(t *testing.T) {
+	mounts, err := readMountsFile(strings.NewReader(`
+/dev/nvme0n1p1
+/dev/nvme0n1p2 /boot
+/dev/nvme0n1p3 /home ext4 rw,relatime 0 0`))
+
+	assert.Nil(t, err)
+	assert.Len(t, mounts, 1)
+	assert.Equal(t, "/dev/nvme0n1p3", mounts[0].Name)
+	assert.Equal(t, "/home", mounts[0].MountPoint)
+	assert.Equal(t, "ext4", mounts[0].Fstype)
+}
+
 func TestMountsWithSpaces(t *testing.T) {
 	// nolint: lll // Why: Test data
 	mounts, _ := readMountsFile(strings.NewReader(`host1:/dir1/ /mnt/dir\040with\040spaces nfs4 rw,nosuid,nodev,noatime,nodiratime,vers=4.2,rsize=1048576,wsize=1048576,namlen=255,hard,proto=tcp,timeo=600,retrans=2,sec=sys,clientaddr=192.168.1.1,fsc,local_lock=none,addr=192.168.1.2 0 0


### PR DESCRIPTION
## What's broken

A short line in the mounts file panics the whole scan.

```
panic: runtime error: index out of range [1] with length 0
	github.com/dundee/gdu/v5/pkg/device.readMountsFile(...) dev_linux.go:61
```

`readMountsFile` splits each line with `strings.Fields` and then indexes `parts[0]`, `parts[1]` and `parts[2]` unconditionally. A blank line, or any line with fewer than three fields, is out of range.

`/proc/mounts` is normally well formed, but `MountsPath` is a field on `LinuxDevicesInfoGetter`, so it can point at a user supplied file, and a truncated read of `/proc/mounts` produces a short final line too. In every case the result is a panic rather than a skipped entry.

## The fix

Skip lines with fewer than three fields and keep scanning. Three is the minimum for a usable entry: device, mount point, fstype.

Skipping rather than erroring matches how the function already treats mounts it cannot use, like the `/snap/` skip in `processMounts`. Failing the whole scan because of one odd line would take gdu down entirely, which is worse than the line being missing.

## Verification

`TestMalformedMountsLinesAreSkipped` feeds a blank line, a one-field line and a two-field line alongside one valid entry, then asserts only the valid entry survives with its fields intact. With the guard removed it panics with the message above. `go test ./pkg/device/...` passes and `go build ./...` succeeds.
