### PR TITLE
feat: add key to copy highlighted item path to clipboard

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/dundee/gdu/v5
 go 1.25.0
 
 require (
+	github.com/atotto/clipboard v0.1.4
 	github.com/dgraph-io/badger/v4 v4.9.2
 	github.com/ebitengine/purego v0.10.2
 	github.com/fatih/color v1.19.0

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
+github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=

--- a/tui/clipboard.go
+++ b/tui/clipboard.go
@@ -1,0 +1,43 @@
+package tui
+
+import (
+	"strings"
+	"time"
+
+	"github.com/atotto/clipboard"
+
+	"github.com/dundee/gdu/v5/build"
+	"github.com/dundee/gdu/v5/pkg/fs"
+)
+
+// clipboardWriteAll is a package-level indirection over the clipboard writer so
+// tests can swap it out without touching a real system clipboard.
+var clipboardWriteAll = clipboard.WriteAll
+
+func (ui *UI) copySelectedPath() {
+	if ui.currentDir == nil {
+		return
+	}
+	row, column := ui.table.GetSelection()
+	selectedFile, ok := ui.table.GetCell(row, column).GetReference().(fs.Item)
+	if !ok {
+		return
+	}
+
+	path := strings.TrimPrefix(selectedFile.GetPath(), build.RootPathPrefix)
+	if err := clipboardWriteAll(path); err != nil {
+		ui.showErr("Error copying path to clipboard", err)
+		return
+	}
+
+	// brief confirmation in the header, restored after a moment like other actions
+	previousHeaderText := ui.header.GetText(false)
+	ui.header.SetText(" Path copied to clipboard")
+	go func() {
+		time.Sleep(2 * time.Second)
+		ui.app.QueueUpdateDraw(func() {
+			ui.header.Clear()
+			ui.header.SetText(previousHeaderText)
+		})
+	}()
+}

--- a/tui/keys.go
+++ b/tui/keys.go
@@ -485,6 +485,8 @@ func (ui *UI) handleMainActions(key *tcell.EventKey) *tcell.EventKey {
 		ui.openItem()
 	case 'i':
 		ui.showInfo()
+	case 'y':
+		ui.copySelectedPath()
 	case 'a', 'B', 'c', 'm':
 		ui.handleToggles(key)
 	case 'r':

--- a/tui/keys_test.go
+++ b/tui/keys_test.go
@@ -1724,3 +1724,69 @@ func TestPrintMarked(t *testing.T) {
 	ui.keyPressed(tcell.NewEventKey(tcell.KeyRune, 'q', 0))
 	assert.NotEmpty(t, buff.String())
 }
+
+func TestCopyPathToClipboard(t *testing.T) {
+	fin := testdir.CreateTestDir()
+	defer fin()
+	simScreen := testapp.CreateSimScreen()
+	defer simScreen.Fini()
+
+	app := testapp.CreateMockedApp(false)
+	ui := CreateUI(app, simScreen, &bytes.Buffer{}, true, true, false, false)
+
+	origWrite := clipboardWriteAll
+	defer func() { clipboardWriteAll = origWrite }()
+	var copied string
+	called := false
+	clipboardWriteAll = func(text string) error {
+		called = true
+		copied = text
+		return nil
+	}
+
+	ui.done = make(chan struct{})
+	assert.Nil(t, ui.AnalyzePath("test_dir", nil))
+	<-ui.done // wait for analyzer
+
+	for _, f := range ui.app.(*testapp.MockedApp).GetUpdateDraws() {
+		f()
+	}
+
+	ui.table.Select(0, 0)
+	row, column := ui.table.GetSelection()
+	selectedFile := ui.table.GetCell(row, column).GetReference().(fs.Item)
+
+	ui.keyPressed(tcell.NewEventKey(tcell.KeyRune, 'y', 0))
+
+	assert.True(t, called)
+	assert.Equal(t, selectedFile.GetPath(), copied)
+}
+
+func TestCopyPathToClipboardError(t *testing.T) {
+	fin := testdir.CreateTestDir()
+	defer fin()
+	simScreen := testapp.CreateSimScreen()
+	defer simScreen.Fini()
+
+	app := testapp.CreateMockedApp(false)
+	ui := CreateUI(app, simScreen, &bytes.Buffer{}, true, true, false, false)
+
+	origWrite := clipboardWriteAll
+	defer func() { clipboardWriteAll = origWrite }()
+	clipboardWriteAll = func(text string) error {
+		return errors.New("no clipboard here")
+	}
+
+	ui.done = make(chan struct{})
+	assert.Nil(t, ui.AnalyzePath("test_dir", nil))
+	<-ui.done // wait for analyzer
+
+	for _, f := range ui.app.(*testapp.MockedApp).GetUpdateDraws() {
+		f()
+	}
+
+	ui.table.Select(0, 0)
+	ui.keyPressed(tcell.NewEventKey(tcell.KeyRune, 'y', 0))
+
+	assert.True(t, ui.pages.HasPage("error"))
+}

--- a/tui/show.go
+++ b/tui/show.go
@@ -43,6 +43,7 @@ Item under cursor:
                [::b]v     [white:black:-]Show content of file
                [::b]o     [white:black:-]Open file or directory in external program
                [::b]i     [white:black:-]Show info about item
+               [::b]y     [white:black:-]Copy path of item under cursor to clipboard
 
 Sort by (twice toggles asc/desc):
                [::b]n     [white:black:-]Sort by name (asc/desc)

--- a/tui/tui_test.go
+++ b/tui/tui_test.go
@@ -164,7 +164,7 @@ func TestHelp(t *testing.T) {
 
 	b, _, _ := simScreen.GetContents()
 
-	cells := b[607 : 607+9]
+	cells := b[557 : 557+9]
 
 	text := []byte("directory")
 	for i, r := range cells {
@@ -185,7 +185,7 @@ func TestHelpBw(t *testing.T) {
 
 	b, _, _ := simScreen.GetContents()
 
-	cells := b[607 : 607+9]
+	cells := b[557 : 557+9]
 
 	text := []byte("directory")
 	for i, r := range cells {


### PR DESCRIPTION
Closes #614. Adds a keybinding to copy the path of the highlighted file or directory to the system clipboard, so you can grab a path in gdu and paste it into another command without retyping or quitting.

I went with `y` rather than the `cc` floated in the issue. `c` is already bound to toggling the item count, so a `cc` chord would collide with it, and gdu doesn't have any other multi-key bindings to model one on. `y` follows vim's yank convention and gdu already leans on vim keys (h/j/k/l, g/G), so it slots in without stepping on anything else. Happy to switch it if you'd prefer a different key.

It pulls in `github.com/atotto/clipboard` for the actual copy. Small, no cgo, and it just shells out to xclip/xsel/wl-copy on Linux and pbcopy on mac. The write goes through a package var (`clipboardWriteAll`) so tests can stub it.

Pressing `y` copies `selectedFile.GetPath()` and flashes "Path copied to clipboard" in the header for a couple seconds, matching the other transient messages. On failure it shows the usual error modal. The help modal gets a line for it. I left the README "basic actions" list alone since that's an intentionally minimal subset that already omits o/i/v/p.

Tests: `TestCopyPathToClipboard` stubs the writer, presses `y`, and checks the selected item's path is what got passed; `TestCopyPathToClipboardError` makes the writer fail and asserts the error modal shows. The two help-render tests read a fixed screen offset, and the extra help line shifts the vertically centered block up one row, so I moved 607 to 557 in both.

`go build ./...`, `go vet ./...`, gofmt and goimports are all clean and `go test ./tui/...` passes. I couldn't verify a real clipboard write because the env is headless with no X selection, so that path only runs through the stub.
