### PR TITLE
fix: panic exporting top files from archives or a persistent DB

### DIFF
--- a/report/export.go
+++ b/report/export.go
@@ -163,9 +163,18 @@ func (ui *UI) topDir(dir fs.Item) fs.Item {
 		topDir.BasePath = d.BasePath
 	}
 	for _, f := range files {
-		file := *f.(*analyze.File)
-		file.Parent = topDir
-		topDir.AddFile(&file)
+		// CollectTopFiles can return any fs.Item implementation (files stored in
+		// SQLite/BadgerDB, entries inside browsed archives, ...), so copy the
+		// attributes through the interface instead of type-asserting *analyze.File.
+		topDir.AddFile(&analyze.File{
+			Name:   f.GetName(),
+			Flag:   f.GetFlag(),
+			Size:   f.GetSize(),
+			Usage:  f.GetUsage(),
+			Mtime:  f.GetMtime(),
+			Mli:    f.GetMultiLinkedInode(),
+			Parent: topDir,
+		})
 	}
 	topDir.UpdateStats(make(fs.HardLinkedItems, 10))
 	return topDir

--- a/report/export.go
+++ b/report/export.go
@@ -175,9 +175,18 @@ func (ui *UI) topDir(dir fs.Item) fs.Item {
 		topDir.BasePath = d.BasePath
 	}
 	for _, f := range files {
-		file := *f.(*analyze.File)
-		file.Parent = topDir
-		topDir.AddFile(&file)
+		// CollectTopFiles can return any fs.Item implementation (files stored in
+		// SQLite/BadgerDB, entries inside browsed archives, ...), so copy the
+		// attributes through the interface instead of type-asserting *analyze.File.
+		topDir.AddFile(&analyze.File{
+			Name:   f.GetName(),
+			Flag:   f.GetFlag(),
+			Size:   f.GetSize(),
+			Usage:  f.GetUsage(),
+			Mtime:  f.GetMtime(),
+			Mli:    f.GetMultiLinkedInode(),
+			Parent: topDir,
+		})
 	}
 	topDir.UpdateStats(make(fs.HardLinkedItems, 10))
 	return topDir

--- a/report/export_test.go
+++ b/report/export_test.go
@@ -1,10 +1,12 @@
 package report
 
 import (
+	"archive/tar"
 	"bytes"
 	"errors"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -100,6 +102,35 @@ func TestAnalyzePathWithTopAndTypeFilter(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotContains(t, reportOutput.String(), `"name":"file"`)
 	assert.NotContains(t, reportOutput.String(), `"name":"file2"`)
+}
+
+func TestAnalyzePathWithTopAndArchiveBrowsing(t *testing.T) {
+	dir := t.TempDir()
+
+	archive, err := os.Create(filepath.Join(dir, "archive.tar"))
+	assert.Nil(t, err)
+	tw := tar.NewWriter(archive)
+	assert.Nil(t, tw.WriteHeader(&tar.Header{
+		Typeflag: tar.TypeReg, Name: "inside.txt", Size: 11, Mode: 0o644,
+	}))
+	_, err = tw.Write([]byte("hello world"))
+	assert.Nil(t, err)
+	assert.Nil(t, tw.Close())
+	assert.Nil(t, archive.Close())
+
+	var output, reportOutput bytes.Buffer
+
+	ui := CreateExportUI(&output, &reportOutput, false, false, false, 5, 0, false, nil)
+	ui.SetArchiveBrowsing(true)
+	ui.SetIgnoreDirPaths([]string{"/xxx"})
+
+	// Files inside an archive are not *analyze.File, so collecting the top
+	// items used to panic instead of exporting them.
+	assert.NotPanics(t, func() {
+		err = ui.AnalyzePath(dir, nil)
+	})
+	assert.Nil(t, err)
+	assert.Contains(t, reportOutput.String(), `"name":"inside.txt"`)
 }
 
 func TestAnalyzePathWithDepth(t *testing.T) {

--- a/report/export_test.go
+++ b/report/export_test.go
@@ -1,10 +1,12 @@
 package report
 
 import (
+	"archive/tar"
 	"bytes"
 	"errors"
 	"io"
 	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 
@@ -99,6 +101,35 @@ func TestAnalyzePathWithTopAndTypeFilter(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotContains(t, reportOutput.String(), `"name":"file"`)
 	assert.NotContains(t, reportOutput.String(), `"name":"file2"`)
+}
+
+func TestAnalyzePathWithTopAndArchiveBrowsing(t *testing.T) {
+	dir := t.TempDir()
+
+	archive, err := os.Create(filepath.Join(dir, "archive.tar"))
+	assert.Nil(t, err)
+	tw := tar.NewWriter(archive)
+	assert.Nil(t, tw.WriteHeader(&tar.Header{
+		Typeflag: tar.TypeReg, Name: "inside.txt", Size: 11, Mode: 0o644,
+	}))
+	_, err = tw.Write([]byte("hello world"))
+	assert.Nil(t, err)
+	assert.Nil(t, tw.Close())
+	assert.Nil(t, archive.Close())
+
+	var output, reportOutput bytes.Buffer
+
+	ui := CreateExportUI(&output, &reportOutput, false, false, false, 5, 0, false, nil)
+	ui.SetArchiveBrowsing(true)
+	ui.SetIgnoreDirPaths([]string{"/xxx"})
+
+	// Files inside an archive are not *analyze.File, so collecting the top
+	// items used to panic instead of exporting them.
+	assert.NotPanics(t, func() {
+		err = ui.AnalyzePath(dir, nil)
+	})
+	assert.Nil(t, err)
+	assert.Contains(t, reportOutput.String(), `"name":"inside.txt"`)
 }
 
 func TestAnalyzePathWithDepth(t *testing.T) {


### PR DESCRIPTION
`--top` panics whenever the scanned tree yields items that are not `*analyze.File`:

```
$ gdu -np -o - -t 3 --archive-browsing /tmp/test
panic: interface conversion: fs.Item is *analyze.TarFile, not *analyze.File
	report.(*UI).topDir(...) report/export.go:166

$ gdu -np -o out.json -t 3 -D /tmp/test.sqlite /tmp/test
panic: interface conversion: fs.Item is *analyze.SqliteItem, not *analyze.File
```

`topDir` type-asserts every item returned by `CollectTopFiles` to `*analyze.File`, but `fs.Item` has several implementations: archive entries when `--archive-browsing` is on, and `SqliteItem` when scanning with a persistent DB. So `-t` crashes with either flag.

The fix builds the copy from the `fs.Item` accessors instead of asserting the concrete type. Output is unchanged for the plain case, since the JSON export already represents these as ordinary file entries.

Verification, same command as above after the fix:

```
[1,2,{"progname":"gdu","progver":"development",...},
[{"name":"/tmp/test","asize":40000,...},
{"name":"x.bin","asize":20000,...}]]
exit=0
```

New regression test builds a real tar, scans it with archive browsing on, and asserts no panic plus the inner file in the output. `go test ./...` passes across all packages.

AI-assisted: written with Claude Code, reviewed and tested by me before sending.
