### PR TITLE
feat: add --trash-command option to move items to trash with an external tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Flags:
       --since string                  Include files with mtime >= WHEN. WHEN accepts RFC3339 timestamp (e.g., 2025-08-11T01:00:00-07:00) or date only YYYY-MM-DD (calendar-day compare; includes the whole day)
   -s, --summarize                     Show only a total in non-interactive mode
   -t, --top int                       Show only top X largest files in non-interactive mode
+      --trash-command string          Command used to move items to trash instead of the built-in XDG trash (the item path is appended, e.g. "trash-put" or "gio trash")
   -T, --type strings                  File types to include (e.g., --type yaml,json)
       --until string                  Include files with mtime <= WHEN. WHEN accepts RFC3339 timestamp or date only YYYY-MM-DD
   -v, --version                       Print version

--- a/cmd/gdu/app/app.go
+++ b/cmd/gdu/app/app.go
@@ -101,6 +101,7 @@ type Flags struct {
 	ChangeCwd          bool      `yaml:"change-cwd"`
 	DeleteInBackground bool      `yaml:"delete-in-background"`
 	DeleteInParallel   bool      `yaml:"delete-in-parallel"`
+	TrashCommand       string    `yaml:"trash-command"`
 	Since              string    `yaml:"since"`
 	Until              string    `yaml:"until"`
 	MaxAge             string    `yaml:"max-age"`
@@ -605,6 +606,11 @@ func (a *App) getOptions() []tui.Option {
 	if a.Flags.DeleteInParallel {
 		opts = append(opts, func(ui *tui.UI) {
 			ui.SetDeleteInParallel()
+		})
+	}
+	if a.Flags.TrashCommand != "" {
+		opts = append(opts, func(ui *tui.UI) {
+			ui.SetTrashCommand(strings.Fields(a.Flags.TrashCommand))
 		})
 	}
 	if a.Flags.BrowseParentDirs {

--- a/cmd/gdu/main.go
+++ b/cmd/gdu/main.go
@@ -102,6 +102,8 @@ func init() {
 	flags.BoolVar(&af.NoViewFile, "no-view-file", false, "Do not allow viewing file contents")
 	flags.BoolVar(&af.NoSpawnShell, "no-spawn-shell", false, "Do not allow spawning shell")
 	flags.BoolVar(&af.NoConfirmQuit, "no-confirm-quit", false, "Do not ask for confirmation before quitting after a long scan")
+	flags.StringVar(&af.TrashCommand, "trash-command", "",
+		"Command used to move items to trash instead of the built-in XDG trash (the item path is appended, e.g. \"trash-put\" or \"gio trash\")")
 	flags.BoolVar(&af.WriteConfig, "write-config", false, "Write current configuration to file (default is $HOME/.gdu.yaml)")
 	flags.StringVar(
 		&af.Since, "since", "",

--- a/configuration.md
+++ b/configuration.md
@@ -140,6 +140,10 @@ Delete items in the background, not blocking the UI from work
 
 Delete items in parallel, which might increase the speed of deletion
 
+#### `trash-command`
+
+Command used to move items to trash (with the `D` key) instead of the built-in XDG trash. The item path is appended as the last argument, so `trash-put` runs as `trash-put <path>`. This lets Gdu defer to a preferred trash tool and trash directory, for example `trash-put --trash-dir ~/.myTrash` or `gio trash`.
+
 #### `browse-parent-dirs`
 
 Allow navigating above the launch directory by pressing the left arrow key. When enabled, pressing left at the top-level directory will rescan and open its parent directory. Disabled by default.

--- a/gdu.1.md
+++ b/gdu.1.md
@@ -102,6 +102,8 @@ non-interactive mode
 
 **\--no-confirm-quit**\[=false\] Do not ask for confirmation before quitting after a long scan
 
+**\--trash-command**=\"\" Command used to move items to trash instead of the built-in XDG trash (the item path is appended, e.g. \"trash-put\" or \"gio trash\")
+
 **\--no-delete**\[=false\] Do not allow deletions
 
 **\--no-view-file**\[=false\] Do not allow viewing file contents

--- a/pkg/remove/trash_command.go
+++ b/pkg/remove/trash_command.go
@@ -1,0 +1,43 @@
+package remove
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/dundee/gdu/v5/pkg/fs"
+)
+
+// runTrashCommand runs the configured trash command. It is a package variable so
+// tests can stub out the external process.
+var runTrashCommand = func(name string, args ...string) ([]byte, error) {
+	return exec.Command(name, args...).CombinedOutput()
+}
+
+// TrashByCommand returns a trasher that hands the item to an external trash tool
+// instead of the built-in XDG trash. The command is given as the program name
+// plus optional arguments (for example "trash-put", or "gio" "trash") and the
+// item path is appended as the last argument. This lets gdu defer to a user's
+// preferred trash tool and trash directory, and makes "move to trash" work on
+// platforms where the built-in XDG trash does not apply.
+func TrashByCommand(command []string) func(fs.Item, fs.Item) error {
+	return func(dir, item fs.Item) error {
+		if len(command) == 0 {
+			return fmt.Errorf("no trash command configured")
+		}
+
+		args := make([]string, 0, len(command))
+		args = append(args, command[1:]...)
+		args = append(args, item.GetPath())
+
+		if out, err := runTrashCommand(command[0], args...); err != nil {
+			if msg := strings.TrimSpace(string(out)); msg != "" {
+				return fmt.Errorf("%w: %s", err, msg)
+			}
+			return err
+		}
+
+		dir.RemoveFile(item)
+		return nil
+	}
+}

--- a/pkg/remove/trash_command_test.go
+++ b/pkg/remove/trash_command_test.go
@@ -1,0 +1,97 @@
+package remove
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dundee/gdu/v5/pkg/analyze"
+	"github.com/dundee/gdu/v5/pkg/fs"
+)
+
+func mockTrashCommand(t *testing.T, run func(string, ...string) ([]byte, error)) {
+	t.Helper()
+	original := runTrashCommand
+	t.Cleanup(func() { runTrashCommand = original })
+	runTrashCommand = run
+}
+
+func sampleDir() (*analyze.Dir, *analyze.File) {
+	dir := &analyze.Dir{
+		File: &analyze.File{
+			Name:  "test_dir",
+			Size:  5,
+			Usage: 12,
+		},
+		ItemCount: 2,
+		BasePath:  ".",
+	}
+	file := &analyze.File{
+		Name:   "file2",
+		Size:   3,
+		Usage:  4,
+		Parent: dir,
+	}
+	dir.Files = fs.Files{file}
+	return dir, file
+}
+
+func TestTrashByCommand(t *testing.T) {
+	var gotName string
+	var gotArgs []string
+	mockTrashCommand(t, func(name string, args ...string) ([]byte, error) {
+		gotName = name
+		gotArgs = args
+		return nil, nil
+	})
+
+	dir, file := sampleDir()
+
+	trasher := TrashByCommand([]string{"trash-put", "--trash-dir", "/tmp/custom"})
+	err := trasher(dir, file)
+	require.NoError(t, err)
+
+	assert.Equal(t, "trash-put", gotName)
+	assert.Equal(t, []string{"--trash-dir", "/tmp/custom", file.GetPath()}, gotArgs)
+	assert.Equal(t, 0, len(dir.Files))
+	assert.Equal(t, int64(1), dir.ItemCount)
+}
+
+func TestTrashByCommandSingleWord(t *testing.T) {
+	var gotArgs []string
+	mockTrashCommand(t, func(name string, args ...string) ([]byte, error) {
+		gotArgs = args
+		return nil, nil
+	})
+
+	dir, file := sampleDir()
+
+	err := TrashByCommand([]string{"trash-put"})(dir, file)
+	require.NoError(t, err)
+	assert.Equal(t, []string{file.GetPath()}, gotArgs)
+}
+
+func TestTrashByCommandEmpty(t *testing.T) {
+	dir, file := sampleDir()
+
+	err := TrashByCommand(nil)(dir, file)
+	require.Error(t, err)
+	assert.Equal(t, 1, len(dir.Files))
+}
+
+func TestTrashByCommandError(t *testing.T) {
+	mockTrashCommand(t, func(name string, args ...string) ([]byte, error) {
+		return []byte("trash-put: cannot trash\n"), fmt.Errorf("exit status 1")
+	})
+
+	dir, file := sampleDir()
+
+	err := TrashByCommand([]string{"trash-put"})(dir, file)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exit status 1")
+	assert.Contains(t, err.Error(), "cannot trash")
+	// The item stays in the tree when the command fails.
+	assert.Equal(t, 1, len(dir.Files))
+}

--- a/tui/trash_command_test.go
+++ b/tui/trash_command_test.go
@@ -1,0 +1,39 @@
+package tui
+
+import (
+	"bytes"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dundee/gdu/v5/internal/testapp"
+	"github.com/dundee/gdu/v5/pkg/analyze"
+	"github.com/dundee/gdu/v5/pkg/fs"
+)
+
+func TestSetTrashCommand(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("relies on the unix 'true' command")
+	}
+
+	simScreen := testapp.CreateSimScreen()
+	defer simScreen.Fini()
+
+	app := testapp.CreateMockedApp(true)
+	ui := CreateUI(app, simScreen, &bytes.Buffer{}, false, false, false, false)
+
+	dir := &analyze.Dir{
+		File:      &analyze.File{Name: "test_dir"},
+		ItemCount: 2,
+		BasePath:  ".",
+	}
+	file := &analyze.File{Name: "file2", Parent: dir}
+	dir.Files = fs.Files{file}
+
+	ui.SetTrashCommand([]string{"true"})
+	err := ui.trasher(dir, file)
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(dir.Files))
+}

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -494,6 +494,13 @@ func (ui *UI) SetDeleteInBackground() {
 	go ui.updateStatusWorker()
 }
 
+// SetTrashCommand configures an external command used to move items to trash
+// instead of the built-in XDG trash. The item path is appended as the last
+// argument when the command runs.
+func (ui *UI) SetTrashCommand(command []string) {
+	ui.trasher = remove.TrashByCommand(command)
+}
+
 func (ui *UI) resetSorting() {
 	ui.sortBy = ui.defaultSortBy
 	ui.sortOrder = ui.defaultSortOrder


### PR DESCRIPTION
Closes #640.

Adds a `--trash-command` option (and a `trash-command` config key) so the `D` key hands items to an external trash tool instead of the built-in XDG trash. The item path is appended as the last argument, so you can point it at trash-put with a custom trash dir, or use gio trash, macos-trash, and so on:

```
gdu --trash-command "trash-put --trash-dir ~/.myTrash"
```

Without the option the built-in XDG trash behaviour is unchanged. As a nice side effect this also makes "move to trash" usable on macOS, where the built-in path doesn't apply and people usually `brew install trash`.

Added tests for the new trasher and updated the README, man page source and configuration docs.
