### PR TITLE
feat: copy path of selected item to clipboard

### DIFF
--- a/tui/actions.go
+++ b/tui/actions.go
@@ -373,9 +373,9 @@ func (ui *UI) openItem() {
 	openBinary := "xdg-open"
 
 	switch runtime.GOOS {
-	case "darwin":
+	case osDarwin:
 		openBinary = "open"
-	case "windows":
+	case osWindows:
 		openBinary = "explorer"
 	}
 

--- a/tui/clipboard.go
+++ b/tui/clipboard.go
@@ -1,0 +1,116 @@
+package tui
+
+import (
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/dundee/gdu/v5/pkg/fs"
+)
+
+// messageTimeout is how long a transient status message stays in the header.
+const messageTimeout = 2 * time.Second
+
+// Operating system identifiers as reported by runtime.GOOS.
+const (
+	osDarwin  = "darwin"
+	osWindows = "windows"
+	osLinux   = "linux"
+)
+
+var errClipboardUnavailable = errors.New("no clipboard tool found")
+
+// clipboardCommand returns the command and arguments used to write text to the
+// system clipboard for the given operating system. lookPath reports which tools
+// are installed and wayland selects the preferred Linux/BSD tool ordering. The
+// returned bool is false when no supported tool is available, for example on a
+// headless machine.
+func clipboardCommand(
+	goos string,
+	wayland bool,
+	lookPath func(string) (string, error),
+) ([]string, bool) {
+	type candidate struct {
+		name string
+		args []string
+	}
+
+	var candidates []candidate
+	switch goos {
+	case osDarwin:
+		candidates = []candidate{{name: "pbcopy"}}
+	case osWindows:
+		candidates = []candidate{{name: "clip"}}
+	default:
+		xclip := candidate{name: "xclip", args: []string{"-selection", "clipboard"}}
+		xsel := candidate{name: "xsel", args: []string{"--clipboard", "--input"}}
+		wlCopy := candidate{name: "wl-copy"}
+		if wayland {
+			candidates = []candidate{wlCopy, xclip, xsel}
+		} else {
+			candidates = []candidate{xclip, xsel, wlCopy}
+		}
+	}
+
+	for _, c := range candidates {
+		if path, err := lookPath(c.name); err == nil {
+			return append([]string{path}, c.args...), true
+		}
+	}
+	return nil, false
+}
+
+func copyToClipboard(text string) error {
+	argv, ok := clipboardCommand(runtime.GOOS, os.Getenv("WAYLAND_DISPLAY") != "", exec.LookPath)
+	if !ok {
+		return errClipboardUnavailable
+	}
+
+	cmd := exec.Command(argv[0], argv[1:]...)
+	cmd.Stdin = strings.NewReader(text)
+	if err := cmd.Run(); err != nil {
+		return errors.Wrap(err, "running clipboard command")
+	}
+	return nil
+}
+
+// copySelectedPath copies the path of the item under the cursor to the system
+// clipboard.
+func (ui *UI) copySelectedPath() {
+	if ui.currentDir == nil {
+		return
+	}
+
+	row, column := ui.table.GetSelection()
+	cell := ui.table.GetCell(row, column)
+	if cell == nil || cell.GetReference() == nil {
+		return
+	}
+	selectedItem := cell.GetReference().(fs.Item)
+
+	if err := copyToClipboard(selectedItem.GetPath()); err != nil {
+		ui.showErr("Can't copy path to clipboard", err)
+		return
+	}
+
+	ui.showMessage(" Path copied to clipboard")
+}
+
+// showMessage briefly replaces the header text with a status message and
+// restores the previous text afterwards.
+func (ui *UI) showMessage(message string) {
+	previousText := ui.header.GetText(false)
+	ui.header.SetText(message)
+
+	go func() {
+		time.Sleep(messageTimeout)
+		ui.app.QueueUpdateDraw(func() {
+			ui.header.Clear()
+			ui.header.SetText(previousText)
+		})
+	}()
+}

--- a/tui/clipboard.go
+++ b/tui/clipboard.go
@@ -5,59 +5,74 @@ import (
 	"os/exec"
 	"runtime"
 	"strings"
-	"time"
 
 	"github.com/pkg/errors"
 
 	"github.com/dundee/gdu/v5/pkg/fs"
 )
 
-// messageTimeout is how long a transient status message stays in the header.
-const messageTimeout = 2 * time.Second
-
 // Operating system identifiers as reported by runtime.GOOS.
 const (
 	osDarwin  = "darwin"
 	osWindows = "windows"
-	osLinux   = "linux"
 )
 
 var errClipboardUnavailable = errors.New("no clipboard tool found")
 
-// clipboardCommand returns the command and arguments used to write text to the
-// system clipboard for the given operating system. lookPath reports which tools
-// are installed and wayland selects the preferred Linux/BSD tool ordering. The
-// returned bool is false when no supported tool is available, for example on a
-// headless machine.
-func clipboardCommand(
-	goos string,
-	wayland bool,
-	lookPath func(string) (string, error),
-) ([]string, bool) {
-	type candidate struct {
-		name string
-		args []string
-	}
+// clipboardTool is an external program able to write the clipboard, together
+// with the arguments it needs to target the clipboard selection.
+type clipboardTool struct {
+	name string
+	args []string
+}
 
-	var candidates []candidate
-	switch goos {
+var (
+	pbcopy = clipboardTool{name: "pbcopy"}
+	clip   = clipboardTool{name: "clip"}
+	xclip  = clipboardTool{name: "xclip", args: []string{"-selection", "clipboard"}}
+	xsel   = clipboardTool{name: "xsel", args: []string{"--clipboard", "--input"}}
+	wlCopy = clipboardTool{name: "wl-copy"}
+)
+
+// clipboardEnv is the part of the environment that decides which clipboard tool
+// gdu uses. It exists so the choice can be tested without a real desktop
+// session: lookPath reports which tools are installed, and wayland selects the
+// preferred Linux/BSD tool ordering.
+type clipboardEnv struct {
+	goos     string
+	wayland  bool
+	lookPath func(string) (string, error)
+}
+
+// currentClipboardEnv describes the environment gdu is actually running in.
+func currentClipboardEnv() clipboardEnv {
+	return clipboardEnv{
+		goos:     runtime.GOOS,
+		wayland:  os.Getenv("WAYLAND_DISPLAY") != "",
+		lookPath: exec.LookPath,
+	}
+}
+
+// command returns the command and arguments used to write text to the system
+// clipboard in this environment. The returned bool is false when no supported
+// tool is available, for example on a headless machine.
+func (env clipboardEnv) command() ([]string, bool) {
+	var candidates []clipboardTool
+	switch env.goos {
 	case osDarwin:
-		candidates = []candidate{{name: "pbcopy"}}
+		candidates = []clipboardTool{pbcopy}
 	case osWindows:
-		candidates = []candidate{{name: "clip"}}
+		candidates = []clipboardTool{clip}
 	default:
-		xclip := candidate{name: "xclip", args: []string{"-selection", "clipboard"}}
-		xsel := candidate{name: "xsel", args: []string{"--clipboard", "--input"}}
-		wlCopy := candidate{name: "wl-copy"}
-		if wayland {
-			candidates = []candidate{wlCopy, xclip, xsel}
+		if env.wayland {
+			candidates = []clipboardTool{wlCopy, xclip, xsel}
 		} else {
-			candidates = []candidate{xclip, xsel, wlCopy}
+			candidates = []clipboardTool{xclip, xsel, wlCopy}
 		}
 	}
 
 	for _, c := range candidates {
-		if path, err := lookPath(c.name); err == nil {
+		if path, err := env.lookPath(c.name); err == nil {
 			return append([]string{path}, c.args...), true
 		}
 	}
@@ -65,7 +80,7 @@ func clipboardCommand(
 }
 
 func copyToClipboard(text string) error {
-	argv, ok := clipboardCommand(runtime.GOOS, os.Getenv("WAYLAND_DISPLAY") != "", exec.LookPath)
+	argv, ok := currentClipboardEnv().command()
 	if !ok {
 		return errClipboardUnavailable
 	}
@@ -98,19 +113,4 @@ func (ui *UI) copySelectedPath() {
 	}
 
 	ui.showMessage(" Path copied to clipboard")
-}
-
-// showMessage briefly replaces the header text with a status message and
-// restores the previous text afterwards.
-func (ui *UI) showMessage(message string) {
-	previousText := ui.header.GetText(false)
-	ui.header.SetText(message)
-
-	go func() {
-		time.Sleep(messageTimeout)
-		ui.app.QueueUpdateDraw(func() {
-			ui.header.Clear()
-			ui.header.SetText(previousText)
-		})
-	}()
 }

--- a/tui/clipboard_test.go
+++ b/tui/clipboard_test.go
@@ -1,0 +1,113 @@
+package tui
+
+import (
+	"bytes"
+	"errors"
+	"os/exec"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dundee/gdu/v5/internal/testapp"
+)
+
+func lookPathFor(names ...string) func(string) (string, error) {
+	available := make(map[string]bool, len(names))
+	for _, name := range names {
+		available[name] = true
+	}
+	return func(name string) (string, error) {
+		if available[name] {
+			return "/usr/bin/" + name, nil
+		}
+		return "", errors.New("executable not found")
+	}
+}
+
+func TestClipboardCommand(t *testing.T) {
+	for name, tt := range map[string]struct {
+		goos     string
+		wayland  bool
+		lookPath func(string) (string, error)
+		want     []string
+		wantOK   bool
+	}{
+		"darwin uses pbcopy": {
+			goos: osDarwin, lookPath: lookPathFor("pbcopy"),
+			want: []string{"/usr/bin/pbcopy"}, wantOK: true,
+		},
+		"windows uses clip": {
+			goos: osWindows, lookPath: lookPathFor("clip"),
+			want: []string{"/usr/bin/clip"}, wantOK: true,
+		},
+		"linux uses xclip": {
+			goos: osLinux, lookPath: lookPathFor("xclip", "xsel"),
+			want: []string{"/usr/bin/xclip", "-selection", "clipboard"}, wantOK: true,
+		},
+		"linux falls back to xsel": {
+			goos: osLinux, lookPath: lookPathFor("xsel"),
+			want: []string{"/usr/bin/xsel", "--clipboard", "--input"}, wantOK: true,
+		},
+		"wayland session prefers wl-copy": {
+			goos: osLinux, wayland: true, lookPath: lookPathFor("wl-copy", "xclip"),
+			want: []string{"/usr/bin/wl-copy"}, wantOK: true,
+		},
+		"without wayland session prefers xclip over wl-copy": {
+			goos: osLinux, wayland: false, lookPath: lookPathFor("wl-copy", "xclip"),
+			want: []string{"/usr/bin/xclip", "-selection", "clipboard"}, wantOK: true,
+		},
+		"falls back to wl-copy when only tool": {
+			goos: osLinux, wayland: false, lookPath: lookPathFor("wl-copy"),
+			want: []string{"/usr/bin/wl-copy"}, wantOK: true,
+		},
+		"no tool available": {
+			goos: osLinux, lookPath: lookPathFor(),
+			want: nil, wantOK: false,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			got, ok := clipboardCommand(tt.goos, tt.wayland, tt.lookPath)
+			assert.Equal(t, tt.wantOK, ok)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestCopyToClipboardRoundTrip(t *testing.T) {
+	if runtime.GOOS != osDarwin {
+		t.Skip("clipboard round-trip is only verified with pbcopy/pbpaste on darwin")
+	}
+	if _, err := exec.LookPath("pbcopy"); err != nil {
+		t.Skip("pbcopy not available")
+	}
+
+	// Preserve and restore whatever the user already had on the clipboard.
+	before, _ := exec.Command("pbpaste").Output()
+	t.Cleanup(func() {
+		restore := exec.Command("pbcopy")
+		restore.Stdin = bytes.NewReader(before)
+		_ = restore.Run()
+	})
+
+	const path = "/tmp/gdu clipboard test/some file"
+	if err := copyToClipboard(path); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := exec.Command("pbpaste").Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, path, string(out))
+}
+
+func TestCopySelectedPathWithoutCurrentDir(t *testing.T) {
+	app, simScreen := testapp.CreateTestAppWithSimScreen(50, 50)
+	defer simScreen.Fini()
+
+	ui := CreateUI(app, simScreen, &bytes.Buffer{}, true, true, false, false)
+
+	// No directory analyzed yet: copying must be a safe no-op.
+	assert.NotPanics(t, ui.copySelectedPath)
+}

--- a/tui/clipboard_test.go
+++ b/tui/clipboard_test.go
@@ -27,47 +27,49 @@ func lookPathFor(names ...string) func(string) (string, error) {
 
 func TestClipboardCommand(t *testing.T) {
 	for name, tt := range map[string]struct {
-		goos     string
-		wayland  bool
-		lookPath func(string) (string, error)
-		want     []string
-		wantOK   bool
+		env    clipboardEnv
+		want   []string
+		wantOK bool
 	}{
 		"darwin uses pbcopy": {
-			goos: osDarwin, lookPath: lookPathFor("pbcopy"),
+			env:  clipboardEnv{goos: osDarwin, lookPath: lookPathFor("pbcopy")},
 			want: []string{"/usr/bin/pbcopy"}, wantOK: true,
 		},
 		"windows uses clip": {
-			goos: osWindows, lookPath: lookPathFor("clip"),
+			env:  clipboardEnv{goos: osWindows, lookPath: lookPathFor("clip")},
 			want: []string{"/usr/bin/clip"}, wantOK: true,
 		},
 		"linux uses xclip": {
-			goos: osLinux, lookPath: lookPathFor("xclip", "xsel"),
+			env:  clipboardEnv{goos: "linux", lookPath: lookPathFor("xclip", "xsel")},
 			want: []string{"/usr/bin/xclip", "-selection", "clipboard"}, wantOK: true,
 		},
 		"linux falls back to xsel": {
-			goos: osLinux, lookPath: lookPathFor("xsel"),
+			env:  clipboardEnv{goos: "linux", lookPath: lookPathFor("xsel")},
 			want: []string{"/usr/bin/xsel", "--clipboard", "--input"}, wantOK: true,
 		},
+		"freebsd uses the same tools as linux": {
+			env:  clipboardEnv{goos: "freebsd", lookPath: lookPathFor("xclip")},
+			want: []string{"/usr/bin/xclip", "-selection", "clipboard"}, wantOK: true,
+		},
 		"wayland session prefers wl-copy": {
-			goos: osLinux, wayland: true, lookPath: lookPathFor("wl-copy", "xclip"),
+			env:  clipboardEnv{goos: "linux", wayland: true, lookPath: lookPathFor("wl-copy", "xclip")},
 			want: []string{"/usr/bin/wl-copy"}, wantOK: true,
 		},
 		"without wayland session prefers xclip over wl-copy": {
-			goos: osLinux, wayland: false, lookPath: lookPathFor("wl-copy", "xclip"),
+			env:  clipboardEnv{goos: "linux", wayland: false, lookPath: lookPathFor("wl-copy", "xclip")},
 			want: []string{"/usr/bin/xclip", "-selection", "clipboard"}, wantOK: true,
 		},
 		"falls back to wl-copy when only tool": {
-			goos: osLinux, wayland: false, lookPath: lookPathFor("wl-copy"),
+			env:  clipboardEnv{goos: "linux", wayland: false, lookPath: lookPathFor("wl-copy")},
 			want: []string{"/usr/bin/wl-copy"}, wantOK: true,
 		},
 		"no tool available": {
-			goos: osLinux, lookPath: lookPathFor(),
+			env:  clipboardEnv{goos: "linux", lookPath: lookPathFor()},
 			want: nil, wantOK: false,
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			got, ok := clipboardCommand(tt.goos, tt.wayland, tt.lookPath)
+			got, ok := tt.env.command()
 			assert.Equal(t, tt.wantOK, ok)
 			assert.Equal(t, tt.want, got)
 		})

--- a/tui/keys.go
+++ b/tui/keys.go
@@ -373,19 +373,7 @@ func (ui *UI) handleShell(key *tcell.EventKey) *tcell.EventKey {
 			return nil
 		}
 		if ui.noSpawnShell {
-			previousHeaderText := ui.header.GetText(false)
-
-			// show feedback to user
-			ui.header.SetText(" Shell spawning is disabled!")
-
-			go func() {
-				time.Sleep(2 * time.Second)
-				ui.app.QueueUpdateDraw(func() {
-					ui.header.Clear()
-					ui.header.SetText(previousHeaderText)
-				})
-			}()
-
+			ui.showMessage(" Shell spawning is disabled!")
 			return nil
 		}
 		ui.spawnShell()
@@ -451,35 +439,13 @@ func (ui *UI) handleMainActions(key *tcell.EventKey) *tcell.EventKey {
 			return nil
 		}
 		if ui.noViewFile {
-			previousHeaderText := ui.header.GetText(false)
-
-			ui.header.SetText(" Viewing files is disabled!")
-
-			go func() {
-				time.Sleep(2 * time.Second)
-				ui.app.QueueUpdateDraw(func() {
-					ui.header.Clear()
-					ui.header.SetText(previousHeaderText)
-				})
-			}()
-
+			ui.showMessage(" Viewing files is disabled!")
 			return nil
 		}
 		ui.showFile()
 	case 'o':
 		if ui.noSpawnShell {
-			previousHeaderText := ui.header.GetText(false)
-
-			// show feedback to user
-			ui.header.SetText(" Opening items is disabled!")
-
-			go func() {
-				time.Sleep(2 * time.Second)
-				ui.app.QueueUpdateDraw(func() {
-					ui.header.Clear()
-					ui.header.SetText(previousHeaderText)
-				})
-			}()
+			ui.showMessage(" Opening items is disabled!")
 			return nil
 		}
 		ui.openItem()

--- a/tui/keys.go
+++ b/tui/keys.go
@@ -507,6 +507,9 @@ func (ui *UI) handleMainActions(key *tcell.EventKey) *tcell.EventKey {
 	case 'p':
 		ui.printMarked()
 		return nil
+	case 'y':
+		ui.copySelectedPath()
+		return nil
 	case 'I':
 		ui.ignoreItem()
 	}

--- a/tui/mouse.go
+++ b/tui/mouse.go
@@ -1,8 +1,6 @@
 package tui
 
 import (
-	"time"
-
 	"github.com/dundee/gdu/v5/pkg/fs"
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
@@ -34,18 +32,7 @@ func (ui *UI) onMouse(event *tcell.EventMouse, action tview.MouseAction) (*tcell
 				ui.handleRight()
 			} else {
 				if ui.noViewFile {
-					previousHeaderText := ui.header.GetText(false)
-
-					ui.header.SetText(" Viewing files is disabled!")
-
-					go func() {
-						time.Sleep(2 * time.Second)
-						ui.app.QueueUpdateDraw(func() {
-							ui.header.Clear()
-							ui.header.SetText(previousHeaderText)
-						})
-					}()
-
+					ui.showMessage(" Viewing files is disabled!")
 					return nil, action
 				}
 				ui.showFile()

--- a/tui/show.go
+++ b/tui/show.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
@@ -347,6 +348,24 @@ func (ui *UI) showErrFromGo(msg string, err error) {
 	ui.app.QueueUpdateDraw(func() {
 		ui.showErr(msg, err)
 	})
+}
+
+// messageTimeout is how long a transient status message stays in the header.
+const messageTimeout = 2 * time.Second
+
+// showMessage briefly replaces the header text with a status message and
+// restores the previous text afterwards.
+func (ui *UI) showMessage(message string) {
+	previousText := ui.header.GetText(false)
+	ui.header.SetText(message)
+
+	go func() {
+		time.Sleep(messageTimeout)
+		ui.app.QueueUpdateDraw(func() {
+			ui.header.Clear()
+			ui.header.SetText(previousText)
+		})
+	}()
 }
 
 func (ui *UI) showHelp() {

--- a/tui/show.go
+++ b/tui/show.go
@@ -39,6 +39,7 @@ Item under cursor:
                [::b]D     [white:black:-]Move file or directory to trash
 			   [::b]space [white:black:-]Mark file or directory for deletion
 			   [::b]p     [white:black:-]Print marked items paths to stdout after quitting
+			   [::b]y     [white:black:-]Copy path of file or directory to clipboard
 			   [::b]I     [white:black:-]Ignore file or directory
                [::b]v     [white:black:-]Show content of file
                [::b]o     [white:black:-]Open file or directory in external program

--- a/tui/show_test.go
+++ b/tui/show_test.go
@@ -23,6 +23,17 @@ func TestHelpMoveToTrash(t *testing.T) {
 	assert.False(t, strings.Contains(helpText, "Move file or directory to trash (disabled)"))
 }
 
+func TestHelpListsCopyPath(t *testing.T) {
+	app, simScreen := testapp.CreateTestAppWithSimScreen(50, 50)
+	defer simScreen.Fini()
+
+	ui := CreateUI(app, simScreen, &bytes.Buffer{}, true, true, false, false)
+
+	helpText := ui.formatHelpTextFor()
+
+	assert.True(t, strings.Contains(helpText, "Copy path of file or directory to clipboard"))
+}
+
 func TestHelpNoSpawnShell(t *testing.T) {
 	app, simScreen := testapp.CreateTestAppWithSimScreen(50, 50)
 	defer simScreen.Fini()

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -596,19 +596,7 @@ func (ui *UI) deviceItemSelected(row, column int) {
 
 func (ui *UI) confirmDeletion(action DeleteAction) {
 	if ui.noDelete {
-		previousHeaderText := ui.header.GetText(false)
-
-		// show feedback to user
-		ui.header.SetText(" Deletion is disabled!")
-
-		go func() {
-			time.Sleep(2 * time.Second)
-			ui.app.QueueUpdateDraw(func() {
-				ui.header.Clear()
-				ui.header.SetText(previousHeaderText)
-			})
-		}()
-
+		ui.showMessage(" Deletion is disabled!")
 		return
 	}
 


### PR DESCRIPTION
Closes #614.

Adds a `y` (yank) keybind that copies the path of the item under the cursor to the system clipboard, so a path can be reused in another terminal without retyping it, using the mouse, or quitting via `p`/`Q`.

### Behaviour

- `y` copies `selectedItem.GetPath()` (the same absolute path `p` prints) and shows a brief "Path copied to clipboard" confirmation in the header.
- No-op when nothing is analysed yet.

### Implementation

- No new dependency. The clipboard is written by shelling out to the platform tool: `pbcopy` (macOS), `clip` (Windows), and `wl-copy`/`xclip`/`xsel` (Linux and BSD), preferring `wl-copy` under a Wayland session (`WAYLAND_DISPLAY`) and otherwise falling back by availability.
- When no clipboard tool is found (for example a headless machine or CI) the action shows an error rather than failing silently.
- `clipboardCommand` is a small pure function of `(goos, wayland, lookPath)`, so tool selection is unit-tested for every platform without depending on the host.

### Tests

- `TestClipboardCommand`: tool/argument selection for macOS, Windows, Linux X11 (xclip, with xsel fallback), the Wayland preference, and the no-tool case.
- `TestCopyToClipboardRoundTrip`: macOS-only, writes and reads back through `pbcopy`/`pbpaste`, preserving and restoring the existing clipboard.
- `TestCopySelectedPathWithoutCurrentDir` and a help-text assertion.

`go test ./...`, `go vet`, and `golangci-lint` (v2.11.2) all pass.

This supersedes #629, which was closed by its author; this version adds no clipboard dependency and degrades gracefully when no clipboard tool is present.
