### PR TITLE
fix(report): prevent export progress from wrapping

### DIFF
--- a/report/export.go
+++ b/report/export.go
@@ -19,6 +19,8 @@ import (
 	"github.com/fatih/color"
 )
 
+const clearTerminalLine = "\r\x1b[2K"
+
 // UI struct
 type UI struct {
 	*common.UI
@@ -273,27 +275,22 @@ func (ui *UI) exportDir(dir fs.Item, waitWritten *sync.WaitGroup) error {
 func (ui *UI) updateProgress() {
 	waitingForWrite := false
 
-	emptyRow := "\r"
-	for j := 0; j < 100; j++ {
-		emptyRow += " "
-	}
-
 	progressRunes := []rune(`⠇⠏⠋⠙⠹⠸⠼⠴⠦⠧`)
 
 	doneChan := ui.Analyzer.GetDone()
 
 	i := 0
 	for {
-		fmt.Fprint(ui.output, emptyRow)
+		fmt.Fprint(ui.output, clearTerminalLine)
 
 		progress := ui.Analyzer.GetProgress()
 
 		select {
 		case <-doneChan:
-			fmt.Fprint(ui.output, "\r")
+			fmt.Fprint(ui.output, clearTerminalLine)
 			waitingForWrite = true
 		case <-ui.writtenChan:
-			fmt.Fprint(ui.output, "\r")
+			fmt.Fprint(ui.output, clearTerminalLine)
 			return
 		default:
 		}

--- a/report/export_test.go
+++ b/report/export_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"os"
+	"strings"
 	"sync"
 	"testing"
 
@@ -321,6 +322,23 @@ func TestAnalyzePathWithProgress(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Contains(t, reportOutput.String(), `"name":"nested"`)
+}
+
+func TestExportProgressClearsLineWithoutPadding(t *testing.T) {
+	var output bytes.Buffer
+	ui := CreateExportUI(&output, io.Discard, false, true, false, 0, 0, false, nil)
+
+	written := make(chan struct{})
+	go func() {
+		ui.writtenChan <- struct{}{}
+		close(written)
+	}()
+
+	ui.updateProgress()
+	<-written
+
+	assert.Contains(t, output.String(), "\x1b[2K")
+	assert.NotContains(t, output.String(), strings.Repeat(" ", 100))
 }
 
 func TestShowDevices(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes #580.

Export progress cleared the terminal row by writing 100 spaces. On narrower
terminals, each refresh wrapped and left blank lines behind; use the terminal
erase-line sequence so progress stays on one row regardless of terminal width.

## Changes

- Replace fixed-width export progress padding with terminal line erasure.
- Add regression coverage that rejects the wrapping 100-space clear.

## Testing

- `go test ./report -run TestExportProgressClearsLineWithoutPadding -count=1`
- `go test ./report -count=1`
- `go test ./...`
- `PATH=/tmp/gdu-tools:$PATH make lint`