### PR TITLE
ci: build Windows ARM64 release binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ build-all:
 
 	CGO_ENABLED=0 gox \
 		-os="windows" \
-		-arch="amd64" \
+		-arch="amd64 arm64" \
 		-output="dist/gdu_{{.OS}}_{{.Arch}}" \
 		-ldflags="$(LDFLAGS)" \
 		$(PACKAGE)/$(CMD_GDU)


### PR DESCRIPTION
## Summary

Build a Windows ARM64 executable in the `build-all` target alongside the existing Windows AMD64 binary.

## Validation

The binary compiled successfully on GitHub's native `windows-11-arm` runner: [Windows ARM64 smoke](https://github.com/meop/gdu/actions/runs/33240626102).

The fork-only smoke workflow used for that validation is not included in this PR.
