### PR TITLE
feat: add --trash-command option

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Flags:
       --since string                  Include files with mtime >= WHEN. WHEN accepts RFC3339 timestamp (e.g., 2025-08-11T01:00:00-07:00) or date only YYYY-MM-DD (calendar-day compare; includes the whole day)
   -s, --summarize                     Show only a total in non-interactive mode
   -t, --top int                       Show only top X largest files in non-interactive mode
+      --trash-command string          Command used to move items to trash instead of the built-in trash (e.g. 'trash-put --trash-dir ~/mytrash')
   -T, --type strings                  File types to include (e.g., --type yaml,json)
       --until string                  Include files with mtime <= WHEN. WHEN accepts RFC3339 timestamp or date only YYYY-MM-DD
   -v, --version                       Print version
@@ -101,6 +102,7 @@ Basic list of actions in interactive mode (show help modal for more):
   → or Enter or l                     Go to highlighted directory
   ← or h                              Go to parent directory
   d                                   Delete the selected file or directory
+  D                                   Move the selected file or directory to trash
   e                                   Empty the selected directory
   n                                   Sort by name
   s                                   Sort by size
@@ -114,6 +116,8 @@ Basic list of actions in interactive mode (show help modal for more):
     gdu -a                                # show apparent size instead of disk usage
     gdu --no-delete                       # prevent write operations
     gdu --no-view-file                    # prevent viewing file contents
+    gdu --trash-command 'trash-put --trash-dir ~/mytrash'   # use own trash command for the D key
+    gdu --trash-command 'mv -f "$1" ~/mytrash/'             # trash by moving items with mv
     gdu <some_dir_to_analyze>             # analyze given dir
     gdu -d                                # show all mounted disks
     gdu -l ./gdu.log <some_dir>           # write errors to log file

--- a/cmd/gdu/app/app.go
+++ b/cmd/gdu/app/app.go
@@ -101,6 +101,7 @@ type Flags struct {
 	ChangeCwd          bool      `yaml:"change-cwd"`
 	DeleteInBackground bool      `yaml:"delete-in-background"`
 	DeleteInParallel   bool      `yaml:"delete-in-parallel"`
+	TrashCommand       string    `yaml:"trash-command"`
 	Since              string    `yaml:"since"`
 	Until              string    `yaml:"until"`
 	MaxAge             string    `yaml:"max-age"`
@@ -613,6 +614,11 @@ func (a *App) getOptions() []tui.Option {
 	if a.Flags.DeleteInParallel {
 		opts = append(opts, func(ui *tui.UI) {
 			ui.SetDeleteInParallel()
+		})
+	}
+	if a.Flags.TrashCommand != "" {
+		opts = append(opts, func(ui *tui.UI) {
+			ui.SetTrashCommand(a.Flags.TrashCommand)
 		})
 	}
 	if a.Flags.BrowseParentDirs {

--- a/cmd/gdu/app/app_test.go
+++ b/cmd/gdu/app/app_test.go
@@ -320,6 +320,21 @@ func TestGuiDeleteInParallel(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+func TestGuiTrashCommand(t *testing.T) {
+	fin := testdir.CreateTestDir()
+	defer fin()
+
+	out, err := runApp(
+		&Flags{LogFile: "/dev/null", TrashCommand: "trash-put"},
+		[]string{"test_dir"},
+		true,
+		testdev.DevicesInfoGetterMock{},
+	)
+
+	assert.Empty(t, out)
+	assert.Nil(t, err)
+}
+
 func TestAnalyzePathWithGuiBackgroundDeletion(t *testing.T) {
 	fin := testdir.CreateTestDir()
 	defer fin()

--- a/cmd/gdu/main.go
+++ b/cmd/gdu/main.go
@@ -102,6 +102,8 @@ func init() {
 	flags.BoolVar(&af.NoViewFile, "no-view-file", false, "Do not allow viewing file contents")
 	flags.BoolVar(&af.NoSpawnShell, "no-spawn-shell", false, "Do not allow spawning shell")
 	flags.BoolVar(&af.NoConfirmQuit, "no-confirm-quit", false, "Do not ask for confirmation before quitting after a long scan")
+	flags.StringVar(&af.TrashCommand, "trash-command", "",
+		"Command used to move items to trash instead of the built-in trash (e.g. 'trash-put --trash-dir ~/mytrash')")
 	flags.BoolVar(&af.WriteConfig, "write-config", false, "Write current configuration to file (default is $HOME/.gdu.yaml)")
 	flags.StringVar(
 		&af.Since, "since", "",

--- a/configuration.md
+++ b/configuration.md
@@ -142,6 +142,39 @@ Delete items in the background, not blocking the UI from work
 
 Delete items in parallel, which might increase the speed of deletion
 
+#### `trash-command`
+
+Command used by the `D` key to move items to trash, replacing the built-in [FreeDesktop trash](https://specifications.freedesktop.org/trash-spec/latest/) implementation. Useful to trash into a non-default location, or to use a trash tool on systems where the built-in trash is not available (macOS).
+
+The command is evaluated by `/bin/sh` with the absolute path of the item appended as an argument, so shell syntax such as variable expansion works:
+
+```yaml
+trash-command: trash-put --trash-dir ~/mytrash
+```
+
+##### Using `mv`
+
+Commands taking their destination last would receive the item path in the wrong place. Refer to the path explicitly as `"$1"` and it is not appended:
+
+```yaml
+trash-command: mv -f "$1" ~/mytrash/
+```
+
+Note the trailing slash on the destination: without it, `mv` renames the item to `~/mytrash` when that directory does not exist, quietly replacing whatever was there. With it, a missing trash dir becomes an error dialog instead.
+
+Unlike a real trash tool, `mv` overwrites an item of the same name that was trashed earlier, and records nothing that would allow restoring the item to its original location.
+
+Further details:
+
+* The path is passed as a positional shell parameter, so item names are never interpreted as shell syntax.
+* The path is appended to the command unless the command refers to it itself via `$1`, `$@` or `$*`. An appended path needs the command to end where an argument can follow (`gio trash --` works, `some-command;` does not); otherwise use `"$1"`.
+* The absolute path is also exported as the `GDU_TRASH_PATH` environment variable.
+* The command must not be interactive. It gets no terminal, the UI keeps running while it executes, and with `delete-in-background` it may even run from a background worker.
+* When the command fails, its exit status and standard error output are shown in an error dialog and the item stays in the listing.
+* When the command succeeds but the item is still present on disk, the item stays in the listing as well. Only the selected item is refreshed, so an item moved elsewhere by the command is not picked up at its new location.
+* `no-delete` disables the `D` key regardless of this option.
+* Not supported on Windows, which has no POSIX shell to evaluate the command in.
+
 #### `browse-parent-dirs`
 
 Allow navigating above the launch directory by pressing the left arrow key. When enabled, pressing left at the top-level directory will rescan and open its parent directory. Disabled by default.

--- a/docs/adr/0002-external-trash-command.md
+++ b/docs/adr/0002-external-trash-command.md
@@ -1,0 +1,75 @@
+# 2. The external trash command receives the path as a shell argument
+
+Date: 2026-09-02
+
+## Status
+
+Accepted
+
+## Context
+
+The `D` key moves an item into the FreeDesktop trash. That implementation is
+fixed: it always targets `$XDG_DATA_HOME/Trash`, and it exists only on
+non-macOS Unix — darwin and Windows get a stub that errors out.
+
+Users asked for the escape hatch ncdu offers as `--delete-command`
+(issue #640): a custom trash directory via `trash-put --trash-dir DIR`, or a
+working `D` key on macOS via `trash`/`gio trash`.
+
+ncdu appends the absolute path to the given string and evaluates the result in
+a shell. Appending the path *textually* means a file named `; rm -rf ~` becomes
+shell syntax. Not using a shell at all avoids that, but then `~` and `$HOME` in
+a command read from `~/.gdu.yaml` are never expanded, which is exactly the
+"custom trash dir" case the option exists for.
+
+Appending also assumes the command ends where an argument can follow. That
+holds for `trash-put` and `gio trash --`, but not for `mv`, which takes its
+destination last. Testing showed the natural reaction is to write
+`mv "$1" ~/Trash`, which under an unconditional append receives the path twice.
+
+A second question is when to drop the item from the in-memory tree. gdu has no
+per-item refresh; it only knows how to remove a row. The command is arbitrary,
+so exit code 0 does not imply the item is gone.
+
+## Decision
+
+The command is evaluated by `/bin/sh -c '<command> "$@"' gdu <abspath>`.
+
+The shell is kept, so expansion and other shell syntax work. The path is passed
+as a positional parameter rather than concatenated, so item names cannot be
+interpreted as shell syntax. `/bin/sh` is used rather than `$SHELL`, because
+`"$@"` must behave predictably.
+
+The `"$@"` suffix is omitted when the command already refers to the path via
+`$1`, `$@` or `$*`. The path is then wherever the user put it, which is what
+commands taking their destination last need.
+
+The tree is updated from the filesystem, not from the exit code: after a
+successful command gdu stats the path and only removes the row if the path is
+really gone.
+
+The command runs without a terminal and the UI is not suspended, so interactive
+commands are unsupported.
+
+Windows returns "not supported", matching the existing built-in trash stub.
+
+## Consequences
+
+- A command without a placeholder must be a prefix that a path can be appended
+  to. `gio trash --` works; a command ending in `;` or a pipeline does not.
+  Writing `"$1"` lifts the constraint, so unlike ncdu there is always a way out.
+- The placeholder rule is implicit: a command containing `$@` for an unrelated
+  reason never receives the path. It then trashes nothing, and because the tree
+  is updated from the filesystem the row simply stays — visible, not silent
+  corruption.
+- A command that succeeds without removing the item (an interactive command
+  answered "no", or a typo like `ls`) leaves the row in place silently. The
+  tree never claims something was trashed when it wasn't, at the cost of a
+  key press that appears to do nothing.
+- An item *moved elsewhere* by the command is dropped from the tree rather than
+  re-parented, since gdu does not rescan. Same limitation as ncdu.
+- macOS users get a working `D` key by pointing the option at a trash CLI. This
+  is a user-configured workaround, not autodetection — probing for `trash` or
+  `gio` on macOS remains open.
+- Windows gains nothing here. A Recycle Bin implementation needs
+  `SHFileOperation`, not a command line.

--- a/gdu.1.md
+++ b/gdu.1.md
@@ -106,6 +106,8 @@ non-interactive mode
 
 **\--no-view-file**\[=false\] Do not allow viewing file contents
 
+**\--trash-command**=\"\" Command used to move items to trash instead of the built-in trash. The command is evaluated by /bin/sh with the absolute path of the item appended as an argument, which is also exported as GDU_TRASH_PATH. Commands taking their destination last can refer to the path as \"\$1\" instead, in which case it is not appended. The command must not be interactive. Not supported on Windows. For example: trash-put \--trash-dir \~/mytrash or mv -f \"\$1\" \~/mytrash/
+
 **-f**, **\--input-file** Import analysis from JSON file. If the file is \"-\", read from standard input.
 
 **-o**, **\--output-file** Export all info into file as JSON. If the file is \"-\", write to standard output.

--- a/pkg/remove/trash_command.go
+++ b/pkg/remove/trash_command.go
@@ -1,0 +1,127 @@
+//go:build !windows
+
+package remove
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/dundee/gdu/v5/pkg/fs"
+)
+
+const (
+	// shellBin is the shell used to evaluate the trash command. A POSIX shell is
+	// used deliberately instead of $SHELL, because the command is assembled with
+	// "$@" and not every interactive shell handles it the same way.
+	shellBin = "/bin/sh"
+
+	// trashPathEnvVar holds the absolute path of the item handed to the command.
+	trashPathEnvVar = "GDU_TRASH_PATH"
+
+	// maxStderrLen caps how much of the command output ends up in the error
+	// message, so a chatty command cannot flood the error modal.
+	maxStderrLen = 1024
+)
+
+// itemPathPlaceholder matches the shell parameters expanding to the item path.
+// A command using any of them decides itself where the path goes, so gdu does
+// not append it.
+var itemPathPlaceholder = regexp.MustCompile(`\$(?:[1@*]|\{1\})`)
+
+type trashCommandOSOps struct {
+	abs     func(string) (string, error)
+	lstat   func(string) (os.FileInfo, error)
+	environ func() []string
+	run     func(argv0 string, argv, envv []string, stderr io.Writer) error
+}
+
+var trashCommandOS = trashCommandOSOps{
+	abs:     filepath.Abs,
+	lstat:   os.Lstat,
+	environ: os.Environ,
+	run:     runTrashCommand,
+}
+
+// TrashCommand returns a remove function which hands the item over to an
+// external command instead of moving it into the built-in XDG trash.
+//
+// The command is evaluated by a POSIX shell with the absolute path of the item
+// passed as a positional parameter, so shell features such as variable
+// expansion work while item names can never be interpreted as shell syntax.
+// The path is appended to the command unless the command refers to it itself
+// via $1, $@ or $*, which commands taking their destination last need. The
+// GDU_TRASH_PATH environment variable is set to the same absolute path.
+//
+// The item is removed from the in-memory tree only once the command succeeded
+// and the path is really gone; a command which leaves the item in place (an
+// interactive command answered with "no", for example) is not an error and
+// leaves the tree untouched.
+func TrashCommand(command string) func(dir, item fs.Item) error {
+	return func(dir, item fs.Item) error {
+		absPath, err := trashCommandOS.abs(item.GetPath())
+		if err != nil {
+			return err
+		}
+
+		var stderr bytes.Buffer
+		argv := []string{"-c", shellScript(command), "gdu", absPath}
+		envv := append(trashCommandOS.environ(), trashPathEnvVar+"="+absPath)
+
+		if err := trashCommandOS.run(shellBin, argv, envv, &stderr); err != nil {
+			return commandError(command, err, stderr.String())
+		}
+
+		if _, err := trashCommandOS.lstat(absPath); err == nil {
+			// The command reported success but the item is still there. Keep the
+			// tree in sync with the filesystem and leave the item listed.
+			return nil
+		}
+
+		dir.RemoveFile(item)
+		return nil
+	}
+}
+
+// shellScript turns the configured command into the script handed to the
+// shell. The item path is always available as $1; it is appended to the command
+// only when the command does not place it somewhere itself.
+func shellScript(command string) string {
+	if itemPathPlaceholder.MatchString(command) {
+		return command
+	}
+	return command + ` "$@"`
+}
+
+// runTrashCommand runs the trash command without attaching the terminal. The
+// command must not be interactive, because gdu keeps rendering the UI (and may
+// even run the command from a background worker) while it executes.
+func runTrashCommand(argv0 string, argv, envv []string, stderr io.Writer) error {
+	log.Printf("Running trash command: %s %v", argv0, argv)
+
+	cmd := exec.Command(argv0, argv...) //nolint:gosec // Running a user supplied command is the point.
+	cmd.Env = envv
+	cmd.Stdout = io.Discard
+	cmd.Stderr = stderr
+	return cmd.Run()
+}
+
+// commandError describes a failed trash command, including whatever the command
+// wrote to its standard error output.
+func commandError(command string, err error, stderr string) error {
+	msg := strings.TrimSpace(stderr)
+	if len(msg) > maxStderrLen {
+		msg = msg[:maxStderrLen] + "..."
+	}
+	if msg == "" {
+		return fmt.Errorf("running trash command %q: %w", command, err)
+	}
+	return fmt.Errorf("running trash command %q: %w: %s", command, err, msg)
+}

--- a/pkg/remove/trash_command_test.go
+++ b/pkg/remove/trash_command_test.go
@@ -1,0 +1,346 @@
+//go:build !windows
+
+package remove
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dundee/gdu/v5/internal/testdir"
+	"github.com/dundee/gdu/v5/pkg/analyze"
+	"github.com/dundee/gdu/v5/pkg/fs"
+)
+
+func mockTrashCommandOS(t *testing.T, configure func(*trashCommandOSOps)) {
+	t.Helper()
+	original := trashCommandOS
+	t.Cleanup(func() { trashCommandOS = original })
+	configure(&trashCommandOS)
+}
+
+// createTestTree builds the in-memory counterpart of the directory created by
+// testdir.CreateTestDir and returns the dir holding file2 together with the file.
+func createTestTree() (*analyze.Dir, *analyze.File) {
+	dir := &analyze.Dir{
+		File: &analyze.File{
+			Name:  "test_dir",
+			Size:  5,
+			Usage: 12,
+		},
+		ItemCount: 3,
+		BasePath:  ".",
+	}
+	subdir := &analyze.Dir{
+		File: &analyze.File{
+			Name:   "nested",
+			Size:   4,
+			Usage:  8,
+			Parent: dir,
+		},
+		ItemCount: 2,
+	}
+	file := &analyze.File{
+		Name:   "file2",
+		Size:   3,
+		Usage:  4,
+		Parent: subdir,
+	}
+	dir.Files = fs.Files{subdir}
+	subdir.Files = fs.Files{file}
+
+	return subdir, file
+}
+
+func TestTrashCommand(t *testing.T) {
+	fin := testdir.CreateTestDir()
+	defer fin()
+
+	subdir, file := createTestTree()
+
+	err := TrashCommand("rm -rf")(subdir, file)
+	require.NoError(t, err)
+
+	_, err = os.Stat("test_dir/nested/file2")
+	assert.True(t, os.IsNotExist(err))
+
+	assert.Equal(t, 0, len(subdir.Files))
+	assert.Equal(t, int64(1), subdir.ItemCount)
+}
+
+func TestTrashCommandOnDir(t *testing.T) {
+	fin := testdir.CreateTestDir()
+	defer fin()
+
+	dir := &analyze.Dir{
+		File: &analyze.File{
+			Name:  "test_dir",
+			Size:  5,
+			Usage: 12,
+		},
+		ItemCount: 3,
+		BasePath:  ".",
+	}
+	subdir := &analyze.Dir{
+		File: &analyze.File{
+			Name:   "nested",
+			Size:   4,
+			Usage:  8,
+			Parent: dir,
+		},
+		ItemCount: 2,
+	}
+	dir.Files = fs.Files{subdir}
+
+	err := TrashCommand("rm -rf")(dir, subdir)
+	require.NoError(t, err)
+
+	_, err = os.Stat("test_dir/nested")
+	assert.True(t, os.IsNotExist(err))
+	assert.Equal(t, 0, len(dir.Files))
+}
+
+func TestShellScript(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+		want    string
+	}{
+		{
+			name:    "path appended",
+			command: "trash-put",
+			want:    `trash-put "$@"`,
+		},
+		{
+			name:    "path appended after arguments",
+			command: "trash-put --trash-dir ~/mytrash",
+			want:    `trash-put --trash-dir ~/mytrash "$@"`,
+		},
+		{
+			name:    "env var is not a placeholder",
+			command: "trash-put --trash-dir $HOME/mytrash",
+			want:    `trash-put --trash-dir $HOME/mytrash "$@"`,
+		},
+		{
+			name:    "quoted first parameter",
+			command: `mv -f "$1" ~/mytrash/`,
+			want:    `mv -f "$1" ~/mytrash/`,
+		},
+		{
+			name:    "braced first parameter",
+			command: `mv -f "${1}" ~/mytrash/`,
+			want:    `mv -f "${1}" ~/mytrash/`,
+		},
+		{
+			name:    "all parameters",
+			command: `mv -f "$@" ~/mytrash/`,
+			want:    `mv -f "$@" ~/mytrash/`,
+		},
+		{
+			name:    "all parameters as single word",
+			command: `mv -f "$*" ~/mytrash/`,
+			want:    `mv -f "$*" ~/mytrash/`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, shellScript(tt.command))
+		})
+	}
+}
+
+// writeScript creates a shell script with the given body and returns a command
+// running it, so tests can use commands carrying their own arguments.
+func writeScript(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "script.sh")
+	require.NoError(t, os.WriteFile(path, []byte(body), 0o600))
+	return "/bin/sh " + path
+}
+
+// TestTrashCommandWithArguments checks that the path is appended to a command
+// which already carries arguments of its own.
+func TestTrashCommandWithArguments(t *testing.T) {
+	fin := testdir.CreateTestDir()
+	defer fin()
+
+	target := t.TempDir()
+	subdir, file := createTestTree()
+
+	// $1 is the argument given in the command, $2 the appended item path.
+	command := writeScript(t, `mv -f "$2" "$1"`) + " " + target
+
+	err := TrashCommand(command)(subdir, file)
+	require.NoError(t, err)
+
+	assert.FileExists(t, filepath.Join(target, "file2"))
+	assert.NoFileExists(t, "test_dir/nested/file2")
+	assert.Equal(t, 0, len(subdir.Files))
+}
+
+// TestTrashCommandWithMv covers the mv recipe from the documentation. mv takes
+// its destination last, so the command places the item path itself instead of
+// having it appended. It also checks that the command is evaluated by a shell,
+// so a trash dir given in the config file can use ~.
+func TestTrashCommandWithMv(t *testing.T) {
+	fin := testdir.CreateTestDir()
+	defer fin()
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	require.NoError(t, os.Mkdir(filepath.Join(home, "mytrash"), 0o700))
+
+	subdir, file := createTestTree()
+
+	err := TrashCommand(`mv -f "$1" ~/mytrash/`)(subdir, file)
+	require.NoError(t, err)
+
+	assert.FileExists(t, filepath.Join(home, "mytrash", "file2"))
+	assert.NoFileExists(t, "test_dir/nested/file2")
+	assert.Equal(t, 0, len(subdir.Files))
+}
+
+// TestTrashCommandWithMvToMissingDir makes sure the trailing slash in the
+// documented mv recipe turns a missing trash dir into an error instead of
+// renaming the item onto the destination path.
+func TestTrashCommandWithMvToMissingDir(t *testing.T) {
+	fin := testdir.CreateTestDir()
+	defer fin()
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	subdir, file := createTestTree()
+
+	err := TrashCommand(`mv -f "$1" ~/mytrash/`)(subdir, file)
+	require.Error(t, err)
+
+	assert.NoFileExists(t, filepath.Join(home, "mytrash"))
+	assert.FileExists(t, "test_dir/nested/file2")
+	assert.Equal(t, 1, len(subdir.Files))
+}
+
+func TestTrashCommandPassesPathAsArgumentAndEnvVar(t *testing.T) {
+	fin := testdir.CreateTestDir()
+	defer fin()
+
+	out := filepath.Join(t.TempDir(), "args")
+	subdir, file := createTestTree()
+
+	command := writeScript(t, `printf '%s\n' "$#" "$1" "$GDU_TRASH_PATH" > "`+out+`"`)
+
+	err := TrashCommand(command)(subdir, file)
+	require.NoError(t, err)
+
+	wantPath, err := filepath.Abs("test_dir/nested/file2")
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(out)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"1", wantPath, wantPath}, strings.Fields(string(data)))
+}
+
+// TestTrashCommandWithSpecialCharsInName makes sure item names are never
+// interpreted as shell syntax.
+func TestTrashCommandWithSpecialCharsInName(t *testing.T) {
+	base := t.TempDir()
+	name := "; touch pwned; echo 'x'"
+	path := filepath.Join(base, name)
+	require.NoError(t, os.WriteFile(path, []byte("x"), 0o600))
+
+	dir := &analyze.Dir{
+		File:      &analyze.File{Name: filepath.Base(base)},
+		ItemCount: 2,
+		BasePath:  filepath.Dir(base),
+	}
+	file := &analyze.File{Name: name, Size: 1, Usage: 1, Parent: dir}
+	dir.Files = fs.Files{file}
+
+	err := TrashCommand("rm -f")(dir, file)
+	require.NoError(t, err)
+
+	assert.NoFileExists(t, path)
+	assert.NoFileExists(t, filepath.Join(base, "pwned"))
+	assert.NoFileExists(t, "pwned")
+	assert.Equal(t, 0, len(dir.Files))
+}
+
+func TestTrashCommandFailing(t *testing.T) {
+	fin := testdir.CreateTestDir()
+	defer fin()
+
+	subdir, file := createTestTree()
+
+	err := TrashCommand(writeScript(t, "exit 3"))(subdir, file)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "running trash command")
+	assert.Contains(t, err.Error(), "exit status 3")
+
+	assert.FileExists(t, "test_dir/nested/file2")
+	assert.Equal(t, 1, len(subdir.Files))
+}
+
+func TestTrashCommandFailingWithStderr(t *testing.T) {
+	fin := testdir.CreateTestDir()
+	defer fin()
+
+	subdir, file := createTestTree()
+
+	err := TrashCommand(writeScript(t, "echo 'trash dir is missing' >&2\nexit 1"))(subdir, file)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "trash dir is missing")
+	assert.Equal(t, 1, len(subdir.Files))
+}
+
+// TestTrashCommandLeavingItemInPlace covers a command which succeeds without
+// removing the item, e.g. an interactive command answered with "no".
+func TestTrashCommandLeavingItemInPlace(t *testing.T) {
+	fin := testdir.CreateTestDir()
+	defer fin()
+
+	subdir, file := createTestTree()
+
+	err := TrashCommand("true")(subdir, file)
+	require.NoError(t, err)
+
+	assert.FileExists(t, "test_dir/nested/file2")
+	assert.Equal(t, 1, len(subdir.Files))
+	assert.Equal(t, int64(2), subdir.ItemCount)
+}
+
+func TestTrashCommandAbsError(t *testing.T) {
+	sentinel := errors.New("abs failed")
+	mockTrashCommandOS(t, func(ops *trashCommandOSOps) {
+		ops.abs = func(string) (string, error) { return "", sentinel }
+	})
+
+	subdir, file := createTestTree()
+
+	err := TrashCommand("rm -rf")(subdir, file)
+	require.ErrorIs(t, err, sentinel)
+	assert.Equal(t, 1, len(subdir.Files))
+}
+
+func TestTrashCommandStderrTruncated(t *testing.T) {
+	mockTrashCommandOS(t, func(ops *trashCommandOSOps) {
+		ops.run = func(_ string, _, _ []string, stderr io.Writer) error {
+			_, err := stderr.Write([]byte(strings.Repeat("x", maxStderrLen+10)))
+			require.NoError(t, err)
+			return errors.New("failed")
+		}
+	})
+
+	subdir, file := createTestTree()
+
+	err := TrashCommand("rm -rf")(subdir, file)
+	require.Error(t, err)
+	assert.True(t, strings.HasSuffix(err.Error(), "..."))
+	assert.Less(t, len(err.Error()), maxStderrLen+100)
+}

--- a/pkg/remove/trash_command_windows.go
+++ b/pkg/remove/trash_command_windows.go
@@ -1,0 +1,17 @@
+//go:build windows
+
+package remove
+
+import (
+	"fmt"
+
+	"github.com/dundee/gdu/v5/pkg/fs"
+)
+
+// TrashCommand is not supported on Windows, which has no POSIX shell to
+// evaluate the command in.
+func TrashCommand(command string) func(dir, item fs.Item) error {
+	return func(dir, item fs.Item) error {
+		return fmt.Errorf("trash command is not supported on Windows")
+	}
+}

--- a/pkg/remove/trash_command_windows_test.go
+++ b/pkg/remove/trash_command_windows_test.go
@@ -1,0 +1,19 @@
+//go:build windows
+
+package remove
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dundee/gdu/v5/pkg/analyze"
+)
+
+func TestTrashCommandNotSupported(t *testing.T) {
+	dir := &analyze.Dir{File: &analyze.File{Name: "test_dir"}}
+	file := &analyze.File{Name: "file", Parent: dir}
+
+	err := TrashCommand("rm -rf")(dir, file)
+	assert.Error(t, err)
+}

--- a/tui/trash_command_test.go
+++ b/tui/trash_command_test.go
@@ -1,0 +1,84 @@
+//go:build !windows
+
+package tui
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dundee/gdu/v5/internal/testapp"
+	"github.com/dundee/gdu/v5/internal/testdir"
+)
+
+func TestSetTrashCommand(t *testing.T) {
+	fin := testdir.CreateTestDir()
+	defer fin()
+	simScreen := testapp.CreateSimScreen()
+	defer simScreen.Fini()
+
+	app := testapp.CreateMockedApp(true)
+	ui := CreateUI(app, simScreen, &bytes.Buffer{}, false, true, false, false)
+	ui.done = make(chan struct{})
+	ui.askBeforeDelete = false
+	ui.SetTrashCommand("rm -rf")
+
+	err := ui.AnalyzePath("test_dir", nil)
+	assert.Nil(t, err)
+
+	<-ui.done // wait for analyzer
+
+	for _, f := range ui.app.(*testapp.MockedApp).GetUpdateDraws() {
+		f()
+	}
+
+	assert.Equal(t, 1, ui.table.GetRowCount())
+
+	ui.table.Select(0, 0)
+	ui.keyPressed(tcell.NewEventKey(tcell.KeyRune, 'D', 0))
+
+	<-ui.done
+
+	for _, f := range ui.app.(*testapp.MockedApp).GetUpdateDraws() {
+		f()
+	}
+
+	assert.NoDirExists(t, "test_dir/nested")
+	assert.Equal(t, 0, ui.table.GetRowCount())
+}
+
+func TestSetTrashCommandFailing(t *testing.T) {
+	fin := testdir.CreateTestDir()
+	defer fin()
+	simScreen := testapp.CreateSimScreen()
+	defer simScreen.Fini()
+
+	app := testapp.CreateMockedApp(true)
+	ui := CreateUI(app, simScreen, &bytes.Buffer{}, false, true, false, false)
+	ui.done = make(chan struct{})
+	ui.askBeforeDelete = false
+	ui.SetTrashCommand("false")
+
+	err := ui.AnalyzePath("test_dir", nil)
+	assert.Nil(t, err)
+
+	<-ui.done // wait for analyzer
+
+	for _, f := range ui.app.(*testapp.MockedApp).GetUpdateDraws() {
+		f()
+	}
+
+	ui.table.Select(0, 0)
+	ui.keyPressed(tcell.NewEventKey(tcell.KeyRune, 'D', 0))
+
+	<-ui.done
+
+	for _, f := range ui.app.(*testapp.MockedApp).GetUpdateDraws() {
+		f()
+	}
+
+	assert.True(t, ui.pages.HasPage("error"))
+	assert.DirExists(t, "test_dir/nested")
+}

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -342,6 +342,11 @@ func (ui *UI) SetDeleteInParallel() {
 	ui.remover = remove.ItemFromDirParallel
 }
 
+// SetTrashCommand replaces the built-in trash with an external command
+func (ui *UI) SetTrashCommand(command string) {
+	ui.trasher = remove.TrashCommand(command)
+}
+
 // StartUILoop starts tview application
 func (ui *UI) StartUILoop() error {
 	signals := make(chan os.Signal, 1)


### PR DESCRIPTION
Replace the built-in XDG trash used by the D key with a user supplied command, so items can be trashed into a non-default location or with a trash tool on systems where the built-in trash is not available.

The command is evaluated by /bin/sh with the absolute path of the item passed as a positional parameter, so shell syntax works while item names can never be interpreted as shell syntax. The path is appended unless the command refers to it itself via $1, $@ or $*, which commands taking their destination last, such as mv, need. The path is also exported as GDU_TRASH_PATH.

The item is dropped from the tree only once the command succeeded and the path is really gone, so a command that leaves the item in place does not make the listing lie.

Not supported on Windows, which has no POSIX shell to evaluate the command in.

Closes #640