### PR TITLE
feat: allow scanning multiple directories

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -8,6 +8,18 @@ Architectural decisions live in [`docs/adr/`](docs/adr/).
 Anything gdu can put on a row: a file or a directory. Devices are not items —
 they are listed by a separate screen with their own vocabulary.
 
+## Scanned root
+
+A directory named on the command line, i.e. one of the starting points of a
+scan. There can be more than one. Scanned roots are labelled by their absolute
+path, unlike every other item, which is labelled by its base name.
+
+## Virtual top level directory
+
+The synthetic directory that holds the scanned roots when there is more than
+one, so that they can be listed, sorted and compared as siblings. It is not an
+item on any filesystem and has no path; every other directory gdu shows does.
+
 ## Apparent size
 
 The size an item claims to be, i.e. the length of its contents.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Or you can use Gdu directly via Docker:
 ## Usage
 
 ```
-  gdu [flags] [directory_to_scan]
+  gdu [flags] [directory_to_scan...]
 
 Flags:
       --archive-browsing              Enable browsing of zip/jar/tar archives (tar, tar.gz, tar.bz2, tar.xz)
@@ -115,6 +115,7 @@ Basic list of actions in interactive mode (show help modal for more):
     gdu --no-delete                       # prevent write operations
     gdu --no-view-file                    # prevent viewing file contents
     gdu <some_dir_to_analyze>             # analyze given dir
+    gdu dir_a dir_b dir_c                 # analyze several dirs at once
     gdu -d                                # show all mounted disks
     gdu -l ./gdu.log <some_dir>           # write errors to log file
     gdu -i /sys,/proc /                   # ignore some paths
@@ -140,6 +141,18 @@ Basic list of actions in interactive mode (show help modal for more):
     gdu --web /                           # analyze and browse the results in a web browser
     gdu --web --web-listen localhost:8080 /   # serve the web UI on a fixed address
     gdu --web --web-open=false /          # print the URL but do not open a browser
+
+## Scanning multiple directories
+
+More than one directory can be given on the command line, which is useful when only a subset of a large directory is of interest:
+
+    gdu ~/projects/alpha ~/projects/beta ~/projects/gamma
+
+The directories are scanned one after another and presented together under a virtual top level directory named `(multiple)`, so they can be compared and sorted like ordinary siblings. They are listed by their absolute path, so directories that share a base name stay distinguishable. Each of them keeps its real path, so rescanning, deletion and opening a shell work as usual once you navigate into one of them.
+
+The virtual top level directory itself has no counterpart on disk, so operations that need a real path are unavailable while it is shown: `--change-cwd`, spawning a shell, browsing to the parent directory (`--browse-parent-dirs`) and exporting to JSON. Rescanning it rescans every directory below it.
+
+Directories that are nested in one another are rejected, since scanning both would count the nested part twice. Exporting (`-o`) and database storage (`--db`) accept a single directory only.
 
 ## Modes
 

--- a/cmd/gdu/app/app.go
+++ b/cmd/gdu/app/app.go
@@ -33,6 +33,10 @@ import (
 type UI interface {
 	ListDevices(getter device.DevicesInfoGetter) error
 	AnalyzePath(path string, parentDir gfs.Item) error
+	// AnalyzePaths scans several roots and presents them under one virtual top
+	// level dir. Implementations that cannot represent more than one root
+	// return an error.
+	AnalyzePaths(paths []string) error
 	ReadAnalysis(input io.Reader) error
 	ReadFromStorage(storagePath, path string) error
 	SetIgnoreTypes(types []string)
@@ -246,10 +250,14 @@ func (a *App) Run() error {
 		return errors.New("--output-attrs requires --output-file")
 	}
 
-	path := a.getPath()
-	path, err = filepath.Abs(path)
+	paths, err := a.resolvePaths()
 	if err != nil {
 		return err
+	}
+	if len(paths) > 1 {
+		if err := a.checkMultiPathSupport(); err != nil {
+			return err
+		}
 	}
 
 	ui, err = a.createUI(outputAttributes)
@@ -298,8 +306,10 @@ func (a *App) Run() error {
 			return err
 		}
 	}
-	if err := a.setNoCross(path); err != nil {
-		return err
+	for _, path := range paths {
+		if err := a.setNoCross(path); err != nil {
+			return err
+		}
 	}
 
 	// Process type filters
@@ -330,18 +340,85 @@ func (a *App) Run() error {
 
 	a.setMaxProcs()
 
-	if err := a.runAction(ui, path); err != nil {
+	if err := a.runAction(ui, paths); err != nil {
 		return err
 	}
 
 	return ui.StartUILoop()
 }
 
-func (a *App) getPath() string {
-	if len(a.Args) == 1 {
-		return a.Args[0]
+func (a *App) getPaths() []string {
+	if len(a.Args) > 0 {
+		return a.Args
 	}
-	return "."
+	return []string{"."}
+}
+
+// resolvePaths turns the directory arguments into absolute paths, dropping
+// exact duplicates.
+//
+// Nested paths are rejected rather than deduplicated: scanning both a directory
+// and something inside it would count the nested part twice in every total gdu
+// reports, and there is no answer to that which is not surprising.
+func (a *App) resolvePaths() ([]string, error) {
+	args := a.getPaths()
+	paths := make([]string, 0, len(args))
+	seen := make(map[string]struct{}, len(args))
+
+	for _, arg := range args {
+		path, err := filepath.Abs(arg)
+		if err != nil {
+			return nil, err
+		}
+		if _, ok := seen[path]; ok {
+			continue
+		}
+		seen[path] = struct{}{}
+		paths = append(paths, path)
+	}
+
+	for i, path := range paths {
+		for j, other := range paths {
+			if i == j {
+				continue
+			}
+			if isSubPath(other, path) {
+				return nil, fmt.Errorf(
+					"directory %s is nested in %s, scanning both would count it twice", other, path,
+				)
+			}
+		}
+	}
+
+	return paths, nil
+}
+
+// checkMultiPathSupport rejects the modes that cannot represent more than one
+// scanned root. Both the JSON export format and the on-disk storage are keyed
+// by a single root, so there is nowhere to put a virtual top level dir.
+func (a *App) checkMultiPathSupport() error {
+	switch {
+	case a.Flags.OutputFile != "":
+		return errors.New("--output-file accepts only one directory to scan")
+	case a.Flags.DbPath != "":
+		return errors.New("--db accepts only one directory to scan")
+	}
+	return nil
+}
+
+// isSubPath reports whether path lies inside parent. Both must be absolute and
+// cleaned, as returned by filepath.Abs.
+func isSubPath(path, parent string) bool {
+	rel, err := filepath.Rel(parent, path)
+	if err != nil {
+		return false
+	}
+	if rel == "." || rel == ".." {
+		return false
+	}
+	// only a leading ".." path *element* means "outside parent"; a name such as
+	// "..foo" is an ordinary child
+	return !strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }
 
 func (a *App) setMaxProcs() {
@@ -639,7 +716,7 @@ func (a *App) setNoCross(path string) error {
 	return nil
 }
 
-func (a *App) runAction(ui UI, path string) error {
+func (a *App) runAction(ui UI, paths []string) error {
 	if a.Flags.Profiling {
 		go func() {
 			http.HandleFunc("/debug/pprof/", pprof.Index)
@@ -679,18 +756,29 @@ func (a *App) runAction(ui UI, path string) error {
 			log.Printf("Could not prevent dataless materialization: %s", err)
 		}
 
-		if build.RootPathPrefix != "" {
-			path = build.RootPathPrefix + path
+		scanPaths := make([]string, 0, len(paths))
+		for _, path := range paths {
+			if build.RootPathPrefix != "" {
+				path = build.RootPathPrefix + path
+			}
+
+			if _, err := a.PathChecker(path); err != nil {
+				return err
+			}
+			scanPaths = append(scanPaths, path)
 		}
 
-		_, err := a.PathChecker(path)
-		if err != nil {
-			return err
+		if len(scanPaths) == 1 {
+			log.Printf("Analyzing path: %s", scanPaths[0])
+			if err := ui.AnalyzePath(scanPaths[0], nil); err != nil {
+				return fmt.Errorf("scanning dir: %w", err)
+			}
+			break
 		}
 
-		log.Printf("Analyzing path: %s", path)
-		if err := ui.AnalyzePath(path, nil); err != nil {
-			return fmt.Errorf("scanning dir: %w", err)
+		log.Printf("Analyzing paths: %s", strings.Join(scanPaths, ", "))
+		if err := ui.AnalyzePaths(scanPaths); err != nil {
+			return fmt.Errorf("scanning dirs: %w", err)
 		}
 	}
 	return nil

--- a/cmd/gdu/app/app_test.go
+++ b/cmd/gdu/app/app_test.go
@@ -781,6 +781,7 @@ type uiTimeFilterMock struct {
 
 func (m *uiTimeFilterMock) ListDevices(getter device.DevicesInfoGetter) error { return nil }
 func (m *uiTimeFilterMock) AnalyzePath(path string, parentDir gfs.Item) error { return nil }
+func (m *uiTimeFilterMock) AnalyzePaths(paths []string) error                 { return nil }
 func (m *uiTimeFilterMock) ReadAnalysis(input io.Reader) error                { return nil }
 func (m *uiTimeFilterMock) ReadFromStorage(storagePath, path string) error    { return nil }
 func (m *uiTimeFilterMock) SetIgnoreTypes(types []string)                     {}

--- a/cmd/gdu/app/multipath_test.go
+++ b/cmd/gdu/app/multipath_test.go
@@ -1,0 +1,171 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dundee/gdu/v5/internal/testdev"
+	"github.com/dundee/gdu/v5/internal/testdir"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// createMultiTestDir creates two sibling directories that can be scanned
+// together, and returns their names.
+func createMultiTestDir(t *testing.T) (first, second string) {
+	t.Helper()
+
+	for _, dir := range []string{"multi_a/nested", "multi_b/other"} {
+		require.NoError(t, os.MkdirAll(dir, os.ModePerm))
+	}
+	require.NoError(t, os.WriteFile("multi_a/nested/file", []byte("hello"), 0o600))
+	require.NoError(t, os.WriteFile("multi_b/other/file2", []byte("go"), 0o600))
+
+	t.Cleanup(func() {
+		assert.NoError(t, os.RemoveAll("multi_a"))
+		assert.NoError(t, os.RemoveAll("multi_b"))
+	})
+
+	return "multi_a", "multi_b"
+}
+
+func TestResolvePathsDefaultsToCwd(t *testing.T) {
+	a := &App{Flags: &Flags{}, Args: []string{}}
+
+	paths, err := a.resolvePaths()
+
+	cwd, cwdErr := filepath.Abs(".")
+	require.NoError(t, cwdErr)
+	assert.NoError(t, err)
+	assert.Equal(t, []string{cwd}, paths)
+}
+
+func TestResolvePathsMakesArgsAbsolute(t *testing.T) {
+	a := &App{Flags: &Flags{}, Args: []string{"multi_a", "multi_b"}}
+
+	paths, err := a.resolvePaths()
+
+	assert.NoError(t, err)
+	require.Len(t, paths, 2)
+	for _, path := range paths {
+		assert.True(t, filepath.IsAbs(path), "expected absolute path, got %s", path)
+	}
+}
+
+func TestResolvePathsDropsDuplicates(t *testing.T) {
+	a := &App{Flags: &Flags{}, Args: []string{"multi_a", "./multi_a", "multi_b"}}
+
+	paths, err := a.resolvePaths()
+
+	assert.NoError(t, err)
+	assert.Len(t, paths, 2)
+}
+
+func TestResolvePathsRejectsNestedPaths(t *testing.T) {
+	a := &App{Flags: &Flags{}, Args: []string{"multi_a", "multi_a/nested"}}
+
+	_, err := a.resolvePaths()
+
+	assert.ErrorContains(t, err, "would count it twice")
+}
+
+func TestResolvePathsRejectsNestedPathsRegardlessOfOrder(t *testing.T) {
+	a := &App{Flags: &Flags{}, Args: []string{"multi_a/nested", "multi_a"}}
+
+	_, err := a.resolvePaths()
+
+	assert.ErrorContains(t, err, "would count it twice")
+}
+
+func TestResolvePathsAllowsSiblingsWithSharedPrefix(t *testing.T) {
+	a := &App{Flags: &Flags{}, Args: []string{"multi_a", "multi_ab"}}
+
+	paths, err := a.resolvePaths()
+
+	assert.NoError(t, err)
+	assert.Len(t, paths, 2)
+}
+
+func TestIsSubPath(t *testing.T) {
+	root := string(filepath.Separator)
+
+	assert.True(t, isSubPath(filepath.Join(root, "a", "b"), filepath.Join(root, "a")))
+	assert.True(t, isSubPath(filepath.Join(root, "a", "..foo"), filepath.Join(root, "a")))
+	assert.False(t, isSubPath(filepath.Join(root, "a"), filepath.Join(root, "a")))
+	assert.False(t, isSubPath(filepath.Join(root, "ab"), filepath.Join(root, "a")))
+	assert.False(t, isSubPath(filepath.Join(root, "a"), filepath.Join(root, "a", "b")))
+}
+
+func TestAnalyzeMultiplePaths(t *testing.T) {
+	first, second := createMultiTestDir(t)
+
+	out, err := runApp(
+		&Flags{LogFile: "/dev/null"},
+		[]string{first, second},
+		false,
+		testdev.DevicesInfoGetterMock{},
+	)
+
+	assert.NoError(t, err)
+	// both scanned roots are listed under the virtual top level dir
+	assert.Contains(t, out, first)
+	assert.Contains(t, out, second)
+}
+
+func TestAnalyzeMultiplePathsSummarize(t *testing.T) {
+	first, second := createMultiTestDir(t)
+
+	out, err := runApp(
+		&Flags{LogFile: "/dev/null", Summarize: true, NonInteractive: true},
+		[]string{first, second},
+		false,
+		testdev.DevicesInfoGetterMock{},
+	)
+
+	assert.NoError(t, err)
+	assert.NotEmpty(t, out)
+}
+
+func TestAnalyzeSinglePathIsUnchangedByMultiPathSupport(t *testing.T) {
+	fin := testdir.CreateTestDir()
+	defer fin()
+
+	out, err := runApp(
+		&Flags{LogFile: "/dev/null"},
+		[]string{"test_dir"},
+		false,
+		testdev.DevicesInfoGetterMock{},
+	)
+
+	assert.NoError(t, err)
+	assert.Contains(t, out, "nested")
+	// no virtual root is introduced for a single directory
+	assert.NotContains(t, out, "(multiple)")
+}
+
+func TestMultiplePathsRejectedForExport(t *testing.T) {
+	first, second := createMultiTestDir(t)
+
+	_, err := runApp(
+		&Flags{LogFile: "/dev/null", OutputFile: "/dev/null"},
+		[]string{first, second},
+		false,
+		testdev.DevicesInfoGetterMock{},
+	)
+
+	assert.ErrorContains(t, err, "--output-file accepts only one directory")
+}
+
+func TestMultiplePathsRejectedForStorage(t *testing.T) {
+	first, second := createMultiTestDir(t)
+
+	_, err := runApp(
+		&Flags{LogFile: "/dev/null", DbPath: filepath.Join(t.TempDir(), "gdu.db")},
+		[]string{first, second},
+		false,
+		testdev.DevicesInfoGetterMock{},
+	)
+
+	assert.ErrorContains(t, err, "--db accepts only one directory")
+}

--- a/cmd/gdu/main.go
+++ b/cmd/gdu/main.go
@@ -29,14 +29,17 @@ var (
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "gdu [directory_to_scan]",
+	Use:   "gdu [directory_to_scan...]",
 	Short: "Pretty fast disk usage analyzer written in Go",
 	Long: `Pretty fast disk usage analyzer written in Go.
 
 Gdu is intended primarily for SSD disks where it can fully utilize parallel processing.
 However HDDs work as well, but the performance gain is not so huge.
+
+More than one directory can be given, in which case they are scanned separately
+and presented together under a virtual top level directory.
 `,
-	Args:         cobra.MaximumNArgs(1),
+	Args:         cobra.ArbitraryArgs,
 	SilenceUsage: true,
 	RunE:         runE,
 }

--- a/docs/adr/0002-multiple-scanned-roots-share-a-virtual-top-level-dir.md
+++ b/docs/adr/0002-multiple-scanned-roots-share-a-virtual-top-level-dir.md
@@ -1,0 +1,75 @@
+# 2. Multiple scanned roots share a virtual top level directory
+
+Date: 2026-09-02
+
+## Status
+
+Accepted
+
+## Context
+
+gdu accepted exactly one directory to scan (`cobra.MaximumNArgs(1)`). Issue #423
+asks for a subset of a large directory's children to be scanned together: with a
+hundred subdirectories, scanning all of them takes minutes and scanning them one
+at a time defeats the purpose, which is to compare them.
+
+Everything downstream of the analyzer assumes a single-rooted tree. The TUI
+anchors navigation on a `topDir`/`topDirPath` pair and stops the `/..` row at it;
+`Dir.subtractStats` walks parent pointers to the root; the ncdu-compatible export
+format holds exactly one root array. A second root has nowhere to go.
+
+Two shapes were available:
+
+1. Keep N independent trees and teach every consumer to iterate them.
+2. Give the N roots a synthetic parent, so there is still one tree.
+
+## Decision
+
+Multiple scanned roots are grouped under a **virtual top level directory**
+(`analyze.CreateVirtualRootDir`), and the rest of gdu keeps working on the single
+rooted tree it already expects.
+
+The virtual root is a real `analyze.Dir` with no parent and no `BasePath`, named
+`(multiple)`. Because `Dir.GetPath` prefers `BasePath` over the parent chain, the
+roots below it keep reporting their true absolute path even though they now have
+a parent — so rescan, deletion, shell spawning and path display need no special
+handling once the user has navigated into a root.
+
+Consequences of the virtual root having no path are handled by refusing the
+operation rather than inventing one: `--change-cwd`, spawning a shell, browsing
+to a parent (`--browse-parent-dirs`) and JSON export are unavailable while it is
+displayed.
+
+Rows directly under the virtual root are **labelled with their absolute path**
+rather than their base name (`analyze.ItemDisplayName`). Two roots taken from
+different parents routinely share a base name — `gdu /a/data /b/data` would
+otherwise show `data` twice — and the absolute path is what the user typed.
+Below the roots, ordinary base names resume.
+
+Two related decisions:
+
+- **Nested roots are rejected**, not deduplicated. `gdu /a /a/b` counts `/a/b`
+  twice in every total gdu reports, and no silent resolution of that is
+  unsurprising. Exact duplicates are dropped, since they have one obvious
+  meaning.
+- **Export (`-o`) and storage (`--db`) accept one directory only.** Both are
+  keyed by a single root, and inventing a multi-root encoding would break
+  compatibility with ncdu for a case nobody has asked for yet.
+
+## Consequences
+
+- Roots are scanned sequentially, not concurrently. The analyzer owns one set of
+  progress channels per scan and `ResetProgress` replaces them, so a second
+  concurrent scan on the same analyzer would close a closed channel. Progress
+  therefore restarts per root, and the modal reports `Scanning 2/3...`.
+- `ResetProgress` also clears the analyzer's cancelled flag, so a cancel request
+  made between roots would be lost. The TUI tracks the request separately in
+  `scanCancelRequested` and stops the loop itself, keeping partial results as a
+  cancelled single scan does.
+- The non-interactive stdout mode gives up its memory-efficient `SimpleDir`
+  analyzer for multiple roots: `SimpleDir` deliberately panics on `SetParent` and
+  cannot be re-parented. `--top` and `--depth` already make the same trade.
+- Labelling roots by path means the directory marker (`/` in the TUI and in
+  stdout) has to be suppressed for them, since an absolute path already opens
+  with a separator. Filtering at the virtual root matches against the path shown,
+  not the base name, so what is typed matches what is on screen.

--- a/gdu.1.md
+++ b/gdu.1.md
@@ -10,7 +10,7 @@ gdu - Pretty fast disk usage analyzer written in Go
 
 # SYNOPSIS
 
-**gdu \[flags\] \[directory_to_scan\]**
+**gdu \[flags\] \[directory_to_scan...\]**
 
 # DESCRIPTION
 
@@ -19,6 +19,13 @@ Pretty fast disk usage analyzer written in Go.
 Gdu is intended primarily for SSD disks where it can fully utilize
 parallel processing. However HDDs work as well, but the performance gain
 is not so huge.
+
+More than one directory can be given. They are scanned one after another
+and presented together under a virtual top level directory named
+"(multiple)", listed by their absolute path. Nested directories are
+rejected, as scanning both would count the nested part twice. Exporting
+(\--output-file) and database storage (\--db) accept a single directory
+only.
 
 # OPTIONS
 

--- a/pkg/analyze/virtualroot.go
+++ b/pkg/analyze/virtualroot.go
@@ -1,0 +1,67 @@
+package analyze
+
+import (
+	"github.com/dundee/gdu/v5/pkg/fs"
+)
+
+// VirtualRootName is the display name of the synthetic directory that groups
+// several independently scanned roots.
+//
+// It is deliberately not a valid absolute path. Every consumer that resolves a
+// path back to the filesystem (rescan, delete, spawn shell, change cwd) keys off
+// the item's path, so a name that cannot be mistaken for a real directory keeps
+// those operations from ever targeting the virtual root itself.
+const VirtualRootName = "(multiple)"
+
+// CreateVirtualRootDir groups several independently scanned roots under one
+// synthetic parent directory, so that scanning N directories can be presented
+// through the same single-rooted tree the rest of gdu expects.
+//
+// The roots keep their own BasePath, so Dir.GetPath still reports their real
+// absolute path even though they now have a parent. The virtual root has
+// neither a parent nor a BasePath, which is what IsVirtualRootDir detects and
+// what makes GetPath fall back to VirtualRootName.
+//
+// Stats are not aggregated here; call UpdateStats on the returned dir once the
+// roots have been scanned.
+func CreateVirtualRootDir(roots ...fs.Item) *Dir {
+	dir := &Dir{
+		File: &File{
+			Name: VirtualRootName,
+			Flag: getDirFlag(nil, len(roots)),
+		},
+		ItemCount: 1,
+		Files:     make(fs.Files, 0, len(roots)),
+	}
+
+	for _, root := range roots {
+		root.SetParent(dir)
+		dir.AddFile(root)
+	}
+
+	return dir
+}
+
+// ItemDisplayName returns the label to show for item when it is listed directly
+// under parent.
+//
+// Scanned roots grouped under the virtual top level dir are labelled with their
+// absolute path rather than their base name: base names collide as soon as two
+// roots come from different parent directories, and the absolute path is what
+// the user asked for on the command line.
+func ItemDisplayName(parent, item fs.Item) string {
+	if IsVirtualRootDir(parent) {
+		return item.GetPath()
+	}
+	return item.GetName()
+}
+
+// IsVirtualRootDir reports whether item is the synthetic dir created by
+// CreateVirtualRootDir, i.e. a node with no counterpart on the filesystem.
+func IsVirtualRootDir(item fs.Item) bool {
+	dir, ok := item.(*Dir)
+	if !ok || dir.File == nil {
+		return false
+	}
+	return dir.Parent == nil && dir.BasePath == "" && dir.Name == VirtualRootName
+}

--- a/pkg/analyze/virtualroot_test.go
+++ b/pkg/analyze/virtualroot_test.go
@@ -1,0 +1,95 @@
+package analyze
+
+import (
+	"testing"
+
+	"github.com/dundee/gdu/v5/pkg/fs"
+	"github.com/stretchr/testify/assert"
+)
+
+func createScannedRoot(basePath, name string, size int64) *Dir {
+	return &Dir{
+		File: &File{
+			Name: name,
+			Size: size,
+		},
+		BasePath:  basePath,
+		ItemCount: 1,
+		Files: fs.Files{
+			&File{Name: "file", Size: size, Usage: size},
+		},
+	}
+}
+
+func TestCreateVirtualRootDirKeepsRootPaths(t *testing.T) {
+	first := createScannedRoot("/home/user", "projects", 10)
+	second := createScannedRoot("/var", "log", 20)
+
+	root := CreateVirtualRootDir(first, second)
+
+	// the roots gained a parent but must still report their real location
+	assert.Equal(t, "/home/user/projects", first.GetPath())
+	assert.Equal(t, "/var/log", second.GetPath())
+	assert.Equal(t, root, first.GetParent())
+	assert.Equal(t, root, second.GetParent())
+}
+
+func TestCreateVirtualRootDirHasNoFilesystemPath(t *testing.T) {
+	root := CreateVirtualRootDir(createScannedRoot("/var", "log", 1))
+
+	assert.Equal(t, VirtualRootName, root.GetPath())
+	assert.Nil(t, root.GetParent())
+	assert.True(t, root.IsDir())
+}
+
+func TestCreateVirtualRootDirAggregatesStats(t *testing.T) {
+	root := CreateVirtualRootDir(
+		createScannedRoot("/home/user", "projects", 10),
+		createScannedRoot("/var", "log", 20),
+	)
+
+	root.UpdateStats(make(fs.HardLinkedItems))
+
+	assert.Equal(t, int64(30), root.GetSize())
+	assert.Equal(t, int64(30), root.GetUsage())
+	// two roots with one file each, plus the roots and the virtual dir itself
+	assert.Equal(t, int64(5), root.GetItemCount())
+}
+
+func TestCreateVirtualRootDirWithoutRoots(t *testing.T) {
+	root := CreateVirtualRootDir()
+
+	root.UpdateStats(make(fs.HardLinkedItems))
+
+	assert.Equal(t, VirtualRootName, root.GetPath())
+	assert.Equal(t, int64(1), root.GetItemCount())
+}
+
+func TestIsVirtualRootDir(t *testing.T) {
+	scanned := createScannedRoot("/var", "log", 1)
+	root := CreateVirtualRootDir(scanned)
+
+	assert.True(t, IsVirtualRootDir(root))
+	assert.False(t, IsVirtualRootDir(scanned))
+	assert.False(t, IsVirtualRootDir(&File{Name: VirtualRootName}))
+}
+
+// A real directory that happens to be called "(multiple)" must not be mistaken
+// for the virtual root, or gdu would refuse to operate on it.
+func TestIsVirtualRootDirIgnoresRealDirWithSameName(t *testing.T) {
+	scanned := createScannedRoot("/home/user", VirtualRootName, 1)
+
+	assert.False(t, IsVirtualRootDir(scanned))
+}
+
+func TestVirtualRootDirSubtractsStatsOnRemove(t *testing.T) {
+	first := createScannedRoot("/home/user", "projects", 10)
+	second := createScannedRoot("/var", "log", 20)
+	root := CreateVirtualRootDir(first, second)
+	root.UpdateStats(make(fs.HardLinkedItems))
+
+	root.RemoveFile(second)
+
+	assert.Equal(t, int64(10), root.GetSize())
+	assert.Equal(t, int64(10), root.GetUsage())
+}

--- a/report/export.go
+++ b/report/export.go
@@ -150,6 +150,16 @@ func (ui *UI) AnalyzePath(path string, _ fs.Item) error {
 	return ui.exportDir(dir, &waitWritten)
 }
 
+// AnalyzePaths is not supported by the export UI: the ncdu-compatible export
+// format holds exactly one root directory, so there is nowhere to record a
+// virtual dir grouping several of them.
+func (ui *UI) AnalyzePaths(paths []string) error {
+	if len(paths) == 1 {
+		return ui.AnalyzePath(paths[0], nil)
+	}
+	return errors.New("exporting more than one directory is not supported")
+}
+
 func (ui *UI) topDir(dir fs.Item) fs.Item {
 	files := analyze.CollectTopFiles(dir, ui.top)
 

--- a/report/export_test.go
+++ b/report/export_test.go
@@ -478,3 +478,12 @@ func TestFormatSizeDec(t *testing.T) {
 	assert.Contains(t, ui.formatSize(1<<60+1), "EB")
 	assert.Contains(t, ui.formatSize(-1<<10-1), "kB")
 }
+
+func TestAnalyzePathsRejectsMultipleDirs(t *testing.T) {
+	buff := bytes.NewBuffer(make([]byte, 10))
+	ui := CreateExportUI(buff, buff, false, false, false, 0, 0, false, nil)
+
+	err := ui.AnalyzePaths([]string{"test_dir", "other_dir"})
+
+	assert.ErrorContains(t, err, "more than one directory is not supported")
+}

--- a/stdout/multipath_test.go
+++ b/stdout/multipath_test.go
@@ -1,0 +1,100 @@
+package stdout
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dundee/gdu/v5/pkg/analyze"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func createMultiTestDirs(t *testing.T) (first, second string) {
+	t.Helper()
+
+	require.NoError(t, os.MkdirAll("multi_a/nested", os.ModePerm))
+	require.NoError(t, os.MkdirAll("multi_b/other", os.ModePerm))
+	require.NoError(t, os.WriteFile("multi_a/nested/file", []byte("hello"), 0o600))
+	require.NoError(t, os.WriteFile("multi_b/other/file2", []byte("go"), 0o600))
+
+	t.Cleanup(func() {
+		assert.NoError(t, os.RemoveAll("multi_a"))
+		assert.NoError(t, os.RemoveAll("multi_b"))
+	})
+
+	return "multi_a", "multi_b"
+}
+
+func TestAnalyzePathsListsEveryRoot(t *testing.T) {
+	first, second := createMultiTestDirs(t)
+	output := &bytes.Buffer{}
+
+	ui := CreateStdoutUI(output, false, false, false, false, false, false, false, "", 0, false, 0)
+	require.NoError(t, ui.AnalyzePaths([]string{first, second}))
+
+	assert.Contains(t, output.String(), first)
+	assert.Contains(t, output.String(), second)
+}
+
+// Roots from different parents can share a base name, so they are listed by
+// absolute path instead.
+func TestAnalyzePathsLabelsRootsWithTheirPath(t *testing.T) {
+	first := filepath.Join("outer_p", "data")
+	second := filepath.Join("outer_q", "data")
+	for _, dir := range []string{first, second} {
+		require.NoError(t, os.MkdirAll(dir, os.ModePerm))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "file"), []byte("hello"), 0o600))
+	}
+	t.Cleanup(func() {
+		assert.NoError(t, os.RemoveAll("outer_p"))
+		assert.NoError(t, os.RemoveAll("outer_q"))
+	})
+
+	output := &bytes.Buffer{}
+	ui := CreateStdoutUI(output, false, false, false, false, false, false, false, "", 0, false, 0)
+	require.NoError(t, ui.AnalyzePaths([]string{first, second}))
+
+	assert.Contains(t, output.String(), first)
+	assert.Contains(t, output.String(), second)
+	// the path is not given a second leading separator by the directory marker
+	assert.NotContains(t, output.String(), string(filepath.Separator)+first)
+}
+
+func TestAnalyzePathsSummarizeReportsCombinedTotal(t *testing.T) {
+	first, second := createMultiTestDirs(t)
+	output := &bytes.Buffer{}
+
+	ui := CreateStdoutUI(output, false, false, false, false, true, false, false, "", 0, false, 0)
+	require.NoError(t, ui.AnalyzePaths([]string{first, second}))
+
+	assert.NotEmpty(t, output.String())
+}
+
+func TestAnalyzePathsSwapsTopDirAnalyzerForFullTree(t *testing.T) {
+	first, second := createMultiTestDirs(t)
+	output := &bytes.Buffer{}
+
+	ui := CreateStdoutUI(output, false, false, false, false, false, false, false, "", 0, false, 0)
+	// the default stdout analyzer produces SimpleDir, which cannot be re-parented
+	_, isTopDirAnalyzer := ui.Analyzer.(*analyze.TopDirAnalyzer)
+	require.True(t, isTopDirAnalyzer)
+
+	require.NoError(t, ui.AnalyzePaths([]string{first, second}))
+
+	_, stillTopDirAnalyzer := ui.Analyzer.(*analyze.TopDirAnalyzer)
+	assert.False(t, stillTopDirAnalyzer)
+}
+
+func TestAnalyzePathsWithSinglePathBehavesLikeAnalyzePath(t *testing.T) {
+	first, _ := createMultiTestDirs(t)
+	output := &bytes.Buffer{}
+
+	ui := CreateStdoutUI(output, false, false, false, false, false, false, false, "", 0, false, 0)
+	require.NoError(t, ui.AnalyzePaths([]string{first}))
+
+	// contents of the single root are listed, not the root itself
+	assert.Contains(t, output.String(), "nested")
+	assert.NotContains(t, output.String(), analyze.VirtualRootName)
+}

--- a/stdout/stdout.go
+++ b/stdout/stdout.go
@@ -239,6 +239,63 @@ func (ui *UI) AnalyzePath(path string, _ fs.Item) error {
 
 	wait.Wait()
 
+	ui.printAnalyzedDir(dir)
+
+	return nil
+}
+
+// AnalyzePaths analyzes several paths and reports them together, grouped under
+// a virtual top level directory.
+func (ui *UI) AnalyzePaths(paths []string) error {
+	if len(paths) == 1 {
+		return ui.AnalyzePath(paths[0], nil)
+	}
+
+	// The top dir analyzer returns SimpleDir, a reduced item that cannot be
+	// re-parented, so it cannot live under a virtual root. Trade its lower
+	// memory use for the full tree, as --top and --depth already do.
+	if _, ok := ui.Analyzer.(*analyze.TopDirAnalyzer); ok {
+		ui.Analyzer = analyze.CreateAnalyzer()
+	}
+
+	roots := make([]fs.Item, 0, len(paths))
+	for _, path := range paths {
+		// the analyzer owns one set of progress channels per scan, so it has to
+		// be reset before each root - and before updateProgress reads its done
+		// channel
+		ui.Analyzer.ResetProgress()
+
+		var wait sync.WaitGroup
+		updateStatsDone := make(chan struct{}, 1)
+
+		if ui.ShowProgress {
+			wait.Add(1)
+			go func() {
+				defer wait.Done()
+				ui.updateProgress(updateStatsDone)
+			}()
+		}
+
+		root := ui.Analyzer.AnalyzeDir(path, ui.CreateIgnoreFunc(), ui.CreateFileTypeFilter())
+		updateStatsDone <- struct{}{}
+		wait.Wait()
+
+		roots = append(roots, root)
+	}
+
+	dir := analyze.CreateVirtualRootDir(roots...)
+	if ui.IsFilteringFiles() {
+		dir.UpdateStatsWithFileFiltering(make(fs.HardLinkedItems, 10))
+	} else {
+		dir.UpdateStats(make(fs.HardLinkedItems, 10))
+	}
+
+	ui.printAnalyzedDir(dir)
+
+	return nil
+}
+
+func (ui *UI) printAnalyzedDir(dir fs.Item) {
 	switch {
 	case ui.top > 0:
 		ui.printTopFiles(dir)
@@ -249,8 +306,6 @@ func (ui *UI) AnalyzePath(path string, _ fs.Item) error {
 	default:
 		ui.showDir(dir)
 	}
-
-	return nil
 }
 
 // ReadFromStorage reads analysis data from persistent key-value storage
@@ -287,7 +342,7 @@ func (ui *UI) showDir(dir fs.Item) {
 	}
 
 	for file := range dir.GetFiles(sort, sortOrder) {
-		ui.printItem(file)
+		ui.printItem(dir, file)
 	}
 }
 
@@ -321,7 +376,9 @@ func (ui *UI) printTotalItem(file fs.Item) {
 	)
 }
 
-func (ui *UI) printItem(file fs.Item) {
+// printItem prints one row of a directory listing. parent is the directory
+// being listed, which decides how the item is labelled; it may be nil.
+func (ui *UI) printItem(parent, file fs.Item) {
 	var lineFormat string
 	if ui.showItemCnt {
 		if ui.UseColors {
@@ -344,9 +401,14 @@ func (ui *UI) printItem(file fs.Item) {
 		size = file.GetUsage()
 	}
 
-	name := file.GetName()
+	name := analyze.ItemDisplayName(parent, file)
 	if file.IsDir() {
-		name = ui.blue.Sprint("/" + file.GetName())
+		// a scanned root is labelled with its absolute path, which already
+		// reads as a path and must not gain another leading separator
+		if !analyze.IsVirtualRootDir(parent) {
+			name = "/" + name
+		}
+		name = ui.blue.Sprint(name)
 	}
 
 	// Append symlink target with cyan name (like ls --color)

--- a/stdout/stdout_test.go
+++ b/stdout/stdout_test.go
@@ -742,7 +742,7 @@ func TestPrintItemShowsSymlinkTarget(t *testing.T) {
 	ui := CreateStdoutUI(output, false, false, false, false, false, false, false, "", 0, false, 0)
 	ui.SetShowSymlinkTarget(true)
 
-	ui.printItem(newStdoutSymlinkFile())
+	ui.printItem(nil, newStdoutSymlinkFile())
 
 	assert.Contains(t, output.String(), "bin -> usr/bin")
 }
@@ -751,7 +751,7 @@ func TestPrintItemHidesSymlinkTargetByDefault(t *testing.T) {
 	output := bytes.NewBuffer(nil)
 	ui := CreateStdoutUI(output, false, false, false, false, false, false, false, "", 0, false, 0)
 
-	ui.printItem(newStdoutSymlinkFile())
+	ui.printItem(nil, newStdoutSymlinkFile())
 
 	out := output.String()
 	assert.NotContains(t, out, "-> usr/bin")

--- a/tui/actions.go
+++ b/tui/actions.go
@@ -44,11 +44,11 @@ func (ui *UI) ListDevices(getter device.DevicesInfoGetter) error {
 	return nil
 }
 
-// AnalyzePath analyzes recursively disk usage for given path
-func (ui *UI) AnalyzePath(path string, parentDir fs.Item) error {
+// showScanProgressModal builds and shows the modal that reports scan progress.
+func (ui *UI) showScanProgressModal(title string) {
 	ui.progress = tview.NewTextView().SetText("Scanning...")
 	ui.progress.SetBorder(true).SetBorderPadding(2, 2, 2, 2)
-	ui.progress.SetTitle(" Scanning... ")
+	ui.progress.SetTitle(title)
 	ui.progress.SetDynamicColors(true)
 
 	innerFlex := tview.NewFlex().SetDirection(tview.FlexRow).
@@ -72,7 +72,13 @@ func (ui *UI) AnalyzePath(path string, parentDir fs.Item) error {
 
 	ui.pages.AddPage("progress", flex, true, true)
 	ui.progressFlex = flex
+}
 
+// AnalyzePath analyzes recursively disk usage for given path
+func (ui *UI) AnalyzePath(path string, parentDir fs.Item) error {
+	ui.showScanProgressModal(" Scanning... ")
+
+	ui.scanCancelRequested.Store(false)
 	ui.Analyzer.ResetProgress()
 
 	analyzer := ui.Analyzer
@@ -123,6 +129,90 @@ func (ui *UI) AnalyzePath(path string, parentDir fs.Item) error {
 	}()
 
 	return nil
+}
+
+// AnalyzePaths scans several roots one after another and presents them under a
+// virtual top level dir, so that the rest of the UI keeps working on the single
+// rooted tree it expects.
+//
+// The roots are scanned sequentially rather than concurrently because the
+// analyzer owns a single set of progress channels; each root needs the analyzer
+// reset before it starts, which is also why cancellation has to be tracked
+// separately (ResetProgress clears the analyzer's own cancelled flag).
+func (ui *UI) AnalyzePaths(paths []string) error {
+	if len(paths) == 1 {
+		return ui.AnalyzePath(paths[0], nil)
+	}
+
+	ui.showScanProgressModal(scanProgressTitle(1, len(paths)))
+
+	ui.scanCancelRequested.Store(false)
+	ui.scanStart = time.Now()
+	ui.scanning = true
+	ui.scanCancelled = false
+
+	go func() {
+		defer debug.FreeOSMemory()
+
+		roots := make([]fs.Item, 0, len(paths))
+		for i, path := range paths {
+			if i > 0 {
+				title := scanProgressTitle(i+1, len(paths))
+				ui.app.QueueUpdateDraw(func() {
+					ui.progress.SetTitle(title)
+				})
+			}
+
+			ui.Analyzer.ResetProgress()
+			analyzer := ui.Analyzer
+			go ui.updateProgress(analyzer, analyzer.GetDone())
+
+			roots = append(
+				roots,
+				analyzer.AnalyzeDir(path, ui.CreateIgnoreFunc(), ui.CreateFileTypeFilter()),
+			)
+
+			// keep whatever was scanned so far, as a cancelled single scan does
+			if ui.scanCancelRequested.Load() {
+				break
+			}
+		}
+
+		currentDir := analyze.CreateVirtualRootDir(roots...)
+		ui.topDir = currentDir
+		ui.topDirPath = currentDir.GetPath()
+
+		if ui.IsFilteringFiles() {
+			ui.topDir.UpdateStatsWithFileFiltering(ui.linkedItems)
+		} else {
+			ui.topDir.UpdateStats(ui.linkedItems)
+		}
+
+		ui.app.QueueUpdateDraw(func() {
+			ui.scanning = false
+			ui.scanCancelled = false
+			// remember the longest scan so we can guard against accidental quits
+			if d := time.Since(ui.scanStart); d > ui.scanDuration {
+				ui.scanDuration = d
+			}
+			// the finished scan replaces any mid-scan preview
+			ui.previewing = false
+			ui.previewSavedDir = nil
+			ui.currentDir = currentDir
+			ui.showDir()
+			ui.pages.RemovePage("progress")
+		})
+
+		if ui.done != nil {
+			ui.done <- struct{}{}
+		}
+	}()
+
+	return nil
+}
+
+func scanProgressTitle(current, total int) string {
+	return fmt.Sprintf(" Scanning %d/%d... ", current, total)
 }
 
 // ReadAnalysis reads analysis report from JSON file
@@ -411,6 +501,13 @@ func (ui *UI) confirmExport() *tview.Form {
 
 func (ui *UI) exportAnalysis() {
 	ui.pages.RemovePage("export")
+
+	// the export format holds exactly one root, so there is nowhere to put the
+	// virtual dir grouping several of them
+	if analyze.IsVirtualRootDir(ui.topDir) {
+		ui.showMessage("Export is not supported when multiple directories are scanned")
+		return
+	}
 
 	text := tview.NewTextView().SetText("Export in progress...").SetTextAlign(tview.AlignCenter)
 	text.SetBorder(true).SetTitle(" Export data to JSON ")

--- a/tui/exec_other.go
+++ b/tui/exec_other.go
@@ -20,6 +20,10 @@ func (ui *UI) spawnShell() {
 	if ui.currentDir == nil {
 		return
 	}
+	if ui.atVirtualRoot() {
+		ui.showMessage("Shell cannot be spawned at the virtual top level directory")
+		return
+	}
 
 	ui.app.Suspend(func() {
 		if err := os.Chdir(ui.currentDirPath); err != nil {

--- a/tui/exec_windows.go
+++ b/tui/exec_windows.go
@@ -16,6 +16,10 @@ func (ui *UI) spawnShell() {
 	if ui.currentDir == nil {
 		return
 	}
+	if ui.atVirtualRoot() {
+		ui.showMessage("Shell cannot be spawned at the virtual top level directory")
+		return
+	}
 
 	ui.app.Stop()
 

--- a/tui/format.go
+++ b/tui/format.go
@@ -173,6 +173,14 @@ func (ui *UI) formatColumns(statsItem fs.Item, maxima rowMaxima, marked, ignored
 	return row
 }
 
+// dirRowStyle returns the styling that introduces a directory name in a row.
+func (ui *UI) dirRowStyle(marked, ignored bool) string {
+	if ui.UseColors && !marked && !ignored {
+		return fmt.Sprintf("[%s::b]", ui.resultRow.DirectoryColor)
+	}
+	return defaultColorBold
+}
+
 func (ui *UI) formatFileRow(item fs.Item, maxima rowMaxima, marked, ignored bool) string {
 	row := ui.formatColumns(item, maxima, marked, ignored)
 
@@ -181,12 +189,14 @@ func (ui *UI) formatFileRow(item fs.Item, maxima rowMaxima, marked, ignored bool
 		return row + name
 	}
 
+	// Scanned roots are labelled with their absolute path, which already reads
+	// as a path and must not be given another leading separator.
+	if ui.atVirtualRoot() {
+		return row + ui.dirRowStyle(marked, ignored) + tview.Escape(item.GetPath())
+	}
+
 	if item.IsDir() {
-		if ui.UseColors && !marked && !ignored {
-			row += fmt.Sprintf("[%s::b]/", ui.resultRow.DirectoryColor)
-		} else {
-			row += defaultColorBold + "/"
-		}
+		row += ui.dirRowStyle(marked, ignored) + "/"
 	}
 	row += tview.Escape(item.GetName())
 
@@ -225,10 +235,10 @@ func (ui *UI) formatCollapsedRow(
 	row := ui.formatColumns(collapsedPath.DeepestDir, maxima, marked, ignored)
 
 	// Always display as directory with special formatting for collapsed path
-	if ui.UseColors && !marked && !ignored {
-		row += fmt.Sprintf("[%s::b]/", ui.resultRow.DirectoryColor)
-	} else {
-		row += defaultColorBold + "/"
+	row += ui.dirRowStyle(marked, ignored)
+	// a collapsed scanned root already starts from an absolute path
+	if !ui.atVirtualRoot() {
+		row += "/"
 	}
 
 	// Display the collapsed path (e.g., "a/b/c")

--- a/tui/keys.go
+++ b/tui/keys.go
@@ -532,7 +532,8 @@ func (ui *UI) handleLeft() {
 }
 
 func (ui *UI) analyzeParentOfTopDir() {
-	if ui.currentDir == nil || ui.isInArchive() {
+	// the virtual root has no parent on disk to browse up into
+	if ui.currentDir == nil || ui.isInArchive() || ui.atVirtualRoot() {
 		return
 	}
 

--- a/tui/multipath_test.go
+++ b/tui/multipath_test.go
@@ -1,0 +1,223 @@
+package tui
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dundee/gdu/v5/internal/testapp"
+	"github.com/dundee/gdu/v5/pkg/analyze"
+	"github.com/gdamore/tcell/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// createMultiTestDirs creates two sibling directories to be scanned together.
+func createMultiTestDirs(t *testing.T) (first, second string) {
+	t.Helper()
+
+	require.NoError(t, os.MkdirAll("multi_a/nested", os.ModePerm))
+	require.NoError(t, os.MkdirAll("multi_b/other", os.ModePerm))
+	require.NoError(t, os.WriteFile("multi_a/nested/file", []byte("hello"), 0o600))
+	require.NoError(t, os.WriteFile("multi_b/other/file2", []byte("go"), 0o600))
+
+	t.Cleanup(func() {
+		assert.NoError(t, os.RemoveAll("multi_a"))
+		assert.NoError(t, os.RemoveAll("multi_b"))
+	})
+
+	return "multi_a", "multi_b"
+}
+
+// createNestedTestDirs creates two directories that share a base name but live
+// under different parents.
+func createNestedTestDirs(t *testing.T) (first, second string) {
+	first = filepath.Join("outer_p", "data")
+	second = filepath.Join("outer_q", "data")
+
+	for _, dir := range []string{first, second} {
+		require.NoError(t, os.MkdirAll(dir, os.ModePerm))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "file"), []byte("hello"), 0o600))
+	}
+
+	t.Cleanup(func() {
+		assert.NoError(t, os.RemoveAll("outer_p"))
+		assert.NoError(t, os.RemoveAll("outer_q"))
+	})
+
+	return first, second
+}
+
+// analyzeMultiplePaths runs a multi-root scan to completion and flushes the
+// queued UI updates, as the TUI tests do for single-path scans.
+func analyzeMultiplePaths(t *testing.T, paths []string) *UI {
+	t.Helper()
+
+	simScreen := testapp.CreateSimScreen()
+	t.Cleanup(simScreen.Fini)
+
+	app := testapp.CreateMockedApp(true)
+	ui := CreateUI(app, simScreen, &bytes.Buffer{}, true, true, false, false)
+	ui.done = make(chan struct{})
+
+	require.NoError(t, ui.AnalyzePaths(paths))
+
+	<-ui.done
+	for _, draw := range ui.app.(*testapp.MockedApp).GetUpdateDraws() {
+		draw()
+	}
+
+	return ui
+}
+
+func TestAnalyzePathsGroupsRootsUnderVirtualDir(t *testing.T) {
+	first, second := createMultiTestDirs(t)
+
+	ui := analyzeMultiplePaths(t, []string{first, second})
+
+	assert.True(t, analyze.IsVirtualRootDir(ui.currentDir))
+	assert.Equal(t, analyze.VirtualRootName, ui.topDirPath)
+	// no "/.." row is shown at the top, so the rows are exactly the two roots
+	assert.Equal(t, 2, ui.table.GetRowCount())
+
+	names := []string{ui.table.GetCell(0, 0).Text, ui.table.GetCell(1, 0).Text}
+	assert.Contains(t, names[0]+names[1], first)
+	assert.Contains(t, names[0]+names[1], second)
+}
+
+// Roots from different parents can share a base name, so rows under the virtual
+// top level dir are labelled with the absolute path instead.
+func TestRootsAreLabelledWithTheirAbsolutePath(t *testing.T) {
+	first, second := createNestedTestDirs(t)
+
+	ui := analyzeMultiplePaths(t, []string{first, second})
+
+	rows := ui.table.GetCell(0, 0).Text + "\n" + ui.table.GetCell(1, 0).Text
+	assert.Contains(t, rows, first)
+	assert.Contains(t, rows, second)
+	// the path is not given a second leading separator by the directory marker
+	assert.NotContains(t, rows, string(filepath.Separator)+first)
+}
+
+func TestRootsKeepBaseNamesBelowTheVirtualDir(t *testing.T) {
+	first, second := createMultiTestDirs(t)
+	ui := analyzeMultiplePaths(t, []string{first, second})
+
+	// descend into the first root; its children are ordinary rows again
+	ui.table.Select(0, 0)
+	ui.handleRight()
+
+	assert.False(t, analyze.IsVirtualRootDir(ui.currentDir))
+	assert.Contains(t, ui.table.GetCell(1, 0).Text, "/nested")
+}
+
+func TestFilteringAtVirtualRootMatchesThePathShown(t *testing.T) {
+	first, second := createNestedTestDirs(t)
+	ui := analyzeMultiplePaths(t, []string{first, second})
+
+	// "outer_p" appears only in the path, never in the base name
+	ui.filterValue = "outer_p"
+	ui.showDir()
+
+	assert.Equal(t, 1, ui.table.GetRowCount())
+	assert.Contains(t, ui.table.GetCell(0, 0).Text, first)
+}
+
+func TestAnalyzePathsKeepsRealPathsOfRoots(t *testing.T) {
+	first, second := createMultiTestDirs(t)
+
+	ui := analyzeMultiplePaths(t, []string{first, second})
+
+	paths := ui.scannedRootPaths()
+	assert.ElementsMatch(t, []string{first, second}, paths)
+}
+
+func TestAnalyzePathsSumsRootStats(t *testing.T) {
+	first, second := createMultiTestDirs(t)
+
+	ui := analyzeMultiplePaths(t, []string{first, second})
+
+	var rootSize int64
+	for item := range ui.currentDir.GetFiles(0, 0) {
+		rootSize += item.GetSize()
+	}
+	assert.Equal(t, rootSize, ui.currentDir.GetSize())
+}
+
+func TestAnalyzePathsWithSinglePathHasNoVirtualDir(t *testing.T) {
+	first, _ := createMultiTestDirs(t)
+
+	ui := analyzeMultiplePaths(t, []string{first})
+
+	assert.False(t, analyze.IsVirtualRootDir(ui.currentDir))
+	assert.Equal(t, first, ui.currentDir.GetName())
+}
+
+func TestEnteringAndLeavingARootUnderTheVirtualDir(t *testing.T) {
+	first, second := createMultiTestDirs(t)
+	ui := analyzeMultiplePaths(t, []string{first, second})
+
+	// enter the first root
+	ui.table.Select(0, 0)
+	enteredName := ui.currentDir.GetName()
+	ui.handleRight()
+	assert.NotEqual(t, enteredName, ui.currentDir.GetName())
+	assert.False(t, analyze.IsVirtualRootDir(ui.currentDir))
+
+	// and back out to the virtual root via the "/.." row
+	ui.handleLeft()
+	assert.True(t, analyze.IsVirtualRootDir(ui.currentDir))
+}
+
+func TestHandleLeftAtVirtualRootDoesNotBrowseParent(t *testing.T) {
+	first, second := createMultiTestDirs(t)
+	ui := analyzeMultiplePaths(t, []string{first, second})
+	ui.SetBrowseParentDirs()
+
+	ui.handleLeft()
+
+	// the virtual root has no parent on disk, so nothing may be rescanned
+	assert.True(t, analyze.IsVirtualRootDir(ui.currentDir))
+	assert.Equal(t, analyze.VirtualRootName, ui.topDirPath)
+}
+
+func TestRescanAtVirtualRootRescansAllRoots(t *testing.T) {
+	first, second := createMultiTestDirs(t)
+	ui := analyzeMultiplePaths(t, []string{first, second})
+
+	ui.done = make(chan struct{})
+	ui.rescanDir()
+	<-ui.done
+	for _, draw := range ui.app.(*testapp.MockedApp).GetUpdateDraws() {
+		draw()
+	}
+
+	assert.True(t, analyze.IsVirtualRootDir(ui.currentDir))
+	assert.ElementsMatch(t, []string{first, second}, ui.scannedRootPaths())
+}
+
+func TestExportAtVirtualRootIsRejected(t *testing.T) {
+	first, second := createMultiTestDirs(t)
+	ui := analyzeMultiplePaths(t, []string{first, second})
+
+	ui.exportAnalysis()
+
+	assert.Contains(t, ui.header.GetText(false), "Export is not supported")
+	assert.False(t, ui.pages.HasPage("exporting"))
+}
+
+func TestSpawnShellAtVirtualRootIsRejected(t *testing.T) {
+	first, second := createMultiTestDirs(t)
+	ui := analyzeMultiplePaths(t, []string{first, second})
+	called := false
+	ui.exec = func(argv0 string, argv, envv []string) error {
+		called = true
+		return nil
+	}
+
+	assert.Nil(t, ui.keyPressed(tcell.NewEventKey(tcell.KeyRune, 'b', 0)))
+
+	assert.False(t, called)
+	assert.Contains(t, ui.header.GetText(false), "Shell cannot be spawned")
+}

--- a/tui/show.go
+++ b/tui/show.go
@@ -11,6 +11,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/dundee/gdu/v5/build"
+	"github.com/dundee/gdu/v5/pkg/analyze"
 	"github.com/dundee/gdu/v5/pkg/fs"
 )
 
@@ -67,6 +68,20 @@ func (ui *UI) currentDirLabelText() string {
 	return label
 }
 
+// followCurrentDirWithCwd moves the process working directory to the directory
+// being shown, when --change-cwd is enabled. The virtual top level dir has no
+// counterpart on disk, so it is skipped.
+func (ui *UI) followCurrentDirWithCwd() {
+	if ui.changeCwdFn == nil || ui.atVirtualRoot() {
+		return
+	}
+
+	if err := ui.changeCwdFn(ui.currentDirPath); err != nil {
+		log.Printf("error setting cwd: %s", err.Error())
+	}
+	log.Printf("changing cwd to %s", ui.currentDirPath)
+}
+
 // nolint: funlen // Why: complex function
 func (ui *UI) showDir() {
 	var (
@@ -78,13 +93,7 @@ func (ui *UI) showDir() {
 
 	ui.currentDirPath = ui.currentDir.GetPath()
 
-	if ui.changeCwdFn != nil {
-		err := ui.changeCwdFn(ui.currentDirPath)
-		if err != nil {
-			log.Printf("error setting cwd: %s", err.Error())
-		}
-		log.Printf("changing cwd to %s", ui.currentDirPath)
-	}
+	ui.followCurrentDirWithCwd()
 
 	ui.currentDirLabel.SetText(ui.currentDirLabelText()).SetDynamicColors(true)
 
@@ -143,8 +152,10 @@ func (ui *UI) showDir() {
 	}
 
 	for item := range ui.currentDir.GetFiles(sortBy, sortOrder) {
+		// filter on the label the row actually shows, which for a scanned root
+		// under the virtual top level dir is its absolute path
 		if ui.filterValue != "" && !strings.Contains(
-			strings.ToLower(item.GetName()),
+			strings.ToLower(analyze.ItemDisplayName(ui.currentDir, item)),
 			strings.ToLower(ui.filterValue),
 		) {
 			continue

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 	"unicode"
@@ -106,11 +107,16 @@ type UI struct {
 	confirmQuit             bool
 	scanning                bool
 	scanCancelled           bool
-	scanStart               time.Time
-	scanDuration            time.Duration
-	previewing              bool
-	previewSavedDir         fs.Item
-	progressFlex            *tview.Flex
+	// scanCancelRequested mirrors scanCancelled for readers outside the UI
+	// goroutine. A multi-root scan resets the analyzer between roots, which
+	// clears the analyzer's own cancelled flag, so the request has to survive
+	// somewhere the scanning goroutine can safely read it.
+	scanCancelRequested atomic.Bool
+	scanStart           time.Time
+	scanDuration        time.Duration
+	previewing          bool
+	previewSavedDir     fs.Item
+	progressFlex        *tview.Flex
 }
 
 type deleteQueueItem struct {
@@ -432,6 +438,7 @@ func (ui *UI) cancelScan() bool {
 
 	ui.Analyzer.Cancel()
 	ui.scanCancelled = true
+	ui.scanCancelRequested.Store(true)
 	ui.progress.SetTitle(" Stopping scan... ")
 	ui.progress.SetText("Stopping scan and keeping results...")
 	return true
@@ -507,12 +514,37 @@ func (ui *UI) resetSorting() {
 	ui.sortOrder = ui.defaultSortOrder
 }
 
+// atVirtualRoot reports whether the view is at the synthetic dir grouping
+// several scanned roots. That dir has no path on disk, so operations that
+// resolve currentDirPath back to the filesystem must not run there.
+func (ui *UI) atVirtualRoot() bool {
+	return analyze.IsVirtualRootDir(ui.currentDir)
+}
+
 func (ui *UI) rescanDir() {
 	ui.linkedItems = make(fs.HardLinkedItems)
+
+	// at the virtual root there is nothing to rescan but the roots below it
+	if ui.atVirtualRoot() {
+		if err := ui.AnalyzePaths(ui.scannedRootPaths()); err != nil {
+			ui.showErr("Error rescanning paths", err)
+		}
+		return
+	}
+
 	err := ui.AnalyzePath(ui.currentDirPath, ui.currentDir.GetParent())
 	if err != nil {
 		ui.showErr("Error rescanning path", err)
 	}
+}
+
+// scannedRootPaths returns the paths of the roots grouped under the virtual root.
+func (ui *UI) scannedRootPaths() []string {
+	paths := make([]string, 0)
+	for item := range ui.currentDir.GetFiles(fs.SortByName, fs.SortAsc) {
+		paths = append(paths, item.GetPath())
+	}
+	return paths
 }
 
 func (ui *UI) fileItemSelected(row, column int) {

--- a/tui/utils.go
+++ b/tui/utils.go
@@ -4,6 +4,7 @@ import (
 	"path/filepath"
 	"slices"
 
+	"github.com/dundee/gdu/v5/pkg/analyze"
 	"github.com/dundee/gdu/v5/pkg/device"
 	"github.com/dundee/gdu/v5/pkg/fs"
 	"github.com/rivo/tview"
@@ -131,8 +132,12 @@ func findCollapsiblePath(item fs.Item) *CollapsedPath {
 		return nil
 	}
 
+	// a collapsed chain starting at a scanned root is labelled from its
+	// absolute path, as an uncollapsed root would be
+	base := analyze.ItemDisplayName(item.GetParent(), item)
+
 	return &CollapsedPath{
-		DisplayName: filepath.Join(slices.Concat([]string{item.GetName()}, segments)...),
+		DisplayName: filepath.Join(slices.Concat([]string{base}, segments)...),
 		DeepestDir:  current,
 		Segments:    segments,
 	}

--- a/webui/multipath_test.go
+++ b/webui/multipath_test.go
@@ -1,0 +1,86 @@
+package webui
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/dundee/gdu/v5/pkg/analyze"
+	"github.com/dundee/gdu/v5/pkg/fs"
+)
+
+func TestAnalyzePathsGroupsRootsUnderVirtualDir(t *testing.T) {
+	ui := newTestUI()
+	first := makeTree(t)
+	second := makeTree(t)
+
+	if err := ui.AnalyzePaths([]string{first, second}); err != nil {
+		t.Fatalf("AnalyzePaths: %v", err)
+	}
+	waitDone(t, ui)
+
+	if !analyze.IsVirtualRootDir(ui.topDir) {
+		t.Fatalf("expected virtual root, got %T named %q", ui.topDir, ui.topDir.GetName())
+	}
+	if ui.topDirPath != analyze.VirtualRootName {
+		t.Errorf("topDirPath = %q, want %q", ui.topDirPath, analyze.VirtualRootName)
+	}
+
+	// both roots are reachable and keep their real paths
+	for _, path := range []string{first, second} {
+		if _, err := ui.findNode(path); err != nil {
+			t.Errorf("findNode(%q): %v", path, err)
+		}
+	}
+
+	// so is a directory inside one of them
+	if _, err := ui.findNode(filepath.Join(first, "sub")); err != nil {
+		t.Errorf("findNode(sub of first root): %v", err)
+	}
+
+	// and the virtual root itself, as reached from a breadcrumb
+	node, err := ui.findNode(analyze.VirtualRootName)
+	if err != nil {
+		t.Fatalf("findNode(virtual root): %v", err)
+	}
+	resp := buildNodeResponse(node, fs.SortBySize, fs.SortDesc)
+	if len(resp.Children) != 2 {
+		t.Fatalf("virtual root has %d children, want 2", len(resp.Children))
+	}
+
+	// roots are labelled by absolute path, as their base names can collide
+	for _, child := range resp.Children {
+		if child.Name != child.Path {
+			t.Errorf("root labelled %q, want its path %q", child.Name, child.Path)
+		}
+	}
+}
+
+func TestFindNodeRejectsPathOutsideEveryRoot(t *testing.T) {
+	ui := newTestUI()
+
+	if err := ui.AnalyzePaths([]string{makeTree(t), makeTree(t)}); err != nil {
+		t.Fatalf("AnalyzePaths: %v", err)
+	}
+	waitDone(t, ui)
+
+	if _, err := ui.findNode(filepath.Join(t.TempDir(), "elsewhere")); err == nil {
+		t.Error("expected an error for a path outside every scanned root")
+	}
+}
+
+func TestAnalyzePathsWithSinglePathHasNoVirtualDir(t *testing.T) {
+	ui := newTestUI()
+	root := makeTree(t)
+
+	if err := ui.AnalyzePaths([]string{root}); err != nil {
+		t.Fatalf("AnalyzePaths: %v", err)
+	}
+	waitDone(t, ui)
+
+	if analyze.IsVirtualRootDir(ui.topDir) {
+		t.Error("single path must not be wrapped in a virtual root")
+	}
+	if ui.topDirPath != root {
+		t.Errorf("topDirPath = %q, want %q", ui.topDirPath, root)
+	}
+}

--- a/webui/tree.go
+++ b/webui/tree.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/dundee/gdu/v5/pkg/analyze"
 	"github.com/dundee/gdu/v5/pkg/fs"
 )
 
@@ -42,7 +43,9 @@ func toNodeJSON(it fs.Item) nodeJSON {
 		flag = string(f)
 	}
 	return nodeJSON{
-		Name:      it.GetName(),
+		// scanned roots are labelled with their absolute path, since their base
+		// names collide when the roots come from different parent directories
+		Name:      analyze.ItemDisplayName(it.GetParent(), it),
 		Path:      it.GetPath(),
 		IsDir:     it.IsDir(),
 		Size:      it.GetSize(),
@@ -73,6 +76,27 @@ func (ui *UI) findNode(path string) (fs.Item, error) {
 		return root, nil
 	}
 	cleanPath := filepath.Clean(path)
+	if cleanPath == cleanRoot {
+		return root, nil
+	}
+
+	// The virtual top level dir has no path of its own, so paths are resolved
+	// against each of the scanned roots it holds instead.
+	if analyze.IsVirtualRootDir(root) {
+		for child := range root.GetFiles(fs.SortByName, fs.SortAsc) {
+			if node, err := descendFrom(child, child.GetPath(), cleanPath); err == nil {
+				return node, nil
+			}
+		}
+		return nil, errOutsideRoot
+	}
+
+	return descendFrom(root, cleanRoot, cleanPath)
+}
+
+// descendFrom walks from root, which lives at cleanRoot, down to cleanPath.
+// It guards against path traversal outside the root.
+func descendFrom(root fs.Item, cleanRoot, cleanPath string) (fs.Item, error) {
 	if cleanPath == cleanRoot {
 		return root, nil
 	}

--- a/webui/webui.go
+++ b/webui/webui.go
@@ -148,6 +148,54 @@ func (ui *UI) AnalyzePath(path string, parentDir fs.Item) error {
 	return nil
 }
 
+// AnalyzePaths scans several roots one after another and serves them under a
+// virtual top level dir. The roots are scanned sequentially because the
+// analyzer owns a single set of progress channels.
+func (ui *UI) AnalyzePaths(paths []string) error {
+	if len(paths) == 1 {
+		return ui.AnalyzePath(paths[0], nil)
+	}
+
+	ui.mu.Lock()
+	ui.scanning = true
+	ui.scanErr = nil
+	ui.topDirPath = analyze.VirtualRootName
+	ui.mu.Unlock()
+
+	go func() {
+		roots := make([]fs.Item, 0, len(paths))
+		for _, path := range paths {
+			ui.Analyzer.ResetProgress()
+
+			scanDone := make(chan struct{})
+			go ui.pollProgress(scanDone)
+
+			roots = append(
+				roots,
+				ui.Analyzer.AnalyzeDir(path, ui.CreateIgnoreFunc(), ui.CreateFileTypeFilter()),
+			)
+			close(scanDone)
+		}
+
+		dir := analyze.CreateVirtualRootDir(roots...)
+		if ui.IsFilteringFiles() {
+			dir.UpdateStatsWithFileFiltering(ui.linkedItems)
+		} else {
+			dir.UpdateStats(ui.linkedItems)
+		}
+
+		ui.mu.Lock()
+		ui.topDir = dir
+		ui.topDirPath = dir.GetPath()
+		ui.scanning = false
+		ui.mu.Unlock()
+
+		ui.hub.publish(ui.statusJSON())
+	}()
+
+	return nil
+}
+
 // ReadAnalysis reads an analysis report from a JSON reader and serves it.
 func (ui *UI) ReadAnalysis(input io.Reader) error {
 	ui.mu.Lock()


### PR DESCRIPTION
Gdu accepted exactly one directory to scan, so looking at a subset of a large directory's children meant either scanning all of it or running gdu once per child - which defeats the point of comparing them.

Several directories can now be given. They are scanned one after another and grouped under a virtual top level directory, so everything downstream keeps working on the single rooted tree it already expects. The roots keep their own BasePath, so they still report their real path, and they are labelled with it: base names collide as soon as two roots come from different parents.

Operations that need a path on disk are refused while the virtual root is shown (--change-cwd, spawning a shell, --browse-parent-dirs and export); rescanning it rescans every root below it.

Nested directories are rejected, as scanning both would count the nested part twice. Export (-o) and database storage (--db) are keyed by a single root and accept one directory only.

Closes #423