### PR TITLE
fix(report): honor --summarize and --depth for stored and archived items

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Flags:
       --collapse-path                 Collapse single-child directory chains
       --config-file string            Read config from file (default is $HOME/.gdu.yaml)
   -D, --db string                     Store analysis in database (*.sqlite for SQLite, *.badger for BadgerDB)
-      --depth int                     Show directory structure up to specified depth in non-interactive mode (0 means the flag is ignored)
+      --depth int                     Show directory structure up to specified depth in non-interactive mode (0 means the flag is ignored); also limits entries inside browsed archives
       --enable-profiling              Enable collection of profiling data and provide it on http://localhost:6060/debug/pprof/
   -E, --exclude-type strings          File types to exclude (e.g., --exclude-type yaml,json)
   -L, --follow-symlinks               Follow symlinks for files, i.e. show the size of the file to which symlink points to (symlinks to directories are not followed)

--- a/cmd/gdu/main.go
+++ b/cmd/gdu/main.go
@@ -95,7 +95,9 @@ func init() {
 	flags.BoolVarP(&af.NoUnicode, "no-unicode", "u", false, "Do not use Unicode symbols (for size bar)")
 	flags.BoolVarP(&af.Summarize, "summarize", "s", false, "Show only a total in non-interactive mode")
 	flags.IntVarP(&af.Top, "top", "t", 0, "Show only top X largest files in non-interactive mode")
-	flags.IntVar(&af.Depth, "depth", 0, "Show directory structure up to specified depth in non-interactive mode (0 means the flag is ignored)")
+	flags.IntVar(&af.Depth, "depth", 0,
+		"Show directory structure up to specified depth in non-interactive mode"+
+			" (0 means the flag is ignored); also limits entries inside browsed archives")
 	flags.BoolVar(&af.UseSIPrefix, "si", false, "Show sizes with decimal SI prefixes (kB, MB, GB) instead of binary prefixes (KiB, MiB, GiB)")
 	flags.BoolVar(&af.NoPrefix, "no-prefix", false, "Show sizes as raw numbers without any prefixes (SI or binary) in non-interactive mode")
 	flags.BoolVarP(&af.ShowInKiB, "show-in-kib", "k", false, "Show sizes in KiB (or kB with --si) in non-interactive mode")

--- a/gdu.1.md
+++ b/gdu.1.md
@@ -95,7 +95,7 @@ non-interactive mode
 
 **\--archive-browsing**\[=false\] Enable browsing of zip/jar/tar archives (tar, tar.gz, tar.bz2, tar.xz)
 
-**\--depth**\[=0\] Show directory structure up to specified depth in non-interactive mode (0 means the flag is ignored)
+**\--depth**\[=0\] Show directory structure up to specified depth in non-interactive mode (0 means the flag is ignored); also limits entries inside browsed archives
 
 **\--collapse-path**\[=false\] Collapse single-child directory chains
 

--- a/report/export.go
+++ b/report/export.go
@@ -193,38 +193,47 @@ func (ui *UI) topDir(dir fs.Item) fs.Item {
 }
 
 func (ui *UI) limitDirByDepth(dir fs.Item, currentDepth int) fs.Item {
-	if d, ok := dir.(*analyze.Dir); ok {
-		limited := &analyze.Dir{
-			File: &analyze.File{
-				Name:   d.GetName(),
-				Mtime:  d.GetMtime(),
-				Parent: d.GetParent(),
-				Size:   d.GetSize(),
-				Usage:  d.GetUsage(),
-			},
-			BasePath:  d.BasePath,
-			ItemCount: d.ItemCount,
-		}
-		if currentDepth == ui.depth {
-			return limited
-		}
-		for f := range d.GetFiles(fs.SortBySize, fs.SortDesc) {
-			if f.IsDir() {
-				child := ui.limitDirByDepth(f, currentDepth+1)
-				if child != nil {
-					child.SetParent(limited)
-					limited.AddFile(child)
-				}
-			} else if currentDepth+1 <= ui.depth {
-				file := *f.(*analyze.File)
-				file.Parent = limited
-				limited.AddFile(&file)
-			}
-		}
-		return limited
+	if !dir.IsDir() {
+		return dir
 	}
 
-	return dir
+	limited := &analyze.Dir{
+		File: &analyze.File{
+			Name:   dir.GetName(),
+			Flag:   dir.GetFlag(),
+			Mtime:  dir.GetMtime(),
+			Parent: dir.GetParent(),
+			Size:   dir.GetSize(),
+			Usage:  dir.GetUsage(),
+		},
+		ItemCount: dir.GetItemCount(),
+	}
+	if d, ok := dir.(*analyze.Dir); ok {
+		limited.BasePath = d.BasePath
+	}
+	if currentDepth == ui.depth {
+		return limited
+	}
+	for f := range dir.GetFiles(fs.SortBySize, fs.SortDesc) {
+		if f.IsDir() {
+			child := ui.limitDirByDepth(f, currentDepth+1)
+			if child != nil {
+				child.SetParent(limited)
+				limited.AddFile(child)
+			}
+		} else if currentDepth+1 <= ui.depth {
+			limited.AddFile(&analyze.File{
+				Name:   f.GetName(),
+				Flag:   f.GetFlag(),
+				Size:   f.GetSize(),
+				Usage:  f.GetUsage(),
+				Mtime:  f.GetMtime(),
+				Mli:    f.GetMultiLinkedInode(),
+				Parent: limited,
+			})
+		}
+	}
+	return limited
 }
 
 func (ui *UI) summarizeDir(dir fs.Item) fs.Item {
@@ -232,13 +241,13 @@ func (ui *UI) summarizeDir(dir fs.Item) fs.Item {
 		File: &analyze.File{
 			Name:  dir.GetName(),
 			Mtime: dir.GetMtime(),
+			Size:  dir.GetSize(),
+			Usage: dir.GetUsage(),
 		},
+		ItemCount: dir.GetItemCount(),
 	}
 	if d, ok := dir.(*analyze.Dir); ok {
 		summary.BasePath = d.BasePath
-		summary.ItemCount = d.ItemCount
-		summary.Size = d.GetSize()
-		summary.Usage = d.GetUsage()
 	}
 	return summary
 }

--- a/report/export.go
+++ b/report/export.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"math"
 	"os"
+	"path/filepath"
 	"strconv"
 	"sync"
 	"time"
@@ -162,31 +163,50 @@ func (ui *UI) AnalyzePaths(paths []string) error {
 	return errors.New("exporting more than one directory is not supported")
 }
 
+// exportedDir copies the attributes of dir that the export can emit. The
+// export filters can receive any fs.Item implementation (a plain scan,
+// analyses stored in SQLite/BadgerDB, entries inside browsed archives, ...),
+// so the copy reads everything through the interface instead of type-asserting
+// *analyze.Dir. BasePath is not part of the interface and is rebuilt from
+// GetPath, so the top-level entry keeps its full path in the export.
+func exportedDir(dir fs.Item) *analyze.Dir {
+	return &analyze.Dir{
+		File: &analyze.File{
+			Name:  dir.GetName(),
+			Flag:  dir.GetFlag(),
+			Mtime: dir.GetMtime(),
+			Size:  dir.GetSize(),
+			Usage: dir.GetUsage(),
+		},
+		BasePath:  filepath.Dir(dir.GetPath()),
+		ItemCount: dir.GetItemCount(),
+	}
+}
+
+// exportedFile copies the attributes of a file the export can emit, reading
+// them through the fs.Item interface for the same reason as exportedDir.
+func exportedFile(file, parent fs.Item) *analyze.File {
+	copied := &analyze.File{
+		Name:   file.GetName(),
+		Flag:   file.GetFlag(),
+		Size:   file.GetSize(),
+		Usage:  file.GetUsage(),
+		Mtime:  file.GetMtime(),
+		Mli:    file.GetMultiLinkedInode(),
+		Parent: parent,
+	}
+	if symlink, ok := file.(fs.SymlinkItem); ok {
+		copied.Symlink = symlink.GetSymlinkTarget()
+	}
+	return copied
+}
+
 func (ui *UI) topDir(dir fs.Item) fs.Item {
 	files := analyze.CollectTopFiles(dir, ui.top)
 
-	topDir := &analyze.Dir{
-		File: &analyze.File{
-			Name:  dir.GetName(),
-			Mtime: dir.GetMtime(),
-		},
-	}
-	if d, ok := dir.(*analyze.Dir); ok {
-		topDir.BasePath = d.BasePath
-	}
+	topDir := exportedDir(dir)
 	for _, f := range files {
-		// CollectTopFiles can return any fs.Item implementation (files stored in
-		// SQLite/BadgerDB, entries inside browsed archives, ...), so copy the
-		// attributes through the interface instead of type-asserting *analyze.File.
-		topDir.AddFile(&analyze.File{
-			Name:   f.GetName(),
-			Flag:   f.GetFlag(),
-			Size:   f.GetSize(),
-			Usage:  f.GetUsage(),
-			Mtime:  f.GetMtime(),
-			Mli:    f.GetMultiLinkedInode(),
-			Parent: topDir,
-		})
+		topDir.AddFile(exportedFile(f, topDir))
 	}
 	topDir.UpdateStats(make(fs.HardLinkedItems, 10))
 	return topDir
@@ -197,59 +217,24 @@ func (ui *UI) limitDirByDepth(dir fs.Item, currentDepth int) fs.Item {
 		return dir
 	}
 
-	limited := &analyze.Dir{
-		File: &analyze.File{
-			Name:   dir.GetName(),
-			Flag:   dir.GetFlag(),
-			Mtime:  dir.GetMtime(),
-			Parent: dir.GetParent(),
-			Size:   dir.GetSize(),
-			Usage:  dir.GetUsage(),
-		},
-		ItemCount: dir.GetItemCount(),
-	}
-	if d, ok := dir.(*analyze.Dir); ok {
-		limited.BasePath = d.BasePath
-	}
+	limited := exportedDir(dir)
 	if currentDepth == ui.depth {
 		return limited
 	}
 	for f := range dir.GetFiles(fs.SortBySize, fs.SortDesc) {
 		if f.IsDir() {
 			child := ui.limitDirByDepth(f, currentDepth+1)
-			if child != nil {
-				child.SetParent(limited)
-				limited.AddFile(child)
-			}
+			child.SetParent(limited)
+			limited.AddFile(child)
 		} else if currentDepth+1 <= ui.depth {
-			limited.AddFile(&analyze.File{
-				Name:   f.GetName(),
-				Flag:   f.GetFlag(),
-				Size:   f.GetSize(),
-				Usage:  f.GetUsage(),
-				Mtime:  f.GetMtime(),
-				Mli:    f.GetMultiLinkedInode(),
-				Parent: limited,
-			})
+			limited.AddFile(exportedFile(f, limited))
 		}
 	}
 	return limited
 }
 
 func (ui *UI) summarizeDir(dir fs.Item) fs.Item {
-	summary := &analyze.Dir{
-		File: &analyze.File{
-			Name:  dir.GetName(),
-			Mtime: dir.GetMtime(),
-			Size:  dir.GetSize(),
-			Usage: dir.GetUsage(),
-		},
-		ItemCount: dir.GetItemCount(),
-	}
-	if d, ok := dir.(*analyze.Dir); ok {
-		summary.BasePath = d.BasePath
-	}
-	return summary
+	return exportedDir(dir)
 }
 
 func (ui *UI) exportDir(dir fs.Item, waitWritten *sync.WaitGroup) error {

--- a/report/export_hardlink_test.go
+++ b/report/export_hardlink_test.go
@@ -1,0 +1,28 @@
+//go:build !windows
+
+package report
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"github.com/dundee/gdu/v5/internal/testdir"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAnalyzePathWithDepthKeepsHardLinkAttrs(t *testing.T) {
+	fin := testdir.CreateTestDir()
+	defer fin()
+	assert.Nil(t, os.Link("test_dir/nested/file2", "test_dir/nested/file3"))
+
+	var output, reportOutput bytes.Buffer
+	ui := CreateExportUI(&output, &reportOutput, false, false, false, 0, 2, false, nil)
+	ui.SetIgnoreDirPaths([]string{"/xxx"})
+	assert.Nil(t, ui.AnalyzePath("test_dir", nil))
+
+	// the depth filter copies leaves through the fs.Item interface; Flag and
+	// Mli must survive the copy or hard links lose their ino/hlnkc attributes
+	assert.Contains(t, reportOutput.String(), `"hlnkc":true`)
+	assert.Contains(t, reportOutput.String(), `"ino":`)
+}

--- a/report/export_linux_test.go
+++ b/report/export_linux_test.go
@@ -5,6 +5,7 @@ package report
 import (
 	"bytes"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/dundee/gdu/v5/internal/testdir"
@@ -36,6 +37,54 @@ func TestReadFromStorage(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Contains(t, reportOutput.String(), `"name":"nested"`)
+}
+
+func TestAnalyzePathWithSummarizeFromStorage(t *testing.T) {
+	fin := testdir.CreateTestDir()
+	defer fin()
+
+	var plain, plainReport bytes.Buffer
+	plainUI := CreateExportUI(&plain, &plainReport, false, false, false, 0, 0, true, nil)
+	plainUI.SetIgnoreDirPaths([]string{"/xxx"})
+	assert.Nil(t, plainUI.AnalyzePath("test_dir", nil))
+
+	var output, reportOutput bytes.Buffer
+	ui := CreateExportUI(&output, &reportOutput, false, false, false, 0, 0, true, nil)
+	ui.SetIgnoreDirPaths([]string{"/xxx"})
+	ui.SetAnalyzer(analyze.CreateStoredAnalyzer(t.TempDir()))
+	assert.Nil(t, ui.AnalyzePath("test_dir", nil))
+
+	// stored dirs are not *analyze.Dir, so the summary used to report zeroes
+	assert.NotContains(t, reportOutput.String(), `"asize":0,"dsize":0,"items":0`)
+	assert.Equal(t, summaryBody(plainReport.String()), summaryBody(reportOutput.String()))
+}
+
+// summaryBody drops the export header, whose timestamp differs between runs.
+func summaryBody(report string) string {
+	_, body, _ := strings.Cut(report, "\n")
+	return body
+}
+
+func TestAnalyzePathWithDepthFromStorage(t *testing.T) {
+	fin := testdir.CreateTestDir()
+	defer fin()
+
+	var plain, plainReport bytes.Buffer
+	plainUI := CreateExportUI(&plain, &plainReport, false, false, false, 0, 1, false, nil)
+	plainUI.SetIgnoreDirPaths([]string{"/xxx"})
+	assert.Nil(t, plainUI.AnalyzePath("test_dir", nil))
+
+	var output, reportOutput bytes.Buffer
+	ui := CreateExportUI(&output, &reportOutput, false, false, false, 0, 1, false, nil)
+	ui.SetIgnoreDirPaths([]string{"/xxx"})
+	ui.SetAnalyzer(analyze.CreateStoredAnalyzer(t.TempDir()))
+	assert.Nil(t, ui.AnalyzePath("test_dir", nil))
+
+	// stored dirs load their children lazily, so the depth limit used to export
+	// them without stats and without descending into them
+	assert.Contains(t, reportOutput.String(), `"name":"nested"`)
+	assert.NotContains(t, reportOutput.String(), `"asize":0,"dsize":0,"items":0`)
+	assert.Equal(t, summaryBody(plainReport.String()), summaryBody(reportOutput.String()))
 }
 
 func TestReadFromStorageWithErr(t *testing.T) {

--- a/report/export_linux_test.go
+++ b/report/export_linux_test.go
@@ -5,7 +5,6 @@ package report
 import (
 	"bytes"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/dundee/gdu/v5/internal/testdir"
@@ -37,54 +36,6 @@ func TestReadFromStorage(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Contains(t, reportOutput.String(), `"name":"nested"`)
-}
-
-func TestAnalyzePathWithSummarizeFromStorage(t *testing.T) {
-	fin := testdir.CreateTestDir()
-	defer fin()
-
-	var plain, plainReport bytes.Buffer
-	plainUI := CreateExportUI(&plain, &plainReport, false, false, false, 0, 0, true, nil)
-	plainUI.SetIgnoreDirPaths([]string{"/xxx"})
-	assert.Nil(t, plainUI.AnalyzePath("test_dir", nil))
-
-	var output, reportOutput bytes.Buffer
-	ui := CreateExportUI(&output, &reportOutput, false, false, false, 0, 0, true, nil)
-	ui.SetIgnoreDirPaths([]string{"/xxx"})
-	ui.SetAnalyzer(analyze.CreateStoredAnalyzer(t.TempDir()))
-	assert.Nil(t, ui.AnalyzePath("test_dir", nil))
-
-	// stored dirs are not *analyze.Dir, so the summary used to report zeroes
-	assert.NotContains(t, reportOutput.String(), `"asize":0,"dsize":0,"items":0`)
-	assert.Equal(t, summaryBody(plainReport.String()), summaryBody(reportOutput.String()))
-}
-
-// summaryBody drops the export header, whose timestamp differs between runs.
-func summaryBody(report string) string {
-	_, body, _ := strings.Cut(report, "\n")
-	return body
-}
-
-func TestAnalyzePathWithDepthFromStorage(t *testing.T) {
-	fin := testdir.CreateTestDir()
-	defer fin()
-
-	var plain, plainReport bytes.Buffer
-	plainUI := CreateExportUI(&plain, &plainReport, false, false, false, 0, 1, false, nil)
-	plainUI.SetIgnoreDirPaths([]string{"/xxx"})
-	assert.Nil(t, plainUI.AnalyzePath("test_dir", nil))
-
-	var output, reportOutput bytes.Buffer
-	ui := CreateExportUI(&output, &reportOutput, false, false, false, 0, 1, false, nil)
-	ui.SetIgnoreDirPaths([]string{"/xxx"})
-	ui.SetAnalyzer(analyze.CreateStoredAnalyzer(t.TempDir()))
-	assert.Nil(t, ui.AnalyzePath("test_dir", nil))
-
-	// stored dirs load their children lazily, so the depth limit used to export
-	// them without stats and without descending into them
-	assert.Contains(t, reportOutput.String(), `"name":"nested"`)
-	assert.NotContains(t, reportOutput.String(), `"asize":0,"dsize":0,"items":0`)
-	assert.Equal(t, summaryBody(plainReport.String()), summaryBody(reportOutput.String()))
 }
 
 func TestReadFromStorageWithErr(t *testing.T) {

--- a/report/export_storage_test.go
+++ b/report/export_storage_test.go
@@ -1,0 +1,88 @@
+package report
+
+import (
+	"bytes"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dundee/gdu/v5/internal/common"
+	"github.com/dundee/gdu/v5/internal/testdir"
+	"github.com/dundee/gdu/v5/pkg/analyze"
+	"github.com/stretchr/testify/assert"
+)
+
+// assertStorageExportMatchesPlain exports test_dir twice — once with the
+// default in-memory analyzer and once with the given storage-backed analyzer —
+// and requires both report bodies to be equal. Stored dirs are not
+// *analyze.Dir, so --summarize and --depth used to export them with zeroed
+// stats, a bare root name, and (for --depth) without descending into the
+// lazily loaded children. It returns the storage-backed report for extra
+// assertions.
+func assertStorageExportMatchesPlain(
+	t *testing.T, analyzer common.Analyzer, depth int, summarize bool,
+) string {
+	t.Helper()
+
+	fin := testdir.CreateTestDir()
+	defer fin()
+
+	// The absolute path pins the exported root name: it is built from
+	// BasePath, which is not on the fs.Item interface and used to be dropped
+	// for stored roots.
+	path, err := filepath.Abs("test_dir")
+	assert.Nil(t, err)
+
+	var plain, plainReport bytes.Buffer
+	plainUI := CreateExportUI(&plain, &plainReport, false, false, false, 0, depth, summarize, nil)
+	plainUI.SetIgnoreDirPaths([]string{"/xxx"})
+	assert.Nil(t, plainUI.AnalyzePath(path, nil))
+
+	var output, reportOutput bytes.Buffer
+	ui := CreateExportUI(&output, &reportOutput, false, false, false, 0, depth, summarize, nil)
+	ui.SetIgnoreDirPaths([]string{"/xxx"})
+	ui.SetAnalyzer(analyzer)
+	assert.Nil(t, ui.AnalyzePath(path, nil))
+
+	rootName, err := json.Marshal(path)
+	assert.Nil(t, err)
+	assert.Contains(t, reportOutput.String(), `"name":`+string(rootName))
+	assert.NotContains(t, reportOutput.String(), `"asize":0,"dsize":0,"items":0`)
+	assert.Equal(t, reportWithoutHeader(plainReport.String()), reportWithoutHeader(reportOutput.String()))
+
+	return reportOutput.String()
+}
+
+// reportWithoutHeader drops the export header, whose timestamp differs between runs.
+func reportWithoutHeader(report string) string {
+	_, body, _ := strings.Cut(report, "\n")
+	return body
+}
+
+func createSqliteAnalyzer(t *testing.T) common.Analyzer {
+	t.Helper()
+	analyzer, err := analyze.CreateSqliteAnalyzer(filepath.Join(t.TempDir(), "test.sqlite"))
+	if err != nil {
+		t.Skipf("sqlite storage not available: %v", err)
+	}
+	return analyzer
+}
+
+func TestAnalyzePathWithSummarizeFromStorage(t *testing.T) {
+	assertStorageExportMatchesPlain(t, analyze.CreateStoredAnalyzer(t.TempDir()), 0, true)
+}
+
+func TestAnalyzePathWithDepthFromStorage(t *testing.T) {
+	report := assertStorageExportMatchesPlain(t, analyze.CreateStoredAnalyzer(t.TempDir()), 1, false)
+	assert.Contains(t, report, `"name":"nested"`)
+}
+
+func TestAnalyzePathWithSummarizeFromSqliteStorage(t *testing.T) {
+	assertStorageExportMatchesPlain(t, createSqliteAnalyzer(t), 0, true)
+}
+
+func TestAnalyzePathWithDepthFromSqliteStorage(t *testing.T) {
+	report := assertStorageExportMatchesPlain(t, createSqliteAnalyzer(t), 1, false)
+	assert.Contains(t, report, `"name":"nested"`)
+}

--- a/report/export_test.go
+++ b/report/export_test.go
@@ -133,6 +133,59 @@ func TestAnalyzePathWithTopAndArchiveBrowsing(t *testing.T) {
 	assert.Contains(t, reportOutput.String(), `"name":"inside.txt"`)
 }
 
+func TestAnalyzePathWithDepthAndArchiveBrowsing(t *testing.T) {
+	dir := t.TempDir()
+
+	archive, err := os.Create(filepath.Join(dir, "archive.tar"))
+	assert.Nil(t, err)
+	tw := tar.NewWriter(archive)
+	assert.Nil(t, tw.WriteHeader(&tar.Header{
+		Typeflag: tar.TypeReg, Name: "inside.txt", Size: 11, Mode: 0o644,
+	}))
+	_, err = tw.Write([]byte("hello world"))
+	assert.Nil(t, err)
+	assert.Nil(t, tw.Close())
+	assert.Nil(t, archive.Close())
+
+	var output, reportOutput bytes.Buffer
+
+	ui := CreateExportUI(&output, &reportOutput, false, false, false, 0, 2, false, nil)
+	ui.SetArchiveBrowsing(true)
+	ui.SetIgnoreDirPaths([]string{"/xxx"})
+
+	assert.NotPanics(t, func() {
+		err = ui.AnalyzePath(dir, nil)
+	})
+	assert.Nil(t, err)
+	assert.Contains(t, reportOutput.String(), `"name":"archive.tar"`)
+	assert.Contains(t, reportOutput.String(), `"name":"inside.txt"`)
+}
+
+func TestAnalyzePathWithDepthCutsInsideArchive(t *testing.T) {
+	dir := t.TempDir()
+
+	archive, err := os.Create(filepath.Join(dir, "archive.tar"))
+	assert.Nil(t, err)
+	tw := tar.NewWriter(archive)
+	assert.Nil(t, tw.WriteHeader(&tar.Header{
+		Typeflag: tar.TypeReg, Name: "inside.txt", Size: 11, Mode: 0o644,
+	}))
+	_, err = tw.Write([]byte("hello world"))
+	assert.Nil(t, err)
+	assert.Nil(t, tw.Close())
+	assert.Nil(t, archive.Close())
+
+	var output, reportOutput bytes.Buffer
+
+	ui := CreateExportUI(&output, &reportOutput, false, false, false, 0, 1, false, nil)
+	ui.SetArchiveBrowsing(true)
+	ui.SetIgnoreDirPaths([]string{"/xxx"})
+	assert.Nil(t, ui.AnalyzePath(dir, nil))
+
+	assert.Contains(t, reportOutput.String(), `"name":"archive.tar"`)
+	assert.NotContains(t, reportOutput.String(), `"name":"inside.txt"`)
+}
+
 func TestAnalyzePathWithDepth(t *testing.T) {
 	fin := testdir.CreateTestDir()
 	defer fin()

--- a/report/export_test.go
+++ b/report/export_test.go
@@ -104,8 +104,9 @@ func TestAnalyzePathWithTopAndTypeFilter(t *testing.T) {
 	assert.NotContains(t, reportOutput.String(), `"name":"file2"`)
 }
 
-func TestAnalyzePathWithTopAndArchiveBrowsing(t *testing.T) {
-	dir := t.TempDir()
+// createTestArchive writes archive.tar with a single file inside.txt into dir.
+func createTestArchive(t *testing.T, dir string) {
+	t.Helper()
 
 	archive, err := os.Create(filepath.Join(dir, "archive.tar"))
 	assert.Nil(t, err)
@@ -117,6 +118,11 @@ func TestAnalyzePathWithTopAndArchiveBrowsing(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Nil(t, tw.Close())
 	assert.Nil(t, archive.Close())
+}
+
+func TestAnalyzePathWithTopAndArchiveBrowsing(t *testing.T) {
+	dir := t.TempDir()
+	createTestArchive(t, dir)
 
 	var output, reportOutput bytes.Buffer
 
@@ -126,6 +132,7 @@ func TestAnalyzePathWithTopAndArchiveBrowsing(t *testing.T) {
 
 	// Files inside an archive are not *analyze.File, so collecting the top
 	// items used to panic instead of exporting them.
+	var err error
 	assert.NotPanics(t, func() {
 		err = ui.AnalyzePath(dir, nil)
 	})
@@ -135,17 +142,7 @@ func TestAnalyzePathWithTopAndArchiveBrowsing(t *testing.T) {
 
 func TestAnalyzePathWithDepthAndArchiveBrowsing(t *testing.T) {
 	dir := t.TempDir()
-
-	archive, err := os.Create(filepath.Join(dir, "archive.tar"))
-	assert.Nil(t, err)
-	tw := tar.NewWriter(archive)
-	assert.Nil(t, tw.WriteHeader(&tar.Header{
-		Typeflag: tar.TypeReg, Name: "inside.txt", Size: 11, Mode: 0o644,
-	}))
-	_, err = tw.Write([]byte("hello world"))
-	assert.Nil(t, err)
-	assert.Nil(t, tw.Close())
-	assert.Nil(t, archive.Close())
+	createTestArchive(t, dir)
 
 	var output, reportOutput bytes.Buffer
 
@@ -153,6 +150,7 @@ func TestAnalyzePathWithDepthAndArchiveBrowsing(t *testing.T) {
 	ui.SetArchiveBrowsing(true)
 	ui.SetIgnoreDirPaths([]string{"/xxx"})
 
+	var err error
 	assert.NotPanics(t, func() {
 		err = ui.AnalyzePath(dir, nil)
 	})
@@ -163,17 +161,7 @@ func TestAnalyzePathWithDepthAndArchiveBrowsing(t *testing.T) {
 
 func TestAnalyzePathWithDepthCutsInsideArchive(t *testing.T) {
 	dir := t.TempDir()
-
-	archive, err := os.Create(filepath.Join(dir, "archive.tar"))
-	assert.Nil(t, err)
-	tw := tar.NewWriter(archive)
-	assert.Nil(t, tw.WriteHeader(&tar.Header{
-		Typeflag: tar.TypeReg, Name: "inside.txt", Size: 11, Mode: 0o644,
-	}))
-	_, err = tw.Write([]byte("hello world"))
-	assert.Nil(t, err)
-	assert.Nil(t, tw.Close())
-	assert.Nil(t, archive.Close())
+	createTestArchive(t, dir)
 
 	var output, reportOutput bytes.Buffer
 


### PR DESCRIPTION
`--summarize` and `--depth` are dropped when the analysis is stored with `-D`, and `--depth` has no effect inside a browsed archive.

```
$ gdu -o- --summarize dir
[{"name":"/tmp/dir","asize":24000,"dsize":32768,"items":9,"mtime":...}]

$ gdu -D x.sqlite -o- --summarize dir
[{"name":"dir","asize":0,"dsize":0,"items":0,"mtime":...}]
```

`--depth 1` with `-D x.sqlite` exports the whole tree with the limit ignored, and with `-D x.badger` it exports the top level with zeroed stats and no children. `gdu --archive-browsing -o- --depth 1` keeps the entries inside the archive, one level too deep.

`summarizeDir` and `limitDirByDepth` reach the stats behind `dir.(*analyze.Dir)`. A stored root is `*analyze.SqliteItem` or `*analyze.StoredDir` and an archive is a `*analyze.TarDir`, so the assertion fails, and the filter is either skipped entirely or leaves the fields at zero. `fs.Item` already exposes `GetSize`, `GetUsage`, `GetItemCount` and `GetFiles`, so the stats are read through the interface instead. `BasePath` is not on the interface and keeps its own assertion.

Descending into a stored dir now reaches leaves that are not `*analyze.File`, so the leaf copy goes through the interface too. That is the same change `CollectTopFiles` needed in #631.

One behaviour change worth flagging: `--depth` now truncates inside a browsed archive, where before it did nothing. That matches what the flag documents, but it does alter output for `--archive-browsing --depth N`.

## Verification

Four tests added. Each one fails on its own mutation and nothing else does:

| revert | fails |
| --- | --- |
| stats back behind `dir.(*analyze.Dir)` in `summarizeDir` | `TestAnalyzePathWithSummarizeFromStorage` |
| depth guard back to `dir.(*analyze.Dir)` | `TestAnalyzePathWithDepthFromStorage` |
| leaf copy back to `*f.(*analyze.File)` | `TestAnalyzePathWithDepthAndArchiveBrowsing` |

The two storage tests compare the export against the same scan without a database and require the bodies to be equal, so they pin the values rather than just the shape.

For a plain scan the output is byte-identical before and after, checked for `--depth 1/2/3`, `--summarize`, `--top 3`, and with `--output-attrs name,asize,dsize,items,notreg` over a tree containing an empty dir and an unreadable one. `go test ./...` passes, `go test -race ./report/...` passes, and `golangci-lint run -c .golangci.yml` reports the same two pre-existing `goconst` findings as `master`, none of them in the changed files.

AI disclosure: written with Claude Code. I ran the binary before and after against SQLite, BadgerDB and a tar archive, and ran the mutations myself.
