### PR TITLE
fix(device): include same-filesystem bind mounts with --no-cross

### DIFF
--- a/cmd/gdu/app/app_linux_test.go
+++ b/cmd/gdu/app/app_linux_test.go
@@ -3,14 +3,20 @@
 package app
 
 import (
+	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/dundee/gdu/v5/internal/testapp"
 	"github.com/dundee/gdu/v5/internal/testdev"
 	"github.com/dundee/gdu/v5/internal/testdir"
 	"github.com/dundee/gdu/v5/pkg/device"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
 )
 
 func TestNoCrossWithErr(t *testing.T) {
@@ -150,4 +156,53 @@ func TestAnalyzePathWithSqliteStorageError(t *testing.T) {
 
 	assert.Empty(t, out)
 	assert.ErrorContains(t, err, "creating sqlite analyzer")
+}
+
+func TestNoCrossWithMountInfo(t *testing.T) {
+	temp := t.TempDir()
+	root := filepath.Join(temp, "scan")
+	for name, size := range map[string]int{"root.dat": 101, "same/same.dat": 203, "foreign/foreign.dat": 307} {
+		path := filepath.Join(root, filepath.FromSlash(name))
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(t, os.WriteFile(path, bytes.Repeat([]byte("x"), size), 0o600))
+	}
+	var stat unix.Stat_t
+	require.NoError(t, unix.Stat(root, &stat))
+	major, minor := unix.Major(uint64(stat.Dev)), unix.Minor(uint64(stat.Dev))
+	rootField := strings.ReplaceAll(root, " ", `\040`)
+	mountsPath := filepath.Join(temp, "mountinfo")
+	mounts := fmt.Sprintf(`1 1 %d:%d / / rw - ext4 /dev/example rw
+2 1 %d:%d /store %s/same ro - ext4 /dev/example rw
+3 1 %d:%d / %s/foreign rw - tmpfs tmpfs rw
+`, major, minor, major, minor, rootField, major, minor^1, rootField)
+	require.NoError(t, os.WriteFile(mountsPath, []byte(mounts), 0o600))
+
+	for _, tt := range []struct {
+		name    string
+		noCross bool
+		ignore  []string
+		want    string
+	}{
+		{name: "unrestricted", want: "611"},
+		{name: "same filesystem", noCross: true, want: "304"},
+		{name: "explicit ignore", noCross: true, ignore: []string{filepath.Join(root, "same")}, want: "101"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var output bytes.Buffer
+			app := App{
+				Flags: &Flags{
+					LogFile: "/dev/null", NoCross: tt.noCross, IgnoreDirs: tt.ignore,
+					ShowApparentSize: true, NoPrefix: true, NoColor: true, NoProgress: true, Depth: 3,
+				},
+				Args: []string{root}, Writer: &output,
+				TermApp: testapp.CreateMockedApp(false), PathChecker: os.Stat,
+				Getter: device.LinuxDevicesInfoGetter{MountsPath: mountsPath},
+			}
+			require.NoError(t, app.Run())
+			require.NotEmpty(t, output.String())
+			assert.Equal(t, tt.want, strings.Fields(output.String())[0])
+			assert.Equal(t, !tt.noCross, strings.Contains(output.String(), "/foreign/foreign.dat"))
+			assert.Equal(t, len(tt.ignore) == 0, strings.Contains(output.String(), "/same/same.dat"))
+		})
+	}
 }

--- a/configuration.md
+++ b/configuration.md
@@ -84,7 +84,11 @@ Do not show progress in non-interactive mode
 
 #### `no-cross`
 
-Do not cross filesystem boundaries
+Do not cross filesystem boundaries.
+
+On Linux, same-filesystem bind mounts (including read-only mounts) remain
+included. Mounts on other filesystems remain excluded. Explicit ignore rules
+still apply.
 
 #### `no-hidden`
 

--- a/pkg/device/dev.go
+++ b/pkg/device/dev.go
@@ -1,14 +1,19 @@
 package device
 
-import "strings"
+import (
+	"path/filepath"
+	"strings"
+)
 
 // Device struct
 type Device struct {
 	Name       string
 	MountPoint string
 	Fstype     string
-	Size       int64
-	Free       int64
+	// FilesystemID is the Linux device number, or nil when unavailable.
+	FilesystemID *uint64
+	Size         int64
+	Free         int64
 }
 
 // GetUsage returns used size of device
@@ -43,14 +48,21 @@ func (f ByName) Less(i, j int) bool {
 	return f[i].Name < f[j].Name
 }
 
-// GetNestedMountpointsPaths returns paths of nested mount points
+// GetNestedMountpointsPaths returns nested mount points on other or unknown filesystems.
 func GetNestedMountpointsPaths(path string, mounts Devices) []string {
 	paths := make([]string, 0, len(mounts))
+	filesystemID, known := getFilesystemID(path)
 
 	for _, mount := range mounts {
-		if strings.HasPrefix(mount.MountPoint, path) && mount.MountPoint != path {
-			paths = append(paths, mount.MountPoint)
+		relative, err := filepath.Rel(path, mount.MountPoint)
+		if err != nil || relative == "." || relative == ".." ||
+			strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+			continue
 		}
+		if known && mount.FilesystemID != nil && filesystemID == *mount.FilesystemID {
+			continue
+		}
+		paths = append(paths, mount.MountPoint)
 	}
 	return paths
 }

--- a/pkg/device/dev_linux.go
+++ b/pkg/device/dev_linux.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"slices"
+	"strconv"
 	"strings"
 
 	"golang.org/x/sys/unix"
@@ -16,9 +18,9 @@ type LinuxDevicesInfoGetter struct {
 }
 
 // Getter is current instance of DevicesInfoGetter
-var Getter DevicesInfoGetter = LinuxDevicesInfoGetter{MountsPath: "/proc/mounts"}
+var Getter DevicesInfoGetter = LinuxDevicesInfoGetter{MountsPath: "/proc/self/mountinfo"}
 
-// GetMounts returns all mounted filesystems from /proc/mounts
+// GetMounts returns mounted filesystems from a mountinfo or legacy mounts file.
 func (t LinuxDevicesInfoGetter) GetMounts() (devices Devices, err error) {
 	file, err := os.Open(t.MountsPath)
 	if err != nil {
@@ -50,30 +52,67 @@ func (t LinuxDevicesInfoGetter) GetDevicesInfo() (devices Devices, err error) {
 
 func readMountsFile(file io.Reader) (mounts Devices, err error) {
 	mounts = Devices{}
+	parents := make(map[*Device]string)
+	byID := make(map[string]*Device)
 
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
 		line := scanner.Text()
 		parts := strings.Fields(line)
 
-		// skip malformed lines, a valid entry has at least device, mount point and fstype
-		if len(parts) < 3 {
-			continue
+		separator := slices.Index(parts, "-")
+		switch {
+		case separator >= 6 && len(parts) >= separator+4:
+			mount := &Device{
+				Name:         parts[separator+2],
+				MountPoint:   unescapeString(parts[4]),
+				Fstype:       parts[separator+1],
+				FilesystemID: parseFilesystemID(parts[2]),
+			}
+			mounts = append(mounts, mount)
+			parents[mount] = parts[1]
+			byID[parts[0]] = mount
+		case len(parts) >= 3 && strings.HasPrefix(parts[1], "/"):
+			mounts = append(mounts, &Device{
+				Name:       parts[0],
+				MountPoint: unescapeString(parts[1]),
+				Fstype:     parts[2],
+			})
 		}
-
-		device := &Device{
-			Name:       parts[0],
-			MountPoint: unescapeString(parts[1]),
-			Fstype:     parts[2],
-		}
-		mounts = append(mounts, device)
 	}
 
 	if err := scanner.Err(); err != nil {
 		return nil, err
 	}
 
-	return mounts, nil
+	return visibleMounts(mounts, parents, byID), nil
+}
+
+func visibleMounts(mounts Devices, parents map[*Device]string, byID map[string]*Device) Devices {
+	covered := make(map[*Device]bool)
+	for mount, parentID := range parents {
+		parent := byID[parentID]
+		if parent != nil && parent != mount && parent.MountPoint == mount.MountPoint {
+			covered[parent] = true
+		}
+	}
+	return slices.DeleteFunc(mounts, func(mount *Device) bool {
+		if covered[mount] {
+			return true
+		}
+		// Bound malformed parent cycles in custom mount tables.
+		for range len(parents) {
+			parent := byID[parents[mount]]
+			if parent == nil || parent == mount {
+				break
+			}
+			if covered[parent] && parent.MountPoint != mount.MountPoint {
+				return true
+			}
+			mount = parent
+		}
+		return false
+	})
 }
 
 func processMounts(mounts Devices, ignoreErrors bool) (devices Devices, err error) {
@@ -106,4 +145,29 @@ func processMounts(mounts Devices, ignoreErrors bool) (devices Devices, err erro
 
 func unescapeString(str string) string {
 	return strings.ReplaceAll(str, "\\040", " ")
+}
+
+func getFilesystemID(path string) (uint64, bool) {
+	var stat unix.Stat_t
+	if err := unix.Stat(path, &stat); err != nil {
+		return 0, false
+	}
+	return uint64(stat.Dev), true
+}
+
+func parseFilesystemID(value string) *uint64 {
+	majorText, minorText, found := strings.Cut(value, ":")
+	if !found {
+		return nil
+	}
+	major, err := strconv.ParseUint(majorText, 10, 32)
+	if err != nil {
+		return nil
+	}
+	minor, err := strconv.ParseUint(minorText, 10, 32)
+	if err != nil {
+		return nil
+	}
+	id := unix.Mkdev(uint32(major), uint32(minor))
+	return &id
 }

--- a/pkg/device/dev_test.go
+++ b/pkg/device/dev_test.go
@@ -71,3 +71,14 @@ func TestSortByUsedSize(t *testing.T) {
 	assert.Equal(t, "yyy", devices[1].Name)
 	assert.Equal(t, "xxx", devices[2].Name)
 }
+
+func TestNestedMountpointPathBoundary(t *testing.T) {
+	mounts := Devices{
+		{MountPoint: "/scan"},
+		{MountPoint: "/scan/child"},
+		{MountPoint: "/scan-neighbour"},
+		{MountPoint: "/scan-neighbour/child"},
+	}
+
+	assert.Equal(t, []string{"/scan/child"}, GetNestedMountpointsPaths("/scan", mounts))
+}

--- a/pkg/device/filesystem_other.go
+++ b/pkg/device/filesystem_other.go
@@ -1,0 +1,7 @@
+//go:build !linux
+
+package device
+
+func getFilesystemID(_ string) (uint64, bool) {
+	return 0, false
+}

--- a/pkg/device/mountinfo_linux_test.go
+++ b/pkg/device/mountinfo_linux_test.go
@@ -1,0 +1,135 @@
+//go:build linux
+
+package device
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+)
+
+func TestNoCrossUsesMountInfoFilesystem(t *testing.T) {
+	root := t.TempDir()
+	var stat unix.Stat_t
+	require.NoError(t, unix.Stat(root, &stat))
+	id := fmt.Sprintf("%d:%d", unix.Major(uint64(stat.Dev)), unix.Minor(uint64(stat.Dev)))
+	otherID := fmt.Sprintf("%d:%d", unix.Major(uint64(stat.Dev)), unix.Minor(uint64(stat.Dev))^1)
+	rootField := strings.ReplaceAll(root, " ", `\040`)
+	input := fmt.Sprintf(`20 1 %s / %s rw shared:1 - ext4 /dev/example rw
+21 20 %s /store %s/same ro - ext4 /dev/example rw
+22 20 %s / %s/foreign rw - tmpfs tmpfs rw
+`, id, rootField, id, rootField, otherID, rootField)
+
+	mounts, err := readMountsFile(strings.NewReader(input))
+	require.NoError(t, err)
+	require.Len(t, mounts, 3)
+	assert.Equal(t, "/dev/example", mounts[0].Name)
+	assert.Equal(t, root, mounts[0].MountPoint)
+	assert.Equal(t, "ext4", mounts[0].Fstype)
+	require.NotNil(t, mounts[0].FilesystemID)
+	assert.Equal(t, uint64(stat.Dev), *mounts[0].FilesystemID)
+	assert.Equal(t, []string{filepath.Join(root, "foreign")}, GetNestedMountpointsPaths(root, mounts))
+}
+
+func TestMountInfoEscapedMountpoint(t *testing.T) {
+	mounts, err := readMountsFile(strings.NewReader(
+		`42 20 0:44 /with\040space /mnt/with\040space ro shared:2 master:1 - nfs server:/export rw`))
+
+	require.NoError(t, err)
+	require.Len(t, mounts, 1)
+	assert.Equal(t, "server:/export", mounts[0].Name)
+	assert.Equal(t, "/mnt/with space", mounts[0].MountPoint)
+	assert.Equal(t, "nfs", mounts[0].Fstype)
+}
+
+func TestMalformedMountInfoLinesAreSkipped(t *testing.T) {
+	mounts, err := readMountsFile(strings.NewReader(`
+20 1 0:11
+21 1 0:12 / /missing-separator rw
+22 1 0:13 / /missing-source rw - ext4
+23 1 0:14 / /valid rw - ext4 /dev/example rw
+`))
+
+	require.NoError(t, err)
+	require.Len(t, mounts, 1)
+	assert.Equal(t, "/valid", mounts[0].MountPoint)
+}
+
+func TestLegacyMountTableRetainsMountpointExclusion(t *testing.T) {
+	root := t.TempDir()
+	point := filepath.Join(root, "nested")
+	field := strings.ReplaceAll(point, " ", `\040`)
+	mounts, err := readMountsFile(strings.NewReader("/dev/example " + field + " ext4 ro 0 0\n"))
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{point}, GetNestedMountpointsPaths(root, mounts))
+}
+
+func TestUnknownRootFilesystemRetainsMountpointExclusion(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "missing")
+	point := filepath.Join(root, "nested")
+	id := uint64(1)
+	mounts := Devices{{MountPoint: point, FilesystemID: &id}}
+
+	assert.Equal(t, []string{point}, GetNestedMountpointsPaths(root, mounts))
+}
+
+func TestParseFilesystemID(t *testing.T) {
+	for _, value := range []string{"", "missing", "-1:2", "1:-2", "4294967296:1", "1:4294967296", "1:2:3"} {
+		t.Run(value, func(t *testing.T) {
+			assert.Nil(t, parseFilesystemID(value))
+		})
+	}
+	id := parseFilesystemID("0:0")
+	require.NotNil(t, id)
+	assert.Zero(t, *id)
+}
+
+func TestNoCrossIgnoresHiddenMountInfoRecords(t *testing.T) {
+	root := t.TempDir()
+	var stat unix.Stat_t
+	require.NoError(t, unix.Stat(root, &stat))
+	id := fmt.Sprintf("%d:%d", unix.Major(uint64(stat.Dev)), unix.Minor(uint64(stat.Dev)))
+	otherID := fmt.Sprintf("%d:%d", unix.Major(uint64(stat.Dev)), unix.Minor(uint64(stat.Dev))^1)
+	rootField := strings.ReplaceAll(root, " ", `\040`)
+	input := fmt.Sprintf(`1 1 %s / / rw - ext4 /dev/example rw
+22 20 %s / %s/same/hidden rw - tmpfs tmpfs rw
+21 20 %s /store %s/same ro - ext4 /dev/example rw
+20 1 %s / %s/same rw - tmpfs tmpfs rw
+23 21 %s / %s/same/visible rw - tmpfs tmpfs rw
+`, id, otherID, rootField, id, rootField, otherID, rootField, otherID, rootField)
+
+	mounts, err := readMountsFile(strings.NewReader(input))
+	require.NoError(t, err)
+	require.Len(t, mounts, 3)
+	assert.Equal(t, []string{filepath.Join(root, "same", "visible")}, GetNestedMountpointsPaths(root, mounts))
+}
+
+func TestDefaultMountTableHasFilesystemIDs(t *testing.T) {
+	mounts, err := Getter.GetMounts()
+	require.NoError(t, err)
+	for _, mount := range mounts {
+		if mount.MountPoint == "/" {
+			id, known := getFilesystemID("/")
+			require.True(t, known)
+			require.NotNil(t, mount.FilesystemID)
+			assert.Equal(t, id, *mount.FilesystemID)
+			return
+		}
+	}
+	t.Fatal("root mount is missing")
+}
+
+func TestMountInfoParentCyclesAreBounded(t *testing.T) {
+	mounts, err := readMountsFile(strings.NewReader(`1 2 0:1 / /first rw - tmpfs tmpfs rw
+2 1 0:2 / /second rw - tmpfs tmpfs rw
+`))
+
+	require.NoError(t, err)
+	assert.Len(t, mounts, 2)
+}


### PR DESCRIPTION
Fixes #654.

`--no-cross` currently excludes every nested mount point. That also drops read-only bind mounts on the scanned root's own filesystem, such as `/nix/store` in the report.

## Changes

- Use Linux `mountinfo` filesystem device numbers to distinguish bind mounts from filesystem boundaries. The boundary check stats the scanned root, rather than probing each nested mount.
- Use mount/parent IDs to discard hidden stacked mounts and their hidden descendants, so an old covered mount does not incorrectly exclude the visible one. This follows the [mountinfo format and visibility rules](https://man7.org/linux/man-pages/man5/proc_pid_mountinfo.5.html).
- Keep legacy/custom mount tables and non-Linux behavior conservative when filesystem identity is unavailable. Explicit ignore rules still apply.
- Check path components rather than string prefixes, so a scanned root such as `/scan` does not affect `/scan-neighbour`.
- Add parser, boundary, and application-level regressions, and document the Linux behavior.

## Validation

A real read-only bind mount plus a separate tmpfs reproduces the issue on master: `-x` reports 101 bytes instead of keeping the additional 203 same-filesystem bytes. The fix reports 304 and still excludes the 307-byte tmpfs. The output without `-x` is byte-for-byte unchanged.

- Nine real CLI cases pass, including explicit ignores, a bind mount used as the scanned root, multiple roots on different filesystems, and a path containing spaces.
- Full race-instrumented suite passes on Go 1.26.8 and 1.27.0: all 18 packages, with only the Darwin-specific clipboard roundtrip skipped. Test binaries were built with `go test -race -c` and executed as an unprivileged user so permission-error tests run under the intended conditions.
- `make lint` passes with CI's golangci-lint v2.13.2, with no checks disabled.
- The changed device package cross-compiles for Windows amd64, Darwin arm64, FreeBSD/NetBSD/OpenBSD amd64, and Linux 386; these are build-only checks.
