### PR TITLE
feat: allow ctrl+c to quit instead of stopping the scan

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -20,6 +20,12 @@ The synthetic directory that holds the scanned roots when there is more than
 one, so that they can be listed, sorted and compared as siblings. It is not an
 item on any filesystem and has no path; every other directory gdu shows does.
 
+## Stopped scan
+
+A scan the user told to schedule no new work, whose results found so far are
+kept and browsed as if the scan had finished. Distinct from an abandoned scan,
+where the user quits gdu and the results are discarded.
+
 ## Apparent size
 
 The size an item claims to be, i.e. the length of its contents.

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Flags:
       --archive-browsing              Enable browsing of zip/jar/tar archives (tar, tar.gz, tar.bz2, tar.xz)
       --collapse-path                 Collapse single-child directory chains
       --config-file string            Read config from file (default is $HOME/.gdu.yaml)
+      --ctrl-c-quits                  Quit gdu when Ctrl+C is pressed during a scan instead of stopping the scan and keeping results (Esc always stops the scan)
   -D, --db string                     Store analysis in database (*.sqlite for SQLite, *.badger for BadgerDB)
       --depth int                     Show directory structure up to specified depth in non-interactive mode (0 means the flag is ignored); also limits entries inside browsed archives
       --enable-profiling              Enable collection of profiling data and provide it on http://localhost:6060/debug/pprof/
@@ -168,7 +169,7 @@ In non-interactive mode (and without `--top` and `--depth` flags), gdu uses a me
 This means memory usage stays constant regardless of how large the scanned directory tree is.
 When `--top` or `--depth` flags are used, the full directory tree is built in memory as in interactive mode.
 
-Export mode (flag `-o`) outputs all usage data as JSON, which can be later opened using the `-f` flag. In interactive mode, press `Ctrl+C` during a scan to stop scheduling new work and keep the results found so far.
+Export mode (flag `-o`) outputs all usage data as JSON, which can be later opened using the `-f` flag. In interactive mode, press `Esc` or `Ctrl+C` during a scan to stop scheduling new work and keep the results found so far. If you would rather have `Ctrl+C` quit gdu outright, use `--ctrl-c-quits`; `Esc` keeps working either way.
 
 By default the export includes every attribute, and directories always carry their `asize`, `dsize`, and `items` summary stats so they can be preserved on import. Use `--output-attrs=asize,dsize` to emit only selected optional attributes; `name` is always included. Available attributes are `asize`, `dsize`, `items`, `mtime`, and `notreg`.
 

--- a/cmd/gdu/app/app.go
+++ b/cmd/gdu/app/app.go
@@ -113,6 +113,7 @@ type Flags struct {
 	ArchiveBrowsing    bool      `yaml:"archive-browsing"`
 	CollapsePath       bool      `yaml:"collapse-path"`
 	ShowSymlinkTarget  bool      `yaml:"show-symlink-target"`
+	CtrlCQuits         bool      `yaml:"ctrl-c-quits"`
 	BrowseParentDirs   bool      `yaml:"browse-parent-dirs"`
 	Web                bool      `yaml:"-"`
 	WebConfig          WebConfig `yaml:"web"`
@@ -681,6 +682,11 @@ func (a *App) getOptions() []tui.Option {
 	if a.Flags.NoConfirmQuit {
 		opts = append(opts, func(ui *tui.UI) {
 			ui.SetConfirmQuit(false)
+		})
+	}
+	if a.Flags.CtrlCQuits {
+		opts = append(opts, func(ui *tui.UI) {
+			ui.SetCtrlCQuits()
 		})
 	}
 	if a.Flags.DeleteInBackground {

--- a/cmd/gdu/app/app_test.go
+++ b/cmd/gdu/app/app_test.go
@@ -305,6 +305,21 @@ func TestGuiNoSpawnShell(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+func TestGuiCtrlCQuits(t *testing.T) {
+	fin := testdir.CreateTestDir()
+	defer fin()
+
+	out, err := runApp(
+		&Flags{LogFile: "/dev/null", CtrlCQuits: true},
+		[]string{"test_dir"},
+		true,
+		testdev.DevicesInfoGetterMock{},
+	)
+
+	assert.Empty(t, out)
+	assert.Nil(t, err)
+}
+
 func TestGuiDeleteInParallel(t *testing.T) {
 	fin := testdir.CreateTestDir()
 	defer fin()

--- a/cmd/gdu/main.go
+++ b/cmd/gdu/main.go
@@ -107,6 +107,8 @@ func init() {
 	flags.BoolVar(&af.NoViewFile, "no-view-file", false, "Do not allow viewing file contents")
 	flags.BoolVar(&af.NoSpawnShell, "no-spawn-shell", false, "Do not allow spawning shell")
 	flags.BoolVar(&af.NoConfirmQuit, "no-confirm-quit", false, "Do not ask for confirmation before quitting after a long scan")
+	flags.BoolVar(&af.CtrlCQuits, "ctrl-c-quits", false,
+		"Quit gdu when Ctrl+C is pressed during a scan instead of stopping the scan and keeping results (Esc always stops the scan)")
 	flags.StringVar(&af.TrashCommand, "trash-command", "",
 		"Command used to move items to trash instead of the built-in trash (e.g. 'trash-put --trash-dir ~/mytrash')")
 	flags.BoolVar(&af.WriteConfig, "write-config", false, "Write current configuration to file (default is $HOME/.gdu.yaml)")

--- a/cmd/gdu/main_test.go
+++ b/cmd/gdu/main_test.go
@@ -55,6 +55,31 @@ func TestShowSymlinkTargetFlagCanBeSet(t *testing.T) {
 	}
 }
 
+func TestCtrlCQuitsFlagRegistered(t *testing.T) {
+	flag := rootCmd.Flags().Lookup("ctrl-c-quits")
+	if flag == nil {
+		t.Fatal("expected ctrl-c-quits flag to be registered")
+	}
+	if flag.DefValue != "false" {
+		t.Fatalf("expected ctrl-c-quits to default to false, got %q", flag.DefValue)
+	}
+}
+
+func TestCtrlCQuitsFlagCanBeSet(t *testing.T) {
+	t.Cleanup(func() {
+		_ = rootCmd.Flags().Set("ctrl-c-quits", "false")
+	})
+
+	err := rootCmd.Flags().Set("ctrl-c-quits", "true")
+	if err != nil {
+		t.Fatalf("expected setting ctrl-c-quits flag to succeed: %v", err)
+	}
+
+	if !af.CtrlCQuits {
+		t.Fatal("expected CtrlCQuits to be true after setting flag")
+	}
+}
+
 func TestInteractiveFlagRegistered(t *testing.T) {
 	flag := rootCmd.Flags().Lookup("interactive")
 	if flag == nil {

--- a/configuration.md
+++ b/configuration.md
@@ -106,6 +106,14 @@ Do not allow viewing file contents
 
 Do not ask for confirmation before quitting after a long scan. By default, pressing `q`/`Q` after a scan that took more than a few seconds shows a confirmation dialog so that results are not lost by an accidental key press.
 
+#### `ctrl-c-quits`
+
+Quit gdu when `Ctrl+C` is pressed during a scan, instead of stopping the scan and keeping the results found so far.
+
+By default, `Ctrl+C` during a scan produces a stopped scan: no new work is scheduled and the results found so far are kept. Set this option if you prefer `Ctrl+C` to behave the way it does in most other programs and exit gdu instead. Quitting this way is immediate and unconditional — the confirmation dialog described under `no-confirm-quit` is not shown, because `Ctrl+C` is treated as a stronger signal than `q`.
+
+`Esc` always stops the scan and keeps the results, regardless of this option, so the behaviour remains reachable. This option only has an effect while a scan is running; outside a scan `Ctrl+C` already quits gdu.
+
 #### `follow-symlinks`
 
 Follow symlinks for files, i.e. show the size of the file to which symlink points to (symlinks to directories are not followed)

--- a/gdu.1.md
+++ b/gdu.1.md
@@ -109,6 +109,8 @@ non-interactive mode
 
 **\--no-confirm-quit**\[=false\] Do not ask for confirmation before quitting after a long scan
 
+**\--ctrl-c-quits**\[=false\] Quit gdu when Ctrl+C is pressed during a scan instead of stopping the scan and keeping results. Esc always stops the scan and keeps the results found so far, regardless of this flag.
+
 **\--no-delete**\[=false\] Do not allow deletions
 
 **\--no-view-file**\[=false\] Do not allow viewing file contents

--- a/tui/actions_test.go
+++ b/tui/actions_test.go
@@ -148,6 +148,38 @@ func TestCtrlCDuringScanShowsPartialResults(t *testing.T) {
 	assert.Equal(t, 4, ui.table.GetRowCount())
 }
 
+func TestEscDuringScanShowsPartialResults(t *testing.T) {
+	simScreen := testapp.CreateSimScreen()
+	defer simScreen.Fini()
+
+	app := testapp.CreateMockedApp(false)
+	ui := CreateUI(app, simScreen, &bytes.Buffer{}, true, true, false, false)
+	// Ctrl+C is configured to quit, so Esc is the only way to keep results
+	ui.SetCtrlCQuits()
+	analyzer := &blockingAnalyzer{
+		started:   make(chan struct{}),
+		cancelled: make(chan struct{}),
+		done:      make(common.SignalGroup),
+	}
+	ui.Analyzer = analyzer
+	ui.done = make(chan struct{})
+
+	assert.NoError(t, ui.AnalyzePath("test_dir", nil))
+
+	key := ui.keyPressed(tcell.NewEventKey(tcell.KeyEsc, 0, 0))
+	assert.Nil(t, key)
+	assert.True(t, ui.scanCancelled)
+	<-ui.done
+	for _, draw := range app.(*testapp.MockedApp).GetUpdateDraws() {
+		draw()
+	}
+
+	assert.False(t, ui.scanCancelled)
+	assert.False(t, ui.pages.HasPage("progress"))
+	assert.Equal(t, "test_dir", ui.currentDir.GetName())
+	assert.Equal(t, 4, ui.table.GetRowCount())
+}
+
 type blockingAnalyzer struct {
 	testanalyze.MockedAnalyzer
 	started   chan struct{}

--- a/tui/keys.go
+++ b/tui/keys.go
@@ -48,7 +48,8 @@ func (ui *UI) keyPressed(key *tcell.EventKey) *tcell.EventKey {
 		return ui.handleConfirmation(key)
 	}
 
-	if key.Key() == tcell.KeyCtrlC && ui.cancelScan() {
+	key = ui.handleCtrlC(key)
+	if key == nil {
 		return nil
 	}
 
@@ -60,12 +61,7 @@ func (ui *UI) keyPressed(key *tcell.EventKey) *tcell.EventKey {
 		ui.pages.HasPage("deleting") ||
 		ui.pages.HasPage("emptying") ||
 		ui.pages.HasPage("moving to trash") {
-		// allow peeking at the results found so far during a scan
-		if key.Key() == tcell.KeyTab && ui.pages.HasPage("progress") {
-			ui.enterPreview()
-			return nil
-		}
-		return key
+		return ui.handleBlockingModalKeys(key)
 	}
 
 	key = ui.handleHelp(key)
@@ -93,6 +89,40 @@ func (ui *UI) keyPressed(key *tcell.EventKey) *tcell.EventKey {
 	}
 
 	return ui.handleMainActions(key)
+}
+
+// handleCtrlC reacts to Ctrl+C. By default it stops a running scan and keeps
+// the results found so far; when ctrlCQuits is set it quits gdu straight away
+// instead. Returns nil when the event has been consumed.
+func (ui *UI) handleCtrlC(key *tcell.EventKey) *tcell.EventKey {
+	if key.Key() != tcell.KeyCtrlC {
+		return key
+	}
+	if ui.ctrlCQuits {
+		ui.quitNow()
+		return nil
+	}
+	if ui.cancelScan() {
+		return nil
+	}
+	return key
+}
+
+// handleBlockingModalKeys handles the few keys that stay available while a
+// modal that blocks browsing is up (scan progress, deleting, emptying, moving
+// to trash). Returns nil when the event has been consumed.
+func (ui *UI) handleBlockingModalKeys(key *tcell.EventKey) *tcell.EventKey {
+	// allow peeking at the results found so far during a scan
+	if key.Key() == tcell.KeyTab && ui.pages.HasPage("progress") {
+		ui.enterPreview()
+		return nil
+	}
+	// Esc always stops the scan and keeps the results found so far, even when
+	// Ctrl+C is configured to quit instead.
+	if key.Key() == tcell.KeyEsc && ui.cancelScan() {
+		return nil
+	}
+	return key
 }
 
 func (ui *UI) handleClosingModals(key *tcell.EventKey) *tcell.EventKey {

--- a/tui/keys_test.go
+++ b/tui/keys_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
 	"time"
 
@@ -492,6 +493,81 @@ func TestCtrlCDuringScanCancelsAnalyzer(t *testing.T) {
 	assert.True(t, ui.scanCancelled)
 	assert.True(t, ui.Analyzer.(*analyze.ParallelAnalyzer).IsCancelled())
 	assert.Equal(t, " Stopping scan... ", ui.progress.GetTitle())
+}
+
+func TestEscDuringScanCancelsAnalyzer(t *testing.T) {
+	fin := testdir.CreateTestDir()
+	defer fin()
+
+	ui := analyzedUI(t, &bytes.Buffer{})
+	ui.progress = tview.NewTextView()
+	ui.scanning = true
+	ui.pages.AddPage("progress", ui.progress, true, true)
+
+	key := ui.keyPressed(tcell.NewEventKey(tcell.KeyEsc, 0, 0))
+
+	assert.Nil(t, key)
+	assert.True(t, ui.scanCancelled)
+	assert.True(t, ui.Analyzer.(*analyze.ParallelAnalyzer).IsCancelled())
+	assert.Equal(t, " Stopping scan... ", ui.progress.GetTitle())
+}
+
+func TestEscStopsScanEvenWhenCtrlCQuits(t *testing.T) {
+	fin := testdir.CreateTestDir()
+	defer fin()
+
+	ui := analyzedUI(t, &bytes.Buffer{})
+	ui.SetCtrlCQuits()
+	ui.progress = tview.NewTextView()
+	ui.scanning = true
+	ui.pages.AddPage("progress", ui.progress, true, true)
+
+	key := ui.keyPressed(tcell.NewEventKey(tcell.KeyEsc, 0, 0))
+
+	assert.Nil(t, key)
+	assert.True(t, ui.scanCancelled)
+	assert.True(t, ui.Analyzer.(*analyze.ParallelAnalyzer).IsCancelled())
+}
+
+func TestCtrlCQuitsDuringScanWhenConfigured(t *testing.T) {
+	fin := testdir.CreateTestDir()
+	defer fin()
+
+	buff := &bytes.Buffer{}
+	ui := analyzedUI(t, buff)
+	ui.SetCtrlCQuits()
+	ui.progress = tview.NewTextView()
+	ui.scanning = true
+	ui.scanStart = time.Now().Add(-10 * time.Second)
+	ui.pages.AddPage("progress", ui.progress, true, true)
+	ui.markedPaths = []string{"test_dir/nested"}
+
+	key := ui.keyPressed(tcell.NewEventKey(tcell.KeyCtrlC, 0, 0))
+
+	assert.Nil(t, key)
+	// the scan must not be stopped-and-kept, gdu just quits
+	assert.False(t, ui.scanCancelled)
+	assert.False(t, ui.Analyzer.(*analyze.ParallelAnalyzer).IsCancelled())
+	// quitting is immediate and unconditional, even after a long scan
+	assert.False(t, ui.pages.HasPage("confirm"))
+	// the regular quit teardown still runs, so marked paths are printed
+	assert.Equal(t, "test_dir/nested\n", buff.String())
+}
+
+func TestSignalCtrlCQuitsDuringScanWhenConfigured(t *testing.T) {
+	fin := testdir.CreateTestDir()
+	defer fin()
+
+	ui := analyzedUI(t, &bytes.Buffer{})
+	ui.SetCtrlCQuits()
+	ui.progress = tview.NewTextView()
+	ui.scanning = true
+	ui.pages.AddPage("progress", ui.progress, true, true)
+
+	ui.handleSignalEvent(signalEvent(syscall.SIGINT))
+
+	assert.False(t, ui.scanCancelled)
+	assert.False(t, ui.Analyzer.(*analyze.ParallelAnalyzer).IsCancelled())
 }
 
 func TestCtrlCDuringScanPreviewCancelsAnalyzer(t *testing.T) {

--- a/tui/progress.go
+++ b/tui/progress.go
@@ -8,6 +8,16 @@ import (
 	"github.com/dundee/gdu/v5/internal/common"
 )
 
+// stopScanHint returns the progress modal line telling the user how to stop
+// the scan and keep the results found so far. Ctrl+C is only advertised when
+// it is not configured to quit instead.
+func (ui *UI) stopScanHint() string {
+	if ui.ctrlCQuits {
+		return "Press Esc to stop scanning and keep results"
+	}
+	return "Press Esc or Ctrl+C to stop scanning and keep results"
+}
+
 func (ui *UI) updateProgress(analyzer common.Analyzer, doneChan common.SignalGroup) {
 	color := "[white:black:b]"
 	if ui.UseColors {
@@ -60,7 +70,7 @@ func (ui *UI) updateProgress(analyzer common.Analyzer, doneChan common.SignalGro
 					color +
 					delta.String() +
 					"[white:black:-]\n\nPress Tab to preview results found so far\n" +
-					"Press Ctrl+C to stop scanning and keep results")
+					ui.stopScanHint())
 			})
 		}(progress.ItemCount, progress.TotalUsage)
 	}

--- a/tui/show.go
+++ b/tui/show.go
@@ -35,6 +35,10 @@ var (
                [::b]q     [white:black:-]Quit gdu (asks to confirm after a long scan)
                [::b]Q     [white:black:-]Quit gdu and print current directory path
 
+During a scan:
+             [::b]tab     [white:black:-]Preview results found so far
+             [::b]esc     [white:black:-]Stop scanning and keep results
+
 Item under cursor:
                [::b]d     [white:black:-]Delete file or directory
                [::b]e     [white:black:-]Empty file or directory

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -105,6 +105,7 @@ type UI struct {
 	showDiskProgressBar     bool
 	currentDeviceSize       int64
 	confirmQuit             bool
+	ctrlCQuits              bool
 	scanning                bool
 	scanCancelled           bool
 	// scanCancelRequested mirrors scanCancelled for readers outside the UI
@@ -429,9 +430,14 @@ func signalEvent(current os.Signal) *tcell.EventKey {
 }
 
 func (ui *UI) handleSignalEvent(event *tcell.EventKey) {
-	if event.Modifiers() == tcell.ModCtrl && (ui.cancelScan() || ui.scanning) {
+	if event.Modifiers() == tcell.ModCtrl && !ui.ctrlCQuits && (ui.cancelScan() || ui.scanning) {
 		return
 	}
+	ui.quitNow()
+}
+
+// quitNow shuts the app down straight away, without asking for confirmation.
+func (ui *UI) quitNow() {
 	ui.printMarkedPaths()
 	ui.app.Stop()
 }
@@ -453,6 +459,13 @@ func (ui *UI) cancelScan() bool {
 // after a scan that took a noticeable amount of time
 func (ui *UI) SetConfirmQuit(value bool) {
 	ui.confirmQuit = value
+}
+
+// SetCtrlCQuits makes Ctrl+C quit gdu during a scan instead of stopping the
+// scan and keeping the results found so far. Esc always stops the scan,
+// regardless of this setting.
+func (ui *UI) SetCtrlCQuits() {
+	ui.ctrlCQuits = true
 }
 
 // SetShowItemCount sets the flag to show number of items in directory

--- a/tui/tui_test.go
+++ b/tui/tui_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -108,7 +109,21 @@ func TestUpdateProgressShowsCancellationHint(t *testing.T) {
 
 	draws := app.GetUpdateDraws()
 	draws[0]()
-	assert.Contains(t, ui.progress.GetText(false), "Press Ctrl+C to stop scanning and keep results")
+	assert.Contains(t, ui.progress.GetText(false), "Press Esc or Ctrl+C to stop scanning and keep results")
+}
+
+func TestStopScanHint(t *testing.T) {
+	simScreen := testapp.CreateSimScreen()
+	defer simScreen.Fini()
+
+	app := testapp.CreateMockedApp(false)
+	ui := CreateUI(app, simScreen, &bytes.Buffer{}, false, false, false, false)
+
+	assert.Equal(t, "Press Esc or Ctrl+C to stop scanning and keep results", ui.stopScanHint())
+
+	// Ctrl+C quits, so it must not be advertised as the way to keep results
+	ui.SetCtrlCQuits()
+	assert.Equal(t, "Press Esc to stop scanning and keep results", ui.stopScanHint())
 }
 
 func TestSetShowDiskProgressBar(t *testing.T) {
@@ -160,16 +175,7 @@ func TestHelp(t *testing.T) {
 	ui.help.Draw(simScreen)
 	simScreen.Show()
 
-	// printScreen(simScreen)
-
-	b, _, _ := simScreen.GetContents()
-
-	cells := b[607 : 607+9]
-
-	text := []byte("directory")
-	for i, r := range cells {
-		assert.Equal(t, text[i], r.Bytes[0])
-	}
+	assert.Contains(t, screenText(simScreen), "directory")
 }
 
 func TestHelpBw(t *testing.T) {
@@ -181,16 +187,18 @@ func TestHelpBw(t *testing.T) {
 	ui.help.Draw(simScreen)
 	simScreen.Show()
 
-	// printScreen(simScreen)
+	assert.Contains(t, screenText(simScreen), "directory")
+}
 
-	b, _, _ := simScreen.GetContents()
+func TestHelpShowsScanKeys(t *testing.T) {
+	app, simScreen := testapp.CreateTestAppWithSimScreen(50, 50)
+	defer simScreen.Fini()
 
-	cells := b[607 : 607+9]
+	ui := CreateUI(app, simScreen, &bytes.Buffer{}, false, true, false, false)
 
-	text := []byte("directory")
-	for i, r := range cells {
-		assert.Equal(t, text[i], r.Bytes[0])
-	}
+	text := ui.formatHelpTextFor()
+	assert.Contains(t, text, "Preview results found so far")
+	assert.Contains(t, text, "Stop scanning and keep results")
 }
 
 func TestAppRun(t *testing.T) {
@@ -971,6 +979,21 @@ func TestNoViewFile(t *testing.T) {
 	ui.SetNoViewFile()
 
 	assert.Equal(t, ui.noViewFile, true)
+}
+
+// screenText returns the rendered contents of the simulated screen as a single
+// string, with one line per screen row.
+func screenText(simScreen tcell.SimulationScreen) string {
+	b, width, _ := simScreen.GetContents()
+
+	var sb strings.Builder
+	for i, cell := range b {
+		if i > 0 && i%width == 0 {
+			sb.WriteByte('\n')
+		}
+		sb.Write(cell.Bytes)
+	}
+	return sb.String()
 }
 
 // nolint: unused // Why: for debugging


### PR DESCRIPTION
Closes #661.

## Problem

Since #606, `Ctrl+C` during a scan stops the scan and keeps the results found so far. As #661 points out, `Ctrl+C` is the near-universal "exit this program" key, so having gdu stay open is jarring — even for people who want the partial-results behaviour most of the time.

## Solution

New `--ctrl-c-quits` flag (config key `ctrl-c-quits`, default `false`, interactive mode only). When set, `Ctrl+C` during a scan quits gdu.

Quitting this way is **immediate and unconditional** — it deliberately skips the long-scan confirmation dialog from #593, on the grounds that `Ctrl+C` is a stronger signal from the user than `q`. The regular teardown still runs, so marked paths are printed.

`Esc` is now bound to "stop scanning and keep results" **unconditionally**, regardless of the flag. Without this, enabling `--ctrl-c-quits` would make the #606/#150 feature completely unreachable. `Esc` was previously unbound during a scan.

## Notes

- The flag only has an effect *during* a scan. Outside a scan `Ctrl+C` already quit gdu (`handleSignalEvent`), and that is unchanged.
- Both the literal `KeyCtrlC` event and the SIGINT signal path are covered, since which one tcell delivers depends on terminal specifics.
- The `?` help modal documented neither `Tab` (preview, from #594) nor `Ctrl+C`. Both `Tab` and `Esc` are now listed under a new "During a scan:" section.
- `TestHelp`/`TestHelpBw` asserted on a hardcoded screen byte offset (`b[607:616]`), which broke as soon as the help text grew. They now search the rendered screen for the expected text via a new `screenText` helper.
- `keyPressed` went over the `gocyclo` limit of 25, so the Ctrl+C branch and the blocking-modal branch were extracted into `handleCtrlC` and `handleBlockingModalKeys`.
- `CONTEXT.md` gains a **Stopped scan** glossary term. The vocabulary for this was previously spread across four different phrasings; the flag, hint text and docs now use one.
- `gdu.1.md` is updated but the generated `gdu.1` is not regenerated here — it is already several PRs stale, and `make man` runs during release, so regenerating it would have pulled unrelated churn plus a pandoc version bump into this diff.

## Follow-up

A second `Ctrl+C` while a scan is stopping is currently swallowed and does nothing. A separate PR will make it quit.

## Testing

- `make lint` clean (golangci-lint v2.13.2).
- `go test -race ./...` passes.
- New tests: flag registration/set, `getOptions` plumbing, `Esc` stops the scan, `Esc` still stops the scan when `--ctrl-c-quits` is set, `Ctrl+C` quits without a confirm dialog and prints marked paths, the SIGINT path honours the flag, `Esc` yields partial results end-to-end, and the progress hint text varies correctly.