### PR TITLE
feat: quit on second ctrl+c during a scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ In non-interactive mode (and without `--top` and `--depth` flags), gdu uses a me
 This means memory usage stays constant regardless of how large the scanned directory tree is.
 When `--top` or `--depth` flags are used, the full directory tree is built in memory as in interactive mode.
 
-Export mode (flag `-o`) outputs all usage data as JSON, which can be later opened using the `-f` flag. In interactive mode, press `Esc` or `Ctrl+C` during a scan to stop scheduling new work and keep the results found so far. If you would rather have `Ctrl+C` quit gdu outright, use `--ctrl-c-quits`; `Esc` keeps working either way.
+Export mode (flag `-o`) outputs all usage data as JSON, which can be later opened using the `-f` flag. In interactive mode, press `Esc` or `Ctrl+C` during a scan to stop scheduling new work and keep the results found so far; pressing `Ctrl+C` again while the scan is stopping quits gdu. If you would rather have the first `Ctrl+C` quit gdu outright, use `--ctrl-c-quits`; `Esc` keeps working either way.
 
 By default the export includes every attribute, and directories always carry their `asize`, `dsize`, and `items` summary stats so they can be preserved on import. Use `--output-attrs=asize,dsize` to emit only selected optional attributes; `name` is always included. Available attributes are `asize`, `dsize`, `items`, `mtime`, and `notreg`.
 

--- a/tui/cancel_race_test.go
+++ b/tui/cancel_race_test.go
@@ -163,6 +163,8 @@ func TestAnalyzePathImmediateCtrlCIsNotLost(t *testing.T) {
 	// Ctrl-C is intentionally delivered immediately, before AnalyzeDir is
 	// guaranteed to have started. Cancel must still be observed by the double.
 	require.Nil(t, ui.keyPressed(tcell.NewEventKey(tcell.KeyCtrlC, 0, 0)))
+	// The second press escalates to quitting, but must not cancel twice nor
+	// make the in-flight scan unsafe.
 	_ = ui.keyPressed(tcell.NewEventKey(tcell.KeyCtrlC, 0, 0))
 
 	select {
@@ -178,7 +180,7 @@ func TestAnalyzePathImmediateCtrlCIsNotLost(t *testing.T) {
 	drainScanUpdates(t, app, ui)
 
 	require.Equal(t, 1, analyzer.cancelCount())
-	require.Equal(t, 0, app.stopCount())
+	require.Equal(t, 1, app.stopCount())
 	require.Equal(t, "test_dir", ui.currentDir.GetName())
 }
 
@@ -205,16 +207,21 @@ func TestCtrlCBeforeQueuedCompletionKeepsResults(t *testing.T) {
 	require.Equal(t, 4, ui.table.GetRowCount())
 }
 
-func TestRepeatedSignalCtrlCIsIdempotent(t *testing.T) {
+func TestRepeatedSignalCtrlCCancelsOnceThenQuits(t *testing.T) {
 	app := newCancelRaceApp()
 	analyzer := newCancelRaceAnalyzer()
 	ui := newCancelRaceUI(app, analyzer)
 
 	require.NoError(t, ui.AnalyzePath("test_dir", nil))
 	ui.keyPressed(signalEvent(os.Interrupt))
-	ui.keyPressed(signalEvent(os.Interrupt))
 	require.Equal(t, 1, analyzer.cancelCount())
 	require.Equal(t, 0, app.stopCount())
+
+	// The second SIGINT arrives while the scan is still stopping. Cancellation
+	// stays idempotent, but the user's escalation is honoured by quitting.
+	ui.keyPressed(signalEvent(os.Interrupt))
+	require.Equal(t, 1, analyzer.cancelCount())
+	require.Equal(t, 1, app.stopCount())
 
 	close(analyzer.release)
 	select {
@@ -224,10 +231,10 @@ func TestRepeatedSignalCtrlCIsIdempotent(t *testing.T) {
 	}
 	drainScanUpdates(t, app, ui)
 
-	// Once the completion callback has marked the scan finished, SIGINT takes
-	// the normal quit path.
+	// Once the completion callback has marked the scan finished, SIGINT still
+	// takes the normal quit path.
 	ui.keyPressed(signalEvent(os.Interrupt))
-	require.Equal(t, 1, app.stopCount())
+	require.Equal(t, 2, app.stopCount())
 }
 
 func TestSignalLoopQueuesScanCancellation(t *testing.T) {

--- a/tui/keys.go
+++ b/tui/keys.go
@@ -105,6 +105,12 @@ func (ui *UI) handleCtrlC(key *tcell.EventKey) *tcell.EventKey {
 	if ui.cancelScan() {
 		return nil
 	}
+	// Pressing Ctrl+C again while the scan is still stopping escalates to
+	// quitting: the user has already asked to stop and is now asking harder.
+	if ui.scanning {
+		ui.quitNow()
+		return nil
+	}
 	return key
 }
 

--- a/tui/keys_test.go
+++ b/tui/keys_test.go
@@ -495,6 +495,87 @@ func TestCtrlCDuringScanCancelsAnalyzer(t *testing.T) {
 	assert.Equal(t, " Stopping scan... ", ui.progress.GetTitle())
 }
 
+func TestSecondCtrlCWhileScanStoppingQuits(t *testing.T) {
+	fin := testdir.CreateTestDir()
+	defer fin()
+
+	buff := &bytes.Buffer{}
+	ui := analyzedUI(t, buff)
+	ui.progress = tview.NewTextView()
+	ui.scanning = true
+	ui.scanStart = time.Now().Add(-10 * time.Second)
+	ui.pages.AddPage("progress", ui.progress, true, true)
+	ui.markedPaths = []string{"test_dir/nested"}
+
+	// first Ctrl+C stops the scan and keeps the results
+	assert.Nil(t, ui.keyPressed(tcell.NewEventKey(tcell.KeyCtrlC, 0, 0)))
+	assert.True(t, ui.scanCancelled)
+	assert.Contains(t, ui.progress.GetText(false), "Press Ctrl+C again to quit gdu")
+	assert.Empty(t, buff.String())
+
+	// second Ctrl+C, while the scan is still stopping, quits
+	assert.Nil(t, ui.keyPressed(tcell.NewEventKey(tcell.KeyCtrlC, 0, 0)))
+	assert.False(t, ui.pages.HasPage("confirm"))
+	assert.Equal(t, "test_dir/nested\n", buff.String())
+}
+
+func TestSecondSignalWhileScanStoppingQuits(t *testing.T) {
+	fin := testdir.CreateTestDir()
+	defer fin()
+
+	buff := &bytes.Buffer{}
+	ui := analyzedUI(t, buff)
+	ui.progress = tview.NewTextView()
+	ui.scanning = true
+	ui.pages.AddPage("progress", ui.progress, true, true)
+	ui.markedPaths = []string{"test_dir/nested"}
+
+	ui.handleSignalEvent(signalEvent(syscall.SIGINT))
+	assert.True(t, ui.scanCancelled)
+	assert.Empty(t, buff.String())
+
+	ui.handleSignalEvent(signalEvent(syscall.SIGINT))
+	assert.Equal(t, "test_dir/nested\n", buff.String())
+}
+
+func TestEscThenCtrlCWhileScanStoppingQuits(t *testing.T) {
+	fin := testdir.CreateTestDir()
+	defer fin()
+
+	buff := &bytes.Buffer{}
+	ui := analyzedUI(t, buff)
+	ui.progress = tview.NewTextView()
+	ui.scanning = true
+	ui.pages.AddPage("progress", ui.progress, true, true)
+	ui.markedPaths = []string{"test_dir/nested"}
+
+	// Esc stops the scan, Ctrl+C then escalates to quitting
+	assert.Nil(t, ui.keyPressed(tcell.NewEventKey(tcell.KeyEsc, 0, 0)))
+	assert.True(t, ui.scanCancelled)
+
+	assert.Nil(t, ui.keyPressed(tcell.NewEventKey(tcell.KeyCtrlC, 0, 0)))
+	assert.Equal(t, "test_dir/nested\n", buff.String())
+}
+
+func TestEscWhileScanStoppingDoesNotQuit(t *testing.T) {
+	fin := testdir.CreateTestDir()
+	defer fin()
+
+	buff := &bytes.Buffer{}
+	ui := analyzedUI(t, buff)
+	ui.progress = tview.NewTextView()
+	ui.scanning = true
+	ui.pages.AddPage("progress", ui.progress, true, true)
+	ui.markedPaths = []string{"test_dir/nested"}
+
+	assert.Nil(t, ui.keyPressed(tcell.NewEventKey(tcell.KeyEsc, 0, 0)))
+	assert.True(t, ui.scanCancelled)
+
+	// only Ctrl+C escalates; Esc stays idempotent
+	ui.keyPressed(tcell.NewEventKey(tcell.KeyEsc, 0, 0))
+	assert.Empty(t, buff.String())
+}
+
 func TestEscDuringScanCancelsAnalyzer(t *testing.T) {
 	fin := testdir.CreateTestDir()
 	defer fin()

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -430,7 +430,8 @@ func signalEvent(current os.Signal) *tcell.EventKey {
 }
 
 func (ui *UI) handleSignalEvent(event *tcell.EventKey) {
-	if event.Modifiers() == tcell.ModCtrl && !ui.ctrlCQuits && (ui.cancelScan() || ui.scanning) {
+	// A second Ctrl+C while the scan is stopping falls through to quitting.
+	if event.Modifiers() == tcell.ModCtrl && !ui.ctrlCQuits && ui.cancelScan() {
 		return
 	}
 	ui.quitNow()
@@ -451,7 +452,11 @@ func (ui *UI) cancelScan() bool {
 	ui.scanCancelled = true
 	ui.scanCancelRequested.Store(true)
 	ui.progress.SetTitle(" Stopping scan... ")
-	ui.progress.SetText("Stopping scan and keeping results...")
+	stopping := "Stopping scan and keeping results..."
+	if !ui.ctrlCQuits {
+		stopping += "\n\nPress Ctrl+C again to quit gdu"
+	}
+	ui.progress.SetText(stopping)
 	return true
 }
 


### PR DESCRIPTION
Follow-up to #664. **Based on `feat/661-ctrl-c-quits`, so please merge #664 first** — I will retarget this to `master` once that lands. Review only the second commit.

## Problem

`handleSignalEvent` guarded with `ui.cancelScan() || ui.scanning`. That `|| ui.scanning` term covers exactly one case: the window between a scan being stopped and the scan goroutine actually returning. In that window every `Ctrl+C` was silently discarded, with no feedback of any kind. On a slow filesystem the window can last seconds, so a user mashing `Ctrl+C` to get out saw nothing happen.

## Solution

A second `Ctrl+C` in that window now quits gdu, immediately and unconditionally — the user has already asked to stop and is asking harder, so a confirmation dialog would be the worst possible response.

Cancellation itself stays idempotent: the analyzer is still cancelled exactly once. `Esc` also stays idempotent and never quits, so there is still a key that means only "stop the scan".

The stopping modal now says `Press Ctrl+C again to quit gdu`, so the escalation is discoverable rather than folklore.

## Notes on the two changed tests

Both asserted the old swallow behaviour directly, so both had to change. I kept what they were actually protecting:

- `TestAnalyzePathImmediateCtrlCIsNotLost` — the point is that cancellation is not lost when `Ctrl+C` arrives before `AnalyzeDir` starts. `cancelCount() == 1` is unchanged; only `stopCount()` goes 0 -> 1, since the incidental second press now quits.
- `TestRepeatedSignalCtrlCIsIdempotent` -> `TestRepeatedSignalCtrlCCancelsOnceThenQuits`. "Idempotent" was only ever true of cancellation, and that assertion is unchanged. The renamed test now also pins the new escalation, and still checks that SIGINT takes the normal quit path once the scan has finished.

## Testing

- `make lint` clean, `go test -race ./...` passes.
- New tests: second `Ctrl+C` quits and prints marked paths without a confirm dialog, the SIGINT path does the same, `Esc` followed by `Ctrl+C` escalates, and repeated `Esc` does not quit.