### PR TITLE
fix(stdout): honor --top and --depth when reading an input file

### DIFF
--- a/stdout/stdout.go
+++ b/stdout/stdout.go
@@ -545,11 +545,7 @@ func (ui *UI) ReadAnalysis(input io.Reader) error {
 		return err
 	}
 
-	if ui.summarize {
-		ui.printTotalItem(dir)
-	} else {
-		ui.showDir(dir)
-	}
+	ui.printAnalyzedDir(dir)
 
 	return nil
 }

--- a/stdout/stdout_test.go
+++ b/stdout/stdout_test.go
@@ -447,6 +447,62 @@ func TestReadAnalysisWithSummarize(t *testing.T) {
 	assert.Contains(t, output.String(), " gdu\n")
 }
 
+func TestReadAnalysisWithSummarizeAndTop(t *testing.T) {
+	input, err := os.OpenFile("../internal/testdata/test.json", os.O_RDONLY, 0o644)
+	assert.Nil(t, err)
+
+	output := bytes.NewBuffer(make([]byte, 10))
+
+	ui := CreateStdoutUI(output, false, false, false, false, true, false, false, "", 2, false, 0)
+	err = ui.ReadAnalysis(input)
+
+	assert.Nil(t, err)
+
+	out := output.String()
+	// --top wins over --summarize, the same way it does for a scan
+	assert.Contains(t, out, "/home/gdu/app/app_test.go")
+	assert.NotContains(t, out, " gdu\n")
+}
+
+func TestReadAnalysisWithTop(t *testing.T) {
+	input, err := os.OpenFile("../internal/testdata/test.json", os.O_RDONLY, 0o644)
+	assert.Nil(t, err)
+
+	output := bytes.NewBuffer(make([]byte, 10))
+
+	ui := CreateStdoutUI(output, false, false, false, false, false, false, false, "", 2, false, 0)
+	err = ui.ReadAnalysis(input)
+
+	assert.Nil(t, err)
+
+	out := output.String()
+	// the two largest files of the imported analysis, printed by their path
+	// instead of the plain listing of the root
+	assert.Contains(t, out, "/home/gdu/app/app_test.go")
+	assert.Contains(t, out, "/home/gdu/app/app.go")
+	assert.NotContains(t, out, "/home/gdu/main.go")
+	assert.NotContains(t, out, "app_linux_test.go")
+}
+
+func TestReadAnalysisWithDepth(t *testing.T) {
+	input, err := os.OpenFile("../internal/testdata/test.json", os.O_RDONLY, 0o644)
+	assert.Nil(t, err)
+
+	output := bytes.NewBuffer(make([]byte, 10))
+
+	ui := CreateStdoutUI(output, false, false, false, false, false, false, false, "", 0, false, 1)
+	err = ui.ReadAnalysis(input)
+
+	assert.Nil(t, err)
+
+	out := output.String()
+	assert.Contains(t, out, "/home/gdu\n")
+	assert.Contains(t, out, "/home/gdu/app\n")
+	assert.Contains(t, out, "/home/gdu/main.go\n")
+	// depth 1 stops at the direct children of the root
+	assert.NotContains(t, out, "/home/gdu/app/app.go")
+}
+
 func TestMaxInt(t *testing.T) {
 	assert.Equal(t, 5, maxInt(2, 5))
 	assert.Equal(t, 4, maxInt(4, 2))


### PR DESCRIPTION
`--top` and `--depth` are silently dropped when the analysis comes from `-f`. `ReadAnalysis` had its own two-branch decision that only knew about `--summarize`.

```
$ gdu -f dump.json -n --top 3
 12.0 KiB /adir
  4.0 KiB topfile
  4.0 KiB /bdir
      0 B /emptydir     <- the whole listing, --top ignored
```

`printAnalyzedDir` already dispatches all four cases and is what the scan path calls, so `ReadAnalysis` was the last entry point not using it. Same sweep as #660 for the export backend.

Two things worth flagging. `--summarize` with `--top` or `--depth` now resolves as a scan does: top, then depth, then summarize. Before, summarize won on the `-f` path. And `--depth` alone still does not force non-interactive mode, since `ShouldRunInNonInteractiveMode` tests `Top > 0` but not `Depth > 0`, so `gdu -f dump.json --depth 2` from a terminal opens the TUI. I left both of those alone.

Three tests added, each failing on its own mutation: honouring only top, only depth, and keeping the old summarize-first order. Output is byte-identical for every invocation setting neither flag, checked over 15 inputs and 24 flag sets. `go test ./...` and `golangci-lint run -c .golangci.yml` are clean.

AI disclosure: written with Claude Code. I ran the binary before and after, and ran the mutations myself.
