### PR TITLE
fix(stdout): honor apparent-size flag in --top ranking

### DIFF
--- a/pkg/analyze/top.go
+++ b/pkg/analyze/top.go
@@ -1,8 +1,6 @@
 package analyze
 
 import (
-	"sort"
-
 	"github.com/dundee/gdu/v5/pkg/fs"
 )
 
@@ -11,29 +9,40 @@ type TopList struct {
 	Items   fs.Files
 	Count   int
 	MinSize int64
+	SortBy  fs.SortBy
 }
 
-// NewTopList creates new TopList
-func NewTopList(count int) *TopList {
-	return &TopList{Count: count}
+// NewTopList creates new TopList ranking files by sortBy
+func NewTopList(count int, sortBy fs.SortBy) *TopList {
+	return &TopList{Count: count, SortBy: sortBy}
+}
+
+// rankedSize returns the value of the ranking metric of the item, so that the
+// list is built from the same number the caller orders and displays by.
+func (tl *TopList) rankedSize(item fs.Item) int64 {
+	if tl.SortBy == fs.SortByApparentSize {
+		return item.GetSize()
+	}
+	return item.GetUsage()
 }
 
 // Add adds file to the list
 func (tl *TopList) Add(file fs.Item) {
-	if file.GetSize() > tl.MinSize || len(tl.Items) < tl.Count {
+	if tl.rankedSize(file) > tl.MinSize || len(tl.Items) < tl.Count {
 		tl.Items = append(tl.Items, file)
-		sort.Sort(fs.ByApparentSize(tl.Items))
+		sortFiles(tl.Items, tl.SortBy, fs.SortAsc)
 		if len(tl.Items) > tl.Count {
 			tl.Items = tl.Items[1:]
 		}
-		tl.MinSize = tl.Items[0].GetSize()
+		tl.MinSize = tl.rankedSize(tl.Items[0])
 	}
 }
 
-func CollectTopFiles(dir fs.Item, count int) fs.Files {
-	topList := NewTopList(count)
+// CollectTopFiles returns the count largest files in dir, ranked by sortBy
+func CollectTopFiles(dir fs.Item, count int, sortBy fs.SortBy) fs.Files {
+	topList := NewTopList(count, sortBy)
 	walkDir(dir, topList)
-	sort.Sort(sort.Reverse(fs.ByApparentSize(topList.Items)))
+	sortFiles(topList.Items, sortBy, fs.SortDesc)
 	return topList.Items
 }
 

--- a/pkg/analyze/top_test.go
+++ b/pkg/analyze/top_test.go
@@ -17,7 +17,7 @@ func TestCollectTopFiles2(t *testing.T) {
 		"test_dir", func(_, _ string) bool { return false }, func(_ string) bool { return false },
 	)
 
-	topFiles := CollectTopFiles(dir, 2)
+	topFiles := CollectTopFiles(dir, 2, fs.SortByApparentSize)
 	assert.Equal(t, 2, len(topFiles))
 	assert.Equal(t, "file", topFiles[0].GetName())
 	assert.Equal(t, int64(5), topFiles[0].GetSize())
@@ -33,14 +33,56 @@ func TestCollectTopFiles1(t *testing.T) {
 		"test_dir", func(_, _ string) bool { return false }, func(_ string) bool { return false },
 	)
 
-	topFiles := CollectTopFiles(dir, 1)
+	topFiles := CollectTopFiles(dir, 1, fs.SortByApparentSize)
 	assert.Equal(t, 1, len(topFiles))
 	assert.Equal(t, "file", topFiles[0].GetName())
 	assert.Equal(t, int64(5), topFiles[0].GetSize())
 }
 
+// createDivergingDir creates a dir where the two size metrics disagree:
+// "sparse" has the bigger apparent size, "dense" the bigger disk usage.
+func createDivergingDir() *Dir {
+	dir := &Dir{
+		File:      &File{Name: "root"},
+		BasePath:  "/",
+		ItemCount: 3,
+	}
+	dir.AddFile(&File{Name: "sparse", Parent: dir, Size: 10 << 20, Usage: 0})
+	dir.AddFile(&File{Name: "dense", Parent: dir, Size: 5 << 20, Usage: 8 << 20})
+	return dir
+}
+
+func TestCollectTopFilesBySize(t *testing.T) {
+	topFiles := CollectTopFiles(createDivergingDir(), 2, fs.SortBySize)
+
+	assert.Equal(t, 2, len(topFiles))
+	assert.Equal(t, "dense", topFiles[0].GetName())
+	assert.Equal(t, "sparse", topFiles[1].GetName())
+}
+
+func TestCollectTopFilesByApparentSize(t *testing.T) {
+	topFiles := CollectTopFiles(createDivergingDir(), 2, fs.SortByApparentSize)
+
+	assert.Equal(t, 2, len(topFiles))
+	assert.Equal(t, "sparse", topFiles[0].GetName())
+	assert.Equal(t, "dense", topFiles[1].GetName())
+}
+
+func TestAddBySize(t *testing.T) {
+	topList := NewTopList(2, fs.SortBySize)
+	topList.Add(&File{Size: 5, Usage: 1, Name: "file1"})
+	topList.Add(&File{Size: 1, Usage: 5, Name: "file5"})
+	topList.Add(&File{Size: 2, Usage: 2, Name: "file2"})
+
+	sort.Sort(sort.Reverse(topList.Items))
+
+	assert.Equal(t, 2, len(topList.Items))
+	assert.Equal(t, "file5", topList.Items[0].GetName())
+	assert.Equal(t, "file2", topList.Items[1].GetName())
+}
+
 func TestAdd2(t *testing.T) {
-	topList := NewTopList(2)
+	topList := NewTopList(2, fs.SortByApparentSize)
 	topList.Add(&File{Size: 1, Name: "file1"})
 	topList.Add(&File{Size: 5, Name: "file5"})
 	topList.Add(&File{Size: 2, Name: "file2"})
@@ -53,7 +95,7 @@ func TestAdd2(t *testing.T) {
 }
 
 func TestAdd3(t *testing.T) {
-	topList := NewTopList(3)
+	topList := NewTopList(3, fs.SortByApparentSize)
 	topList.Add(&File{Size: 5, Name: "file5"})
 	topList.Add(&File{Size: 1, Name: "file1"})
 	topList.Add(&File{Size: 2, Name: "file2"})

--- a/report/export.go
+++ b/report/export.go
@@ -202,7 +202,9 @@ func exportedFile(file, parent fs.Item) *analyze.File {
 }
 
 func (ui *UI) topDir(dir fs.Item) fs.Item {
-	files := analyze.CollectTopFiles(dir, ui.top)
+	// the export UI is never told about --show-apparent-size, so its top-N
+	// ranking stays on apparent size
+	files := analyze.CollectTopFiles(dir, ui.top, fs.SortByApparentSize)
 
 	topDir := exportedDir(dir)
 	for _, f := range files {

--- a/stdout/stdout.go
+++ b/stdout/stdout.go
@@ -355,7 +355,8 @@ func (ui *UI) showDir(dir fs.Item) {
 }
 
 func (ui *UI) printTopFiles(file fs.Item) {
-	collected := analyze.CollectTopFiles(file, ui.top)
+	sortBy, _ := ui.sortSettings()
+	collected := analyze.CollectTopFiles(file, ui.top, sortBy)
 	for _, file := range collected {
 		ui.printItemPath(file)
 	}

--- a/stdout/stdout_test.go
+++ b/stdout/stdout_test.go
@@ -198,6 +198,35 @@ func TestShowTopBw(t *testing.T) {
 	assert.Contains(t, output.String(), "test_dir/nested/file2")
 }
 
+func TestShowTopWithApparentSize(t *testing.T) {
+	// "sparse" has the bigger apparent size but no disk usage at all, so --top
+	// has to rank "dense" first by default and "sparse" first with
+	// --show-apparent-size, matching the size printed next to each path.
+	root := &analyze.Dir{
+		File:      &analyze.File{Name: "root"},
+		BasePath:  "/",
+		ItemCount: 3,
+	}
+	root.AddFile(&analyze.File{Name: "sparse", Parent: root, Size: 50 << 20})
+	root.AddFile(&analyze.File{Name: "dense", Parent: root, Size: 5 << 20, Usage: 5 << 20})
+
+	output := bytes.NewBuffer(nil)
+	ui := CreateStdoutUI(output, false, false, false, false, false, false, false, "", 2, false, 0)
+	ui.printTopFiles(root)
+
+	out := output.String()
+	assert.Less(t, strings.Index(out, "/root/dense"), strings.Index(out, "/root/sparse"),
+		"largest disk usage should be printed first, got:\n"+out)
+
+	output = bytes.NewBuffer(nil)
+	ui = CreateStdoutUI(output, false, false, true, false, false, false, false, "", 2, false, 0)
+	ui.printTopFiles(root)
+
+	out = output.String()
+	assert.Less(t, strings.Index(out, "/root/sparse"), strings.Index(out, "/root/dense"),
+		"largest apparent size should be printed first, got:\n"+out)
+}
+
 func TestShowDepth(t *testing.T) {
 	fin := testdir.CreateTestDir()
 	defer fin()


### PR DESCRIPTION
`--top` always ranks by apparent size, but stdout prints disk usage unless `-a` is given. A sparse file is reported as the largest, and the list is not sorted by the number printed beside it.

```
$ truncate -s 10M sparse.bin        # plus two ordinary files

$ gdu -n --top 3 --no-prefix .      # before
        0 /tmp/d/sparse.bin
   200704 /tmp/d/medium.bin
    53248 /tmp/d/small.bin

$ gdu -n --top 3 --no-prefix .      # after
   200704 /tmp/d/medium.bin
    53248 /tmp/d/small.bin
        0 /tmp/d/sparse.bin
```

`CollectTopFiles` hardcoded `GetSize` and `ByApparentSize`. It now takes the `fs.SortBy` that `sortSettings` already produces, the helper you added in #630 for this same bug one flag over. Ordering reuses the existing `sortFiles`, so there is no new comparator. `-a --top` output is unchanged.

I left the export backend on apparent size on purpose. `CreateExportUI` is never passed `ShowApparentSize` at all, unlike the stdout, TUI and web constructors, so changing it needs a new parameter and your call on whether a JSON export has a displayed metric. Happy to follow up separately.

Tests cover ranking by each metric and the selection threshold in `TopList.Add`, each failing on its own mutation. `go test ./...` and `golangci-lint run -c .golangci.yml` are clean.

AI disclosure: written with Claude Code. I built both binaries and ran the comparison and the mutations myself.
